### PR TITLE
NO-ISSUE: Restructure osac-installer as production-only Helm installer

### DIFF
--- a/enhancements/installer-restructure/prd.md
+++ b/enhancements/installer-restructure/prd.md
@@ -32,7 +32,7 @@ OSAC deploys across multiple clusters — a management cluster (fulfillment-serv
 
 #### Deployment Topology
 
-- **FR-1:** The installer must provide Helm charts that align with OSAC's multi-cluster deployment boundaries. It must be clear which chart(s) to install on each cluster type (management, hub, workload). `[User: sk-ilya review]`
+- **FR-1:** The installer must provide Helm charts that align with OSAC's multi-cluster deployment boundaries. Each cluster type (management, hub, workload) must be installable with a single `helm install` command producing a complete manifest for that cluster. `[User: sk-ilya review, rccrdpccl review]`
 - **FR-2:** For single-cluster development and testing environments, the charts must be installable together on one cluster with appropriate values.
 - **FR-3:** The same charts must be usable across all environments (production, development, CI) — environment differences are expressed through values, not different charts or tools. `[User: rccrdpccl review]`
 
@@ -56,10 +56,20 @@ OSAC deploys across multiple clusters — a management cluster (fulfillment-serv
 
 - **FR-11:** OSAC releases must be versioned with semantic versioning. Each release represents a tested combination of component versions.
 - **FR-12:** Component charts must be publishable to an OCI registry, enabling air-gapped deployments via registry mirroring.
+- **FR-13:** Chart versions must have a clear relationship to their container image versions. Semver must be enforced across both charts and images to ensure smooth lifecycle management (install, upgrade, rollback). `[User: rccrdpccl review]`
+
+#### Secret Management
+
+- **FR-14:** The installer must define a strategy for how secrets (AAP credentials, network backend passwords, SSH keys, Keycloak configuration, cloud provider credentials) are provided to the Helm chart at install time. `[User: rccrdpccl review]`
+- **FR-15:** The secret management approach must support both manual pre-creation (user creates secrets before helm install) and integration with external secret management systems (e.g., External Secrets Operator, Vault).
+
+#### Chart Ownership
+
+- **FR-16:** Each chart must have a clearly defined owning team responsible for its maintenance, versioning, and release lifecycle. `[User: rccrdpccl review]`
 
 #### Repository Scope
 
-- **FR-13:** The osac-installer repository must contain only production installation artifacts (charts, profiles, documentation). CI-only scripts, developer convenience scripts, and teardown tooling belong in osac-test-infra.
+- **FR-17:** The osac-installer repository must contain only production installation artifacts (charts, profiles, documentation). CI-only scripts, developer convenience scripts, and teardown tooling belong in osac-test-infra.
 
 ### 3.2 Non-Functional Requirements
 
@@ -67,6 +77,7 @@ OSAC deploys across multiple clusters — a management cluster (fulfillment-serv
 - **NFR-2:** The installer must be deployable in air-gapped environments. No installation step may require internet access beyond the chart and image registries.
 - **NFR-3:** CI must validate that a full deployment from Helm charts alone (no scripts) produces a healthy OSAC installation.
 - **NFR-4:** The Helm values schema must validate required configuration fields at install time, providing clear error messages when mandatory values are missing.
+- **NFR-5:** The installer must be compatible with GitOps deployment tools (ArgoCD, Flux). Charts must produce valid manifests via `helm template` without requiring Helm hooks or other lifecycle features that GitOps tools do not support well. `[User: rccrdpccl review]`
 
 ## 4. Acceptance Criteria
 
@@ -77,6 +88,8 @@ OSAC deploys across multiple clusters — a management cluster (fulfillment-serv
 - [ ] `helm upgrade` from OSAC version N to version N+1 completes without errors and preserves existing configuration.
 - [ ] CI runs a full Helm-only deployment and verifies OSAC services are healthy without invoking any shell scripts.
 - [ ] Each OSAC release is published with a semantic version and documents the component versions it includes.
+- [ ] `helm template` produces a valid, complete manifest for each cluster type without relying on hooks.
+- [ ] Secrets can be provided via pre-created Kubernetes secrets or via an external secrets integration.
 
 ## 5. Assumptions
 
@@ -101,10 +114,10 @@ Defining clean chart boundaries across management, hub, and workload clusters re
 
 ### 7.2 Imperative post-install operations may be difficult to automate
 
-Some post-install operations (hub registration, AAP project sync) involve external API calls with retry logic that may be challenging to express reliably within Helm's lifecycle.
+Some post-install operations (hub registration, AAP project sync) involve external API calls with retry logic. Helm hooks are one approach but conflict with GitOps/ArgoCD compatibility (NFR-5). Moving these into operator reconciliation loops is more GitOps-friendly but requires more development.
 
 - **Owner:** OSAC platform team
-- **Mitigation:** Evaluate whether these operations belong in Helm hooks (Jobs) or in the osac-operator's reconciliation loop. Prototype the most complex operation early.
+- **Mitigation:** Evaluate operator-driven reconciliation as the primary approach, since it aligns with both GitOps compatibility and Kubernetes-native patterns. Prototype the most complex operation early.
 
 ### 7.3 Component repos not ready for versioned publishing
 
@@ -136,7 +149,21 @@ Published Helm packages do not bundle arbitrary values files. Should profiles li
 - **Owner:** OSAC platform team
 - **Impact:** Affects FR-10 and the user experience for selecting a deployment configuration.
 
-### 8.4 Should prerequisites be subcharts or a separate chart?
+### 8.4 Who owns each chart?
+
+Should component charts be maintained by the component team (osac-operator team owns the operator chart) or centrally by the installer/platform team? How are dependency-of-dependency charts managed?
+
+- **Owner:** OSAC platform team
+- **Impact:** Affects FR-16 and the release coordination process.
+
+### 8.5 What is the secret management strategy?
+
+How should secrets be provided at install time? Options include: manual pre-creation, Helm values with sops-encrypted files, External Secrets Operator, HashiCorp Vault integration. The strategy must work for both initial install and day-2 secret rotation.
+
+- **Owner:** OSAC platform team (cc @trewest)
+- **Impact:** Affects FR-14, FR-15, and the overall security posture.
+
+### 8.6 Should prerequisites be subcharts or a separate chart?
 
 Including prerequisites as optional subcharts within the main chart(s) enables a single `helm install`. A separate chart gives more flexibility for environments where prerequisites are already managed externally.
 

--- a/enhancements/installer-restructure/prd.md
+++ b/enhancements/installer-restructure/prd.md
@@ -32,15 +32,11 @@ OSAC deploys across multiple clusters — a management cluster (fulfillment-serv
 
 #### Deployment Topology
 
-- **FR-1:** The installer must provide Helm charts that align with OSAC's multi-cluster deployment boundaries. Each cluster type (management, hub, workload) must be installable with a single `helm install` command producing a complete manifest for that cluster. `[User: sk-ilya review, rccrdpccl review]`
-- **FR-2:** For single-cluster development and testing environments, the charts must be installable together on one cluster with appropriate values.
-- **FR-3:** The same charts must be usable across all environments (production, development, CI) — environment differences are expressed through values, not different charts or tools. `[User: rccrdpccl review]`
-
+- **FR-1:** The installer must provide Helm charts that align with OSAC's multi-cluster deployment boundaries. Each cluster type (management, hub, workload) must be installable with a single `helm install` command producing a complete manifest for that cluster.- **FR-2:** For single-cluster development and testing environments, the charts must be installable together on one cluster with appropriate values.
+- **FR-3:** The same charts must be usable across all environments (production, development, CI) — environment differences are expressed through values, not different charts or tools.
 #### Prerequisites
 
-- **FR-4:** Cluster prerequisites (cert-manager, trust-manager, Keycloak, AAP operator, LVMS, MetalLB, CNV, MCE) must be installable as optional components with per-component enable/disable toggles (e.g., `certManager.enabled: true`). `[Clarify: R1.Q1]`
-- **FR-5:** The installer should aim for a single `helm install` experience where prerequisites that are not already present on the cluster can be included in the installation, avoiding a mandatory two-step process. `[User: rccrdpccl review]`
-
+- **FR-4:** Cluster prerequisites (cert-manager, trust-manager, Keycloak, AAP operator, LVMS, MetalLB, CNV, MCE) must be installable as optional components with per-component enable/disable toggles (e.g., `certManager.enabled: true`).- **FR-5:** The installer should aim for a single `helm install` experience where prerequisites that are not already present on the cluster can be included in the installation, avoiding a mandatory two-step process.
 #### Configuration
 
 - **FR-6:** All configuration currently applied by post-deploy scripts (AAP instance group settings, Keycloak credentials, network backend settings, hub registration) must be expressible through Helm values with no external patching required.
@@ -48,25 +44,20 @@ OSAC deploys across multiple clusters — a management cluster (fulfillment-serv
 
 #### Deployment Profiles
 
-- **FR-8:** The installer must define deployment profiles for supported configurations: CaaS (cluster provisioning), VMaaS (compute instances), VMaaS dedicated-cluster mode, BMaaS (bare metal), and full-stack (all capabilities). `[User: sk-ilya review, rccrdpccl review]`
-- **FR-9:** Users must be able to compose profiles with site-specific overrides to customize their deployment.
-- **FR-10:** Profile definitions must be distributable separately from the packaged chart, since published Helm packages do not bundle arbitrary values files. `[User: rccrdpccl review]`
-
+- **FR-8:** The installer must define deployment profiles for supported configurations: CaaS (cluster provisioning), VMaaS (compute instances), VMaaS dedicated-cluster mode, BMaaS (bare metal), and full-stack (all capabilities).- **FR-9:** Users must be able to compose profiles with site-specific overrides to customize their deployment.
+- **FR-10:** Profile definitions must be distributable separately from the packaged chart, since published Helm packages do not bundle arbitrary values files.
 #### Versioning and Distribution
 
 - **FR-11:** OSAC releases must be versioned with semantic versioning. Each release represents a tested combination of component versions.
 - **FR-12:** Component charts must be publishable to an OCI registry, enabling air-gapped deployments via registry mirroring.
-- **FR-13:** Chart versions must have a clear relationship to their container image versions. Semver must be enforced across both charts and images to ensure smooth lifecycle management (install, upgrade, rollback). `[User: rccrdpccl review]`
-
+- **FR-13:** Chart versions must have a clear relationship to their container image versions. Semver must be enforced across both charts and images to ensure smooth lifecycle management (install, upgrade, rollback).
 #### Secret Management
 
-- **FR-14:** The installer must define a strategy for how secrets (AAP credentials, network backend passwords, SSH keys, Keycloak configuration, cloud provider credentials) are provided to the Helm chart at install time. `[User: rccrdpccl review]`
-- **FR-15:** The secret management approach must support both manual pre-creation (user creates secrets before helm install) and integration with external secret management systems (e.g., External Secrets Operator, Vault).
+- **FR-14:** The installer must define a strategy for how secrets (AAP credentials, network backend passwords, SSH keys, Keycloak configuration, cloud provider credentials) are provided to the Helm chart at install time.- **FR-15:** The secret management approach must support both manual pre-creation (user creates secrets before helm install) and integration with external secret management systems (e.g., External Secrets Operator, Vault).
 
 #### Chart Ownership
 
-- **FR-16:** Each chart must have a clearly defined owning team responsible for its maintenance, versioning, and release lifecycle. `[User: rccrdpccl review]`
-
+- **FR-16:** Each chart must have a clearly defined owning team responsible for its maintenance, versioning, and release lifecycle.
 #### Repository Scope
 
 - **FR-17:** The osac-installer repository must contain only production installation artifacts (charts, profiles, documentation). CI-only scripts, developer convenience scripts, and teardown tooling belong in osac-test-infra.
@@ -77,8 +68,7 @@ OSAC deploys across multiple clusters — a management cluster (fulfillment-serv
 - **NFR-2:** The installer must be deployable in air-gapped environments. No installation step may require internet access beyond the chart and image registries.
 - **NFR-3:** CI must validate that a full deployment from Helm charts alone (no scripts) produces a healthy OSAC installation.
 - **NFR-4:** The Helm values schema must validate required configuration fields at install time, providing clear error messages when mandatory values are missing.
-- **NFR-5:** The installer must be compatible with GitOps deployment tools (ArgoCD, Flux). Charts must produce valid manifests via `helm template` without requiring Helm hooks or other lifecycle features that GitOps tools do not support well. `[User: rccrdpccl review]`
-
+- **NFR-5:** The installer must be compatible with GitOps deployment tools (ArgoCD, Flux). Charts must produce valid manifests via `helm template` without requiring Helm hooks or other lifecycle features that GitOps tools do not support well.
 ## 4. Acceptance Criteria
 
 - [ ] A Cloud Provider Admin can install OSAC on a clean OpenShift cluster using `helm install` with a profile values file — no scripts, no manual steps beyond providing site-specific values.

--- a/enhancements/installer-restructure/prd.md
+++ b/enhancements/installer-restructure/prd.md
@@ -1,132 +1,144 @@
-# Restructure osac-installer as a Production-Only Helm Installer
+# OSAC Installer: Structured Helm-Based Installation
 
 | Field       | Value   |
 |-------------|---------|
 | Author(s)   | Dan Manor |
 | Jira        | N/A — conversation-driven |
-| Date        | 2026-07-01 |
+| Date        | 2026-07-02 |
 
 ## 1. Problem Statement
 
-osac-installer evolved from a developer convenience tool into a repository that attempts to serve developers, CI pipelines, and production deployments simultaneously. The result is a codebase with dual deployment methods (Helm and Kustomize), 15 shell scripts that mix production setup with CI-only concerns, and 5 different configuration surfaces. A Cloud Provider Admin attempting to install OSAC in production cannot determine the supported installation path, must run post-install shell scripts after `helm install`, and has no versioned release to pin against. Without restructuring, every new OSAC deployment is a bespoke scripted process — fragile, unreproducible, and incompatible with production tooling like enclave and ArgoCD.
+OSAC deploys across multiple clusters — a management cluster (fulfillment-service, AAP), regional hub clusters (osac-operator), and optionally dedicated workload clusters (VMaaS dedicated mode). Today, installing OSAC requires navigating a repository that mixes production deployment artifacts with developer scripts and CI tooling, uses multiple configuration surfaces (Helm values, environment variables, `.env` files, post-deploy script patching), and requires shell scripts to run after `helm install` to complete the setup. A Cloud Provider Admin cannot install OSAC from the Helm chart alone, has no versioned release to pin against, and must understand which scripts to run and in what order. The chart structure does not reflect the multi-cluster deployment topology, making it unclear what to install where.
 
 ## 2. Goals and Non-Goals
 
 ### 2.1 Goals
 
-- Cloud Provider Admins can install OSAC using a single versioned Helm chart pulled from an OCI registry, with no shell scripts required.
-- Cloud Infrastructure Admins can configure backend integrations (networking, storage, identity) entirely through Helm values files, with no post-deploy patching.
-- The installer supports deploying different OSAC profiles (CaaS, VMaaS, full-stack) by layering values files, without maintaining separate charts or deployment paths.
-- OSAC releases are versioned — each release is a tested, reproducible combination of component chart versions published to an OCI registry.
+- Cloud Provider Admins can install OSAC using versioned Helm charts with no shell scripts required — `helm install` is the complete installation interface.
+- The chart structure reflects OSAC's deployment topology, so it is clear what to install on each cluster (management, hub, workload).
+- Cloud Infrastructure Admins can configure all backend integrations (networking, storage, identity) entirely through Helm values.
+- The installer supports different deployment profiles (CaaS, VMaaS, VMaaS dedicated-cluster, full-stack, BMaaS) through composable values files.
+- OSAC releases are versioned — each release is a tested, reproducible combination of component versions.
 - The installer supports `helm upgrade` for in-place version upgrades.
 
 ### 2.3 Non-Goals
 
-- Developer local/lab installation tooling — moves to osac-test-infra.
-- CI/E2E test infrastructure (overlays, CI-specific scripts, remote cluster setup) — moves to osac-test-infra.
-- Demo or proof-of-concept environment scripts — moves to osac-test-infra.
-- Kustomize as a supported deployment method.
-- A BMaaS-specific profile (planned for a future milestone). `[Clarify: R2.Q3]`
+- CI/E2E test infrastructure (CI-specific overlays, remote cluster setup scripts) — managed in osac-test-infra.
+- Demo or proof-of-concept environment scripts — managed in osac-test-infra.
 
 ## 3. Requirements
 
 ### 3.1 Functional Requirements
 
-#### Prerequisites Installation
+#### Deployment Topology
 
-- **FR-1:** The installer must provide a separate Helm chart for cluster prerequisites (cert-manager, trust-manager, Keycloak, AAP operator, LVMS, MetalLB, CNV, MCE) with per-component enable/disable toggles. `[Clarify: R1.Q1]`
-- **FR-2:** Each prerequisite component must default to enabled, allowing production environments where prerequisites are already installed to disable them individually.
+- **FR-1:** The installer must provide Helm charts that align with OSAC's multi-cluster deployment boundaries. It must be clear which chart(s) to install on each cluster type (management, hub, workload). `[User: sk-ilya review]`
+- **FR-2:** For single-cluster development and testing environments, the charts must be installable together on one cluster with appropriate values.
+- **FR-3:** The same charts must be usable across all environments (production, development, CI) — environment differences are expressed through values, not different charts or tools. `[User: rccrdpccl review]`
 
-#### OSAC Deployment
+#### Prerequisites
 
-- **FR-3:** The installer must provide an umbrella Helm chart that composes all OSAC components (osac-operator, fulfillment-service, osac-aap, bare-metal-fulfillment-operator, osac-ui) as versioned sub-chart dependencies pulled from an OCI registry. `[Clarify: R1.Q4]`
-- **FR-4:** The umbrella chart must include Helm post-install hook Jobs for imperative operations that cannot be expressed as templates: AAP API token creation, hub cluster registration, AAP project synchronization, template publishing, and initial tenant setup.
-- **FR-5:** All configuration currently applied by post-deploy scripts (AAP instance group ConfigMaps and Secrets, Keycloak credentials, network backend settings) must be expressible through Helm values with no external patching required.
+- **FR-4:** Cluster prerequisites (cert-manager, trust-manager, Keycloak, AAP operator, LVMS, MetalLB, CNV, MCE) must be installable as optional components with per-component enable/disable toggles (e.g., `certManager.enabled: true`). `[Clarify: R1.Q1]`
+- **FR-5:** The installer should aim for a single `helm install` experience where prerequisites that are not already present on the cluster can be included in the installation, avoiding a mandatory two-step process. `[User: rccrdpccl review]`
+
+#### Configuration
+
+- **FR-6:** All configuration currently applied by post-deploy scripts (AAP instance group settings, Keycloak credentials, network backend settings, hub registration) must be expressible through Helm values with no external patching required.
+- **FR-7:** Post-install imperative operations (AAP API token creation, hub registration, template publishing, tenant setup) must complete automatically as part of the installation without manual script execution.
 
 #### Deployment Profiles
 
-- **FR-6:** The installer must ship values files for each supported profile: CaaS (cluster provisioning), VMaaS (compute instances), and full-stack (all capabilities). `[Clarify: R2.Q3]`
-- **FR-7:** Users must be able to layer profile values with site-specific overrides (e.g., `helm install osac -f profiles/caas.yaml -f my-site.yaml`).
-
-#### Installation Automation
-
-- **FR-8:** The installer must include a CLI wrapper (Makefile or script) that orchestrates the two-phase install: prerequisites chart installation, readiness verification, then OSAC chart installation. `[Clarify: R2.Q2]`
+- **FR-8:** The installer must define deployment profiles for supported configurations: CaaS (cluster provisioning), VMaaS (compute instances), VMaaS dedicated-cluster mode, BMaaS (bare metal), and full-stack (all capabilities). `[User: sk-ilya review, rccrdpccl review]`
+- **FR-9:** Users must be able to compose profiles with site-specific overrides to customize their deployment.
+- **FR-10:** Profile definitions must be distributable separately from the packaged chart, since published Helm packages do not bundle arbitrary values files. `[User: rccrdpccl review]`
 
 #### Versioning and Distribution
 
-- **FR-9:** Each component repository must publish its Helm chart to an OCI registry with semantic versioning. `[Clarify: R2.Q1]`
-- **FR-10:** The umbrella chart version must represent the OSAC release version, with its Chart.yaml pinning specific component chart versions. A release is a tested combination of component versions.
-- **FR-11:** The production osac-installer repository must contain only the umbrella chart, profiles, CLI wrapper, and documentation — no Git submodules, no kustomize manifests, no shell scripts beyond the CLI wrapper. `[Clarify: R1.Q4]`
+- **FR-11:** OSAC releases must be versioned with semantic versioning. Each release represents a tested combination of component versions.
+- **FR-12:** Component charts must be publishable to an OCI registry, enabling air-gapped deployments via registry mirroring.
 
-#### Migration
+#### Repository Scope
 
-- **FR-12:** The restructuring must be executed incrementally across 5 phases, keeping CI green at each phase boundary: (1) prerequisites chart and profiles, (2) post-install hook Jobs, (3) OCI publishing with semantic versioning, (4) CI/dev script migration to osac-test-infra, (5) kustomize removal.
+- **FR-13:** The osac-installer repository must contain only production installation artifacts (charts, profiles, documentation). CI-only scripts, developer convenience scripts, and teardown tooling belong in osac-test-infra.
 
 ### 3.2 Non-Functional Requirements
 
-- **NFR-1:** The installer must support `helm upgrade` for in-place OSAC version upgrades. Chart templates must be idempotent and handle pre-existing resources. `[Clarify: R1.Q3]`
-- **NFR-2:** The installer must be deployable in air-gapped environments by mirroring the OCI registry. No installation step may require internet access beyond the registry.
-- **NFR-3:** CI must validate a full Helm-only deployment (prerequisites + OSAC) on a test cluster with zero scripts as the acceptance test for each phase of the migration. `[Clarify: R2.Q4]`
-- **NFR-4:** The Helm values schema (values.schema.json) must validate all required configuration fields at install time, providing clear error messages when mandatory values are missing.
+- **NFR-1:** The installer must support `helm upgrade` for in-place OSAC version upgrades. Templates must be idempotent and handle pre-existing resources.
+- **NFR-2:** The installer must be deployable in air-gapped environments. No installation step may require internet access beyond the chart and image registries.
+- **NFR-3:** CI must validate that a full deployment from Helm charts alone (no scripts) produces a healthy OSAC installation.
+- **NFR-4:** The Helm values schema must validate required configuration fields at install time, providing clear error messages when mandatory values are missing.
 
 ## 4. Acceptance Criteria
 
-- [ ] A Cloud Provider Admin can install OSAC on a clean OpenShift cluster by running `helm install` for the prerequisites chart, then `helm install` for the OSAC chart with a profile values file — no scripts, no kustomize, no manual steps.
-- [ ] A Cloud Infrastructure Admin can configure all backend integrations (Netris, ESI, VAST, Keycloak, AAP) through Helm values files alone.
-- [ ] The CLI wrapper (`make install PROFILE=caas VALUES=my-site.yaml`) successfully orchestrates a two-phase deployment from a clean cluster to a working OSAC installation.
-- [ ] `helm upgrade` from OSAC version N to version N+1 completes without errors and preserves existing tenant data and configuration.
-- [ ] The osac-installer repository contains no kustomize files, no Git submodules, and no shell scripts other than the CLI wrapper.
+- [ ] A Cloud Provider Admin can install OSAC on a clean OpenShift cluster using `helm install` with a profile values file — no scripts, no manual steps beyond providing site-specific values.
+- [ ] A Cloud Infrastructure Admin can configure all backend integrations (Netris, ESI, VAST, Keycloak, AAP) through Helm values alone.
+- [ ] The chart structure makes it clear which components install on management, hub, and workload clusters.
+- [ ] The same chart works for both single-cluster dev environments and multi-cluster production topologies, differentiated only by values.
+- [ ] `helm upgrade` from OSAC version N to version N+1 completes without errors and preserves existing configuration.
 - [ ] CI runs a full Helm-only deployment and verifies OSAC services are healthy without invoking any shell scripts.
-- [ ] Each OSAC release is published to the OCI registry with a semantic version and documents the component chart versions it includes.
+- [ ] Each OSAC release is published with a semantic version and documents the component versions it includes.
 
 ## 5. Assumptions
 
-- Component repositories (osac-operator, fulfillment-service, osac-aap, bare-metal-fulfillment-operator, osac-ui) will add CI pipelines to publish their Helm charts to the OCI registry with semantic versions. This is a prerequisite for FR-9 and FR-3.
-- The existing `publish-charts.yaml` CI workflow can be extended to support semantic versioning and OCI publishing without a full rewrite.
-- Post-install imperative operations (AAP token creation, hub registration) can be reliably expressed as Kubernetes Jobs running as Helm hooks, including idempotent retry behavior.
+- Component repositories (osac-operator, fulfillment-service, osac-aap, bare-metal-fulfillment-operator, osac-ui) will add CI pipelines to publish their Helm charts with semantic versions.
+- Post-install imperative operations (AAP token creation, hub registration) can be reliably automated within the Helm installation lifecycle.
 
 ## 6. Dependencies
 
-- **Component repos** — Each component must publish its Helm chart to the OCI registry before the umbrella chart can consume it. FR-3 and FR-9 are blocked until this is in place.
-- **osac-test-infra** — Must accept the migrated CI/dev scripts (teardown, snapshot recovery, remote cluster setup, CaaS agent setup) and update its CI workflows to source them from the new location.
-- **OCI registry** — A container registry (ghcr.io or equivalent) must be available for publishing and pulling Helm charts.
-- **Enclave team** — Must validate that the restructured Helm chart works with enclave's deployment orchestration.
+- **Component repos** — Each component must publish its Helm chart before the installer can consume versioned dependencies.
+- **osac-test-infra** — Must accept migrated CI/dev scripts and update its workflows accordingly.
+- **OCI registry** — A container registry must be available for publishing and pulling Helm charts.
+- **Enclave team** — Must validate that the restructured charts work with enclave's deployment orchestration.
 
 ## 7. Risks
 
-### 7.1 CI disruption during migration
+### 7.1 Multi-cluster chart boundaries are complex
 
-Moving CI scripts to osac-test-infra while CI pipelines still reference them in osac-installer could break automated testing.
-
-- **Owner:** OSAC platform team
-- **Mitigation:** Phase 4 (script migration) updates CI workflows in the same PR that moves the scripts. Incremental approach ensures each phase is independently validated.
-
-### 7.2 Helm hook Jobs may not cover all imperative operations
-
-Some post-install operations (e.g., hub registration via fulfillment CLI, AAP project sync) involve complex retry logic and external API calls that may be difficult to express as reliable Kubernetes Jobs.
+Defining clean chart boundaries across management, hub, and workload clusters requires careful design. Shared resources (CRDs, cluster-scoped RBAC) must be handled without duplication or conflicts.
 
 - **Owner:** OSAC platform team
-- **Mitigation:** Prototype the most complex hook Job (hub registration) early in Phase 2. If Jobs prove insufficient, evaluate moving these operations into the osac-operator's reconciliation loop as a longer-term alternative.
+- **Mitigation:** Prototype multi-cluster chart separation with CaaS (management + hub) before tackling VMaaS dedicated-cluster mode.
 
-### 7.3 Component repos not ready for OCI publishing
+### 7.2 Imperative post-install operations may be difficult to automate
 
-FR-3 depends on all component repos publishing versioned charts. If any component repo lacks chart publishing CI, the umbrella chart cannot consume it from the registry.
+Some post-install operations (hub registration, AAP project sync) involve external API calls with retry logic that may be challenging to express reliably within Helm's lifecycle.
+
+- **Owner:** OSAC platform team
+- **Mitigation:** Evaluate whether these operations belong in Helm hooks (Jobs) or in the osac-operator's reconciliation loop. Prototype the most complex operation early.
+
+### 7.3 Component repos not ready for versioned publishing
+
+The installer depends on all component repos publishing versioned charts. If any component lacks this, the installer cannot consume it from the registry.
 
 - **Owner:** Component repo maintainers
-- **Mitigation:** Track chart publishing readiness per component. The umbrella chart can temporarily use `file://` references for components not yet publishing, with a clear timeline for each to migrate.
+- **Mitigation:** Track chart publishing readiness per component. Allow temporary local references during the transition.
 
 ## 8. Open Questions
 
-### 8.1 What semantic versioning scheme should components use?
+### 8.1 How should charts be structured across clusters?
 
-Should component charts follow independent semver (osac-operator 1.2.0, fulfillment-service 2.1.0) or lockstep versioning (all components at 1.0.0 for OSAC 1.0.0)?
-
-- **Owner:** OSAC platform team
-- **Impact:** Affects FR-9, FR-10, and the release process. Independent versioning is more flexible but harder to communicate; lockstep is simpler but forces version bumps on unchanged components.
-
-### 8.2 Should the prerequisites chart be published to the same OCI registry?
-
-The prerequisites chart installs third-party operators (cert-manager, Keycloak). Should it be versioned and published alongside the OSAC chart, or maintained as a local chart in the repo?
+Should the installer provide one chart per cluster type (management chart, hub chart, workload chart), a single umbrella with cluster-targeting values, or a hybrid approach? Production deployments span multiple independently-maintained clusters, while dev environments run everything on one.
 
 - **Owner:** OSAC platform team
-- **Impact:** Affects FR-1 and the installation workflow. Publishing it enables `helm install osac-prereqs oci://...` in air-gapped environments.
+- **Impact:** Affects FR-1, FR-2, and the overall chart architecture. This is the most significant design decision for the EP.
+
+### 8.2 What semantic versioning scheme should components use?
+
+Should component charts follow independent semver (osac-operator 1.2.0, fulfillment-service 2.1.0) or lockstep versioning (all at 1.0.0 for OSAC 1.0.0)?
+
+- **Owner:** OSAC platform team
+- **Impact:** Affects FR-11 and the release process.
+
+### 8.3 How should deployment profiles be distributed?
+
+Published Helm packages do not bundle arbitrary values files. Should profiles live in a separate repository, be published as OCI artifacts, or be documented as reference configurations?
+
+- **Owner:** OSAC platform team
+- **Impact:** Affects FR-10 and the user experience for selecting a deployment configuration.
+
+### 8.4 Should prerequisites be subcharts or a separate chart?
+
+Including prerequisites as optional subcharts within the main chart(s) enables a single `helm install`. A separate chart gives more flexibility for environments where prerequisites are already managed externally.
+
+- **Owner:** OSAC platform team
+- **Impact:** Affects FR-4, FR-5, and the installation workflow complexity.

--- a/enhancements/installer-restructure/prd.md
+++ b/enhancements/installer-restructure/prd.md
@@ -1,0 +1,132 @@
+# Restructure osac-installer as a Production-Only Helm Installer
+
+| Field       | Value   |
+|-------------|---------|
+| Author(s)   | Dan Manor |
+| Jira        | N/A — conversation-driven |
+| Date        | 2026-07-01 |
+
+## 1. Problem Statement
+
+osac-installer evolved from a developer convenience tool into a repository that attempts to serve developers, CI pipelines, and production deployments simultaneously. The result is a codebase with dual deployment methods (Helm and Kustomize), 15 shell scripts that mix production setup with CI-only concerns, and 5 different configuration surfaces. A Cloud Provider Admin attempting to install OSAC in production cannot determine the supported installation path, must run post-install shell scripts after `helm install`, and has no versioned release to pin against. Without restructuring, every new OSAC deployment is a bespoke scripted process — fragile, unreproducible, and incompatible with production tooling like enclave and ArgoCD.
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+- Cloud Provider Admins can install OSAC using a single versioned Helm chart pulled from an OCI registry, with no shell scripts required.
+- Cloud Infrastructure Admins can configure backend integrations (networking, storage, identity) entirely through Helm values files, with no post-deploy patching.
+- The installer supports deploying different OSAC profiles (CaaS, VMaaS, full-stack) by layering values files, without maintaining separate charts or deployment paths.
+- OSAC releases are versioned — each release is a tested, reproducible combination of component chart versions published to an OCI registry.
+- The installer supports `helm upgrade` for in-place version upgrades.
+
+### 2.3 Non-Goals
+
+- Developer local/lab installation tooling — moves to osac-test-infra.
+- CI/E2E test infrastructure (overlays, CI-specific scripts, remote cluster setup) — moves to osac-test-infra.
+- Demo or proof-of-concept environment scripts — moves to osac-test-infra.
+- Kustomize as a supported deployment method.
+- A BMaaS-specific profile (planned for a future milestone). `[Clarify: R2.Q3]`
+
+## 3. Requirements
+
+### 3.1 Functional Requirements
+
+#### Prerequisites Installation
+
+- **FR-1:** The installer must provide a separate Helm chart for cluster prerequisites (cert-manager, trust-manager, Keycloak, AAP operator, LVMS, MetalLB, CNV, MCE) with per-component enable/disable toggles. `[Clarify: R1.Q1]`
+- **FR-2:** Each prerequisite component must default to enabled, allowing production environments where prerequisites are already installed to disable them individually.
+
+#### OSAC Deployment
+
+- **FR-3:** The installer must provide an umbrella Helm chart that composes all OSAC components (osac-operator, fulfillment-service, osac-aap, bare-metal-fulfillment-operator, osac-ui) as versioned sub-chart dependencies pulled from an OCI registry. `[Clarify: R1.Q4]`
+- **FR-4:** The umbrella chart must include Helm post-install hook Jobs for imperative operations that cannot be expressed as templates: AAP API token creation, hub cluster registration, AAP project synchronization, template publishing, and initial tenant setup.
+- **FR-5:** All configuration currently applied by post-deploy scripts (AAP instance group ConfigMaps and Secrets, Keycloak credentials, network backend settings) must be expressible through Helm values with no external patching required.
+
+#### Deployment Profiles
+
+- **FR-6:** The installer must ship values files for each supported profile: CaaS (cluster provisioning), VMaaS (compute instances), and full-stack (all capabilities). `[Clarify: R2.Q3]`
+- **FR-7:** Users must be able to layer profile values with site-specific overrides (e.g., `helm install osac -f profiles/caas.yaml -f my-site.yaml`).
+
+#### Installation Automation
+
+- **FR-8:** The installer must include a CLI wrapper (Makefile or script) that orchestrates the two-phase install: prerequisites chart installation, readiness verification, then OSAC chart installation. `[Clarify: R2.Q2]`
+
+#### Versioning and Distribution
+
+- **FR-9:** Each component repository must publish its Helm chart to an OCI registry with semantic versioning. `[Clarify: R2.Q1]`
+- **FR-10:** The umbrella chart version must represent the OSAC release version, with its Chart.yaml pinning specific component chart versions. A release is a tested combination of component versions.
+- **FR-11:** The production osac-installer repository must contain only the umbrella chart, profiles, CLI wrapper, and documentation — no Git submodules, no kustomize manifests, no shell scripts beyond the CLI wrapper. `[Clarify: R1.Q4]`
+
+#### Migration
+
+- **FR-12:** The restructuring must be executed incrementally across 5 phases, keeping CI green at each phase boundary: (1) prerequisites chart and profiles, (2) post-install hook Jobs, (3) OCI publishing with semantic versioning, (4) CI/dev script migration to osac-test-infra, (5) kustomize removal.
+
+### 3.2 Non-Functional Requirements
+
+- **NFR-1:** The installer must support `helm upgrade` for in-place OSAC version upgrades. Chart templates must be idempotent and handle pre-existing resources. `[Clarify: R1.Q3]`
+- **NFR-2:** The installer must be deployable in air-gapped environments by mirroring the OCI registry. No installation step may require internet access beyond the registry.
+- **NFR-3:** CI must validate a full Helm-only deployment (prerequisites + OSAC) on a test cluster with zero scripts as the acceptance test for each phase of the migration. `[Clarify: R2.Q4]`
+- **NFR-4:** The Helm values schema (values.schema.json) must validate all required configuration fields at install time, providing clear error messages when mandatory values are missing.
+
+## 4. Acceptance Criteria
+
+- [ ] A Cloud Provider Admin can install OSAC on a clean OpenShift cluster by running `helm install` for the prerequisites chart, then `helm install` for the OSAC chart with a profile values file — no scripts, no kustomize, no manual steps.
+- [ ] A Cloud Infrastructure Admin can configure all backend integrations (Netris, ESI, VAST, Keycloak, AAP) through Helm values files alone.
+- [ ] The CLI wrapper (`make install PROFILE=caas VALUES=my-site.yaml`) successfully orchestrates a two-phase deployment from a clean cluster to a working OSAC installation.
+- [ ] `helm upgrade` from OSAC version N to version N+1 completes without errors and preserves existing tenant data and configuration.
+- [ ] The osac-installer repository contains no kustomize files, no Git submodules, and no shell scripts other than the CLI wrapper.
+- [ ] CI runs a full Helm-only deployment and verifies OSAC services are healthy without invoking any shell scripts.
+- [ ] Each OSAC release is published to the OCI registry with a semantic version and documents the component chart versions it includes.
+
+## 5. Assumptions
+
+- Component repositories (osac-operator, fulfillment-service, osac-aap, bare-metal-fulfillment-operator, osac-ui) will add CI pipelines to publish their Helm charts to the OCI registry with semantic versions. This is a prerequisite for FR-9 and FR-3.
+- The existing `publish-charts.yaml` CI workflow can be extended to support semantic versioning and OCI publishing without a full rewrite.
+- Post-install imperative operations (AAP token creation, hub registration) can be reliably expressed as Kubernetes Jobs running as Helm hooks, including idempotent retry behavior.
+
+## 6. Dependencies
+
+- **Component repos** — Each component must publish its Helm chart to the OCI registry before the umbrella chart can consume it. FR-3 and FR-9 are blocked until this is in place.
+- **osac-test-infra** — Must accept the migrated CI/dev scripts (teardown, snapshot recovery, remote cluster setup, CaaS agent setup) and update its CI workflows to source them from the new location.
+- **OCI registry** — A container registry (ghcr.io or equivalent) must be available for publishing and pulling Helm charts.
+- **Enclave team** — Must validate that the restructured Helm chart works with enclave's deployment orchestration.
+
+## 7. Risks
+
+### 7.1 CI disruption during migration
+
+Moving CI scripts to osac-test-infra while CI pipelines still reference them in osac-installer could break automated testing.
+
+- **Owner:** OSAC platform team
+- **Mitigation:** Phase 4 (script migration) updates CI workflows in the same PR that moves the scripts. Incremental approach ensures each phase is independently validated.
+
+### 7.2 Helm hook Jobs may not cover all imperative operations
+
+Some post-install operations (e.g., hub registration via fulfillment CLI, AAP project sync) involve complex retry logic and external API calls that may be difficult to express as reliable Kubernetes Jobs.
+
+- **Owner:** OSAC platform team
+- **Mitigation:** Prototype the most complex hook Job (hub registration) early in Phase 2. If Jobs prove insufficient, evaluate moving these operations into the osac-operator's reconciliation loop as a longer-term alternative.
+
+### 7.3 Component repos not ready for OCI publishing
+
+FR-3 depends on all component repos publishing versioned charts. If any component repo lacks chart publishing CI, the umbrella chart cannot consume it from the registry.
+
+- **Owner:** Component repo maintainers
+- **Mitigation:** Track chart publishing readiness per component. The umbrella chart can temporarily use `file://` references for components not yet publishing, with a clear timeline for each to migrate.
+
+## 8. Open Questions
+
+### 8.1 What semantic versioning scheme should components use?
+
+Should component charts follow independent semver (osac-operator 1.2.0, fulfillment-service 2.1.0) or lockstep versioning (all components at 1.0.0 for OSAC 1.0.0)?
+
+- **Owner:** OSAC platform team
+- **Impact:** Affects FR-9, FR-10, and the release process. Independent versioning is more flexible but harder to communicate; lockstep is simpler but forces version bumps on unchanged components.
+
+### 8.2 Should the prerequisites chart be published to the same OCI registry?
+
+The prerequisites chart installs third-party operators (cert-manager, Keycloak). Should it be versioned and published alongside the OSAC chart, or maintained as a local chart in the repo?
+
+- **Owner:** OSAC platform team
+- **Impact:** Affects FR-1 and the installation workflow. Publishing it enables `helm install osac-prereqs oci://...` in air-gapped environments.


### PR DESCRIPTION
## PRD: Restructure osac-installer as a Production-Only Helm Installer

### Summary

This PRD proposes restructuring osac-installer from a hybrid dev/CI/production tool into a production-only Helm-based installer. The current repository has dual deployment methods (Helm and Kustomize), 15 shell scripts mixing production and CI concerns, and 5 different configuration surfaces. The restructured installer would be a single versioned Helm chart published to an OCI registry, with deployment profiles for CaaS/VMaaS/full-stack, a separate prerequisites chart, and zero shell scripts.

### Requesting Review On

- Requirements completeness — are all installation scenarios covered?
- Scope — are the goals and non-goals correctly drawn?
- Migration approach — is the 5-phase incremental plan realistic?
- Open questions — versioning scheme (independent vs lockstep) and prerequisites chart publishing need stakeholder input
- Acceptance criteria — are they verifiable and complete?

### How to Review

- Comment inline on specific sections
- Review the open questions (Section 8) — these need your input
- Approve when the PRD accurately reflects the agreed requirements
