### PR TITLE
OSAC-1567: Secret Management design document

### DIFF
--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -308,24 +308,29 @@ startup flags, following the existing pattern for infrastructure
 dependencies like the database connection:
 
 ```
---vault-endpoint        Vault-compatible API endpoint URL
---vault-auth-mount-path Kubernetes auth method mount path (default: auth/kubernetes)
---vault-kv-mount-path   KV v2 secret engine mount path (default: secret)
---vault-role            Role for fulfillment-service authentication
+--vault-endpoint           Vault API endpoint URL (Required)
+--vault-role               Vault role for authentication (Required)
+--vault-auth-method        Auth method: kubernetes (default) or jwt
+--vault-auth-mount-path    Custom mount path (defaults to auth/<method>)
+--vault-jwt-token-file     Custom token file path (overrides defaults)
+--vault-kv-mount-path      KV v2 secret engine mount path (default: secret)
+--vault-ca-cert-file       Path to PEM-encoded CA certificate for Vault TLS
 ```
 
-When these flags are set, the VaultBackend is constructed at startup and
-injected into the PrivateSecretsServer. When unset, the VaultBackend is
-nil and user-created secret operations return `FAILED_PRECONDITION`.
+The `--vault-auth-method` flag selects the authentication strategy:
+
+kubernetes (default) — Exchanges the local pod ServiceAccount token for a Vault token. For cross-cluster setups, Vault must have network access to verify the token against the remote cluster's TokenReview API.
+
+jwt — Authenticates using a projected ServiceAccount token or OIDC JWT. Vault validates the token's cryptographic signature offline using the remote cluster's public JWKS endpoint. This is preferred for decoupled, cross-cluster setups.
 
 The secret store must meet these prerequisites:
 
 - **Reachable endpoint** — the store's API must be reachable from the
   fulfillment-service pods
-- **TLS** — the endpoint must serve TLS; the CA certificate must be
-  trusted by the fulfillment-service
-- **Kubernetes auth method** — enabled and configured to trust the
-  fulfillment-service ServiceAccount for token exchange
+- **TLS** — the endpoint must serve TLS; if the CA is not in the
+  system trust store, provide the CA certificate via `--vault-ca-cert-file`
+- **Auth method** — one of the supported auth methods must be enabled
+  and configured on the store (see `--vault-auth-method` above)
 - **KV v2 secret engine** — mounted at the path specified in
   `--vault-kv-mount-path`
 
@@ -432,10 +437,12 @@ with the new schema.
 **Encryption at rest:** The Vault-compatible secret store provides
 encryption at rest. PostgreSQL stores only metadata (see Proposal).
 
-**Authentication to the secret store:** The fulfillment-service
-authenticates via the Kubernetes auth method [Assumption: Vault-compatible
-stores support K8s auth]. The ServiceAccount token is exchanged for a
-short-lived token scoped to the KV mount. No long-lived tokens are stored.
+**Authentication to the secret store:** The fulfillment-service supports
+two auth methods (see Vault Configuration). Both Kubernetes and JWT/OIDC
+auth exchange a short-lived token for a short-lived Vault token scoped to
+the KV mount — no long-lived tokens are stored. Credentials are read
+from files on disk, allowing injection via Kubernetes Secrets or similar
+mechanisms.
 
 **Input validation:** Total secret data size is capped at 1 MiB (Vault API default
 max entry size). For typed secrets, the server validates both the

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -383,7 +383,7 @@ a Secret resource. The existing inline field is deprecated / removed after data 
 
 Validation rules:
 - Referenced Secret must exist and match the expected type
-- Referenced secret must be in the same project or an ancestor project
+- Referenced secret must be in the same project
 
 **All credential reference fields:**
 
@@ -508,8 +508,8 @@ The public Secret API does not expose the `backend` field or Hub
 coordinates.
 
 **Secret store data organization:** Per-tenant KV paths
-(`{kv_mount_path}/data/{tenant_name}/*`) organize secret data by tenant
-within the store. Tenant isolation is enforced at
+(`{kv_mount_path}/data/{tenant_name}/{project_name}/{name}*`) organize secret data by tenant,
+prject, and name scope within the store.  Acces sisolation is enforced at
 the application layer — the fulfillment-service only reads or writes
 paths matching the authenticated tenant.
 

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -259,8 +259,7 @@ same structure but omits `backend` and `hub_coordinates` from
 Kubernetes Secret `Data`. It is provided on Create/Update, returned on
 Get, and omitted from List. The CLI controls display: the default table
 view shows metadata only, while structured output formats (`-o yaml/json`)
-include base64-encoded data values — following the same convention as
-`kubectl get secret`.
+include data values.
 
 The `type` field is set at creation and immutable. The server validates
 data keys and value format based on type.
@@ -377,15 +376,14 @@ New commands follow existing patterns:
 | `osac get secret <name>` | Get secret (table: metadata only; `-o yaml/json`: includes data) |
 | `osac describe secret <name>` | Detailed secret metadata view |
 | `osac delete secret <name>` | Delete a secret |
-| `osac edit secret <name>` | Edit secret data/metadata in `$EDITOR` (base64-encoded, per kubectl convention) |
+| `osac edit secret <name>` | Edit secret data/metadata in `$EDITOR` |
 
 The `--from-file`, `--from-literal`, and `--type` flags are new to the
 OSAC CLI. They follow `kubectl create secret` conventions because secrets
 hold arbitrary key-value data — unlike other OSAC resources which have
 typed fields with dedicated flags (e.g., `--pull-secret-file`). `--type`
 defaults to `opaque`. Data values are included in structured output
-formats (`-o yaml/json`) as base64-encoded strings, following kubectl
-conventions. The default table view shows metadata only.
+formats (`-o yaml/json`). The default table view shows metadata only.
 
 #### Secret References
 

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -120,15 +120,16 @@ OSAC hub cluster.
 #### Tenant User: Create a Cluster with a Secret Reference
 
 1. The tenant user creates a secret for container image registry auth:
-   `osac create secret my-pull-secret --type pull-secret --from-file auth.json`
+   `osac create secret my-pull-secret --from-file .dockerconfigjson=auth.json`
 2. The tenant user creates a cluster referencing the secret:
    `osac create cluster my-cluster --pull-secret my-pull-secret`
-3. The fulfillment-service validates that `my-pull-secret` exists and is
-   type `PULL_SECRET`. The cluster spec stores
+3. The fulfillment-service validates that `my-pull-secret` exists. The
+   cluster spec stores
    `pull_secret_secret = "my-pull-secret"` — no inline credential data.
 4. The cluster reconciler resolves the reference by reading the secret
-   data via the private Secrets API, then provisions the cluster with
-   the pull secret.
+   data via the private Secrets API, validates the pull secret format,
+   then provisions the cluster. If the format is invalid, the error is
+   reported in the cluster's status.
 
 #### System: Automatic Secret Creation During Cluster Provisioning
 
@@ -154,8 +155,7 @@ Starting state: A new tenant is being provisioned.
 1. The tenant controller generates break glass credentials (username and
    password) via the IDP manager and creates the IdP user account.
 2. The controller calls the private Secrets API to create a Vault-backed
-   secret with type `OPAQUE` and data
-   `{"username": <value>, "password": <value>}`.
+   secret with data `{"username": <value>, "password": <value>}`.
 3. The controller sets `break_glass_credentials_secret` on the
    tenant status to the new secret's name.
 4. A tenant admin retrieves the break glass password via
@@ -229,21 +229,13 @@ message Secret {
 message SecretSpec {
   map<string, bytes> data = 1;
   SecretBackend backend = 2;
-  SecretType type = 3;
-  map<string, string> coordinates = 4;
+  map<string, string> coordinates = 3;
 }
 
 enum SecretBackend {
   SECRET_BACKEND_UNSPECIFIED = 0;
   SECRET_BACKEND_VAULT = 1;
   SECRET_BACKEND_HUB = 2;
-}
-
-enum SecretType {
-  SECRET_TYPE_UNSPECIFIED = 0;
-  SECRET_TYPE_OPAQUE = 1;
-  SECRET_TYPE_PULL_SECRET = 2;
-  SECRET_TYPE_KUBECONFIG = 3;
 }
 
 ```
@@ -256,23 +248,15 @@ Get, and omitted from List. The CLI controls display: the default table
 view shows metadata only, while structured output formats (`-o yaml/json`)
 include data values.
 
-The `type` field is set at creation and immutable. The server validates
-data keys and value format based on type.
-
-#### Secret Types
-
-| Type | Required Keys | Format Validation | Notes |
-|------|--------------|-------------------|-------|
-| `OPAQUE` (default) | At least one arbitrary key | None | Passwords, tokens, API keys |
-| `PULL_SECRET` | `.dockerconfigjson` | Valid JSON with top-level `auths` object | Key name follows the `kubernetes.io/dockerconfigjson` convention; all major runtimes (podman, CRI-O, containerd) use this format |
-| `KUBECONFIG` | `kubeconfig` | Valid YAML with `apiVersion: v1`, `kind: Config` | Structure validated, not connectivity |
+All secrets are opaque key-value data — the secret store does not
+enforce key names or value formats. Consuming resources validate the
+secret's contents when they read it and report errors in their own
+status (e.g., a cluster controller validates that a pull secret
+contains a valid `.dockerconfigjson` key before provisioning).
 
 For Hub-backed secrets (system-created), the `data` map is populated on
 demand from the Kubernetes Secret — the key matches the Kubernetes
 Secret's `Data` field key (typically `kubeconfig` or `password`).
-
-These three types cover the credential migration scope. Additional types
-(e.g., TLS, SSH key) can be added when needed.
 
 The `backend` field is set by the server, not the caller:
 - Public API Create: server sets `backend = VAULT` automatically.
@@ -301,7 +285,7 @@ Secrets are tenant- and project-scoped, following the `objects` table
 pattern.
 
 The `data` JSONB column stores the SecretSpec proto JSON (`backend`,
-`type`, `coordinates`) — not secret bytes (see Proposal).
+`coordinates`) — not secret bytes (see Proposal).
 
 #### Vault Configuration
 
@@ -344,14 +328,14 @@ Private server behavioral specifics:
 
 - **Create:**
   - Sets `backend = VAULT` if not specified
-  - Validates data against the secret type (see Secret Types)
+  - Validates data is non-empty (at least one key)
   - Generates the resource ID, writes data to Vault, then inserts
     metadata into PostgreSQL within the gRPC interceptor transaction
 - **Get:**
   - Reads metadata from PostgreSQL, dispatches to backend to fetch data
 - **Update:**
-  - If `spec.data` is non-empty, validates against the secret type,
-    writes new data to Vault, then updates metadata if needed
+  - If `spec.data` is non-empty, writes new data to Vault, then
+    updates metadata if needed
 - **Update (Hub-backed):**
   - Metadata-only updates (e.g. labels) are allowed.
   - If `spec.data` is non-empty, returns `FAILED_PRECONDITION` — Hub-backed secret data is system-managed.
@@ -376,19 +360,18 @@ New commands follow existing patterns:
 | `osac create secret <name> --from-file=<key>=<path>` | Create a secret with a key-value pair from a file |
 | `osac create secret <name> --from-file=<path>` | Create with filename as the key |
 | `osac create secret <name> --from-literal=<key>=<value>` | Create a secret from a literal value |
-| `osac create secret <name> --type=pull-secret --from-file=<path>` | Create a typed secret (auto-maps to required key) |
 | `osac get secrets` | List secrets (metadata only) |
 | `osac get secret <name>` | Get secret (table: metadata only; `-o yaml/json`: includes data) |
 | `osac describe secret <name>` | Detailed secret metadata view |
 | `osac delete secret <name>` | Delete a secret |
 | `osac edit secret <name>` | Edit secret data/metadata in `$EDITOR` |
 
-The `--from-file`, `--from-literal`, and `--type` flags are new to the
-OSAC CLI. They follow `kubectl create secret` conventions because secrets
-hold arbitrary key-value data — unlike other OSAC resources which have
-typed fields with dedicated flags (e.g., `--pull-secret-file`). `--type`
-defaults to `opaque`. Data values are included in structured output
-formats (`-o yaml/json`). The default table view shows metadata only.
+The `--from-file` and `--from-literal` flags are new to the OSAC CLI.
+They follow `kubectl create secret` conventions because secrets hold
+arbitrary key-value data — unlike other OSAC resources which have
+typed fields with dedicated flags. Data values are included in
+structured output formats (`-o yaml/json`). The default table view
+shows metadata only.
 
 #### Secret References
 
@@ -396,38 +379,41 @@ Resources that currently embed credentials as inline fields gain a new reference
 a Secret resource. The existing inline field is deprecated / removed after data migration.
 
 Validation rules:
-- Referenced Secret must exist and match the expected type
+- Referenced Secret must exist
 - Referenced secret must be in the same project
+- The consuming resource's controller validates the secret's contents
+  at use time and reports format errors in its own status
 
 **All credential reference fields:**
 
-| Resource | Inline Field (deprecated) | Reference Field | Secret Type |
-|----------|--------------------------|-----------------|-------------|
-| Cluster | `pull_secret` | `pull_secret_secret` | `PULL_SECRET` |
-| ClusterTemplate | `pull_secret` | `pull_secret_secret` | `PULL_SECRET` |
-| Hub | `kubeconfig` | `kubeconfig_secret` | `KUBECONFIG` |
-| IdentityProvider | `client_secret` | `client_secret_secret` | `OPAQUE` |
-| IdentityProvider | `bind_credential` | `bind_credential_secret` | `OPAQUE` |
-| StorageBackend | `password` | `password_secret` | `OPAQUE` |
-| Tenant | `break_glass_credentials` | `break_glass_credentials_secret` | `OPAQUE` |
+| Resource | Inline Field (deprecated) | Reference Field |
+|----------|--------------------------|-----------------|
+| Cluster | `pull_secret` | `pull_secret_secret` |
+| ClusterTemplate | `pull_secret` | `pull_secret_secret` |
+| Hub | `kubeconfig` | `kubeconfig_secret` |
+| IdentityProvider | `client_secret` | `client_secret_secret` |
+| IdentityProvider | `bind_credential` | `bind_credential_secret` |
+| StorageBackend | `password` | `password_secret` |
+| Tenant | `break_glass_credentials` | `break_glass_credentials_secret` |
 
+Note: The exact naming, nature, and type of these reference fields may change as a result
+of upcoming type-safe resource references - https://redhat.atlassian.net/browse/OSAC-1330
 
 #### Credential Migration
 
 A Go migration script moves existing inline credentials into the Secrets
 API. The script maps each inline credential to the appropriate key-value
-structure based on the target secret type:
+structure:
 
 1. Reads all resources with inline credential data from PostgreSQL
 2. For each credential, creates a Secret resource in the same project
-   as the parent resource, with the correct type and data map:
-   - `pull_secret` → type `PULL_SECRET`, data
-     `{".dockerconfigjson": <value>}`
-   - `kubeconfig` → type `KUBECONFIG`, data `{"kubeconfig": <value>}`
-   - `client_secret`, `bind_credential`, `password` → type `OPAQUE`,
-     data `{"value": <value>}`
-   - `break_glass_credentials` → type `OPAQUE`,
-     data `{"username": <value>, "password": <value>}`
+   as the parent resource with the appropriate data map:
+   - `pull_secret` → data `{".dockerconfigjson": <value>}`
+   - `kubeconfig` → data `{"kubeconfig": <value>}`
+   - `client_secret`, `bind_credential`, `password` → data
+     `{"value": <value>}`
+   - `break_glass_credentials` → data
+     `{"username": <value>, "password": <value>}`
 3. Writes metadata to PostgreSQL and data to the Vault store
 4. Sets the corresponding `*_secret` field on the resource to the new
    secret's name
@@ -459,8 +445,8 @@ from files on disk, allowing injection via Kubernetes Secrets or similar
 mechanisms.
 
 **Input validation:** Total secret data size is capped at 1 MiB (Vault API default
-max entry size). For typed secrets, the server validates both the
-required keys and the value format (see Secret Types). Secret names
+max entry size). The server validates that secret data contains at
+least one key but does not enforce key names or value formats. Secret names
 follow the existing OSAC naming validation (alphanumeric, hyphens, max
 253 characters).
 

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -149,19 +149,6 @@ available on the hub.
    kubeconfig from the hub cluster — the same retrieval path currently
    implemented in `getHostedClusterSecret()` [Codebase: internal/servers/clusters_server.go].
 
-#### System: Break Glass Credential Creation During Tenant Provisioning
-
-Starting state: A new tenant is being provisioned.
-
-1. The tenant controller generates break glass credentials (username and
-   password) via the IDP manager and creates the IdP user account.
-2. The controller calls the private Secrets API to create a Vault-backed
-   secret with data `{"username": <value>, "password": <value>}`.
-3. The controller sets `break_glass_credentials_secret` on the
-   tenant status to the new secret's name.
-4. A tenant admin retrieves the break glass password via
-   `osac get secret <name> -o yaml` for initial login.
-
 ```mermaid
 sequenceDiagram
     participant User as Tenant User
@@ -395,7 +382,6 @@ Validation rules:
 | IdentityProvider | `client_secret` | `client_secret_secret` |
 | IdentityProvider | `bind_credential` | `bind_credential_secret` |
 | StorageBackend | `password` | `password_secret` |
-| Tenant | `break_glass_credentials` | `break_glass_credentials_secret` |
 
 Note: The exact naming, nature, and type of these reference fields may change as a result
 of upcoming type-safe resource references - https://redhat.atlassian.net/browse/OSAC-1330
@@ -432,8 +418,6 @@ structure:
    - `kubeconfig` → data `{"kubeconfig": <value>}`
    - `client_secret`, `bind_credential`, `password` → data
      `{"value": <value>}`
-   - `break_glass_credentials` → data
-     `{"username": <value>, "password": <value>}`
 3. Writes metadata to PostgreSQL and data to the Vault store
 4. Sets the corresponding `*_secret` field on the resource to the new
    secret's name
@@ -543,7 +527,7 @@ This organizes secret data by tenant, project, and name within the
 store. Access isolation is enforced at the application layer — the
 fulfillment-service only reads or writes paths matching the
 authenticated tenant.  The request handler should drop privileges as early
-as possible so that for a given request being executed it shoud only be able
+as possible so that for a given request being executed it should only be able
 to access secrets for that tenant.
 
 ### Observability and Monitoring

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -3,7 +3,7 @@ title: secret-management
 authors:
   - dcrowder@redhat.com
 creation-date: 2026-07-07
-last-updated: 2026-07-07
+last-updated: 2026-07-16
 tracking-link:
   - https://redhat.atlassian.net/browse/OSAC-1567
 prd:
@@ -46,7 +46,7 @@ This fragmentation creates three problems:
    with database access can read secrets in cleartext.
 2. Tenants cannot manage credentials independently: rotating a pull secret requires updating the
    cluster that uses it, and there is no way to list all credentials a tenant owns.
-3. Third, each new resource type that needs credentials must reimplement redaction and retrieval logic,
+3. Each new resource type that needs credentials must reimplement redaction and retrieval logic,
    increasing the surface area for mistakes.
 
 ### Goals
@@ -59,7 +59,7 @@ This fragmentation creates three problems:
 
 - Secret rotation automation — users can update secret values manually, but scheduled or event-driven rotation workflows are out of scope.
 - UI support — secret management is CLI and API only for 0.2.
-- Secret store deployment and operations — the cloud provider is responsible for deploying and operating the Vault-compatible secret store. OSAC connects to it; OSAC does not manage its lifecycle.
+- Secret store deployment and operations — the cloud provider is responsible for deploying and operating the Vault-compatible secret store. OSAC manages per-tenant namespaces within the store but does not manage the store's own lifecycle (deployment, upgrades, HA, backups).
 
 ## Proposal
 
@@ -81,11 +81,15 @@ responses return metadata only.
 Two secret backends exist for 0.2:
 
 - **Vault** — user-created and system-created secrets stored in a
-  Vault-compatible secret store. The store's connection parameters are
-  configured via fulfillment-service startup flags, like the database
-  connection.
+  Vault-compatible secret store with namespace support (e.g., OpenBao or
+  HashiCorp Vault Enterprise). Each tenant's secrets are stored in a
+  dedicated child namespace under a parent OSAC namespace, providing
+  structural isolation — each namespace has its own KV v2 engine with
+  physically separate storage and its own Keycloak JWT auth method
+  (see Vault Configuration).
 - **Hub** — system-created secrets whose data lives in Kubernetes Secrets
-  on hub clusters (e.g., cluster kubeconfigs, admin passwords). The
+  on hub clusters (e.g., provisioned cluster kubeconfigs and admin
+  passwords created by HostedCluster controllers). The
   fulfillment-service retrieves data on demand using the existing Hub
   kubeconfig infrastructure.
 
@@ -94,13 +98,26 @@ Two secret backends exist for 0.2:
 #### Cloud Infrastructure Admin: Configure the Secret Store
 
 Starting state: The cloud provider has deployed a Vault-compatible secret
-store (e.g., OpenBao or HashiCorp Vault) and made it reachable from the
-OSAC hub cluster.
+store with namespace support (e.g., OpenBao 2.5+ or HashiCorp Vault
+Enterprise) and made it reachable from the OSAC hub cluster.
 
-1. The Cloud Infrastructure Admin sets the appropriate `--vault-*` flags
-   on the fulfillment-service deployment (see Vault Configuration)
-2. On startup, the fulfillment-service validates the connection by
-   performing a health check against the configured endpoint. If the
+1. The Cloud Infrastructure Admin creates the parent OSAC namespace in
+   the secret store (e.g., `osac/`), configures a JWT auth method within
+   it (trusting the Keycloak OIDC discovery endpoint), and creates a
+   policy granting the fulfillment-service access to manage child
+   namespaces (create, delete, configure auth methods and policies). This policy does **not** grant
+   KV read/write access — it is scoped to namespace lifecycle operations
+   only. This is a one-time setup step — per-tenant child namespaces and
+   their auth methods are created automatically during tenant onboarding
+   (see Tenant Namespace Lifecycle).
+2. The Cloud Infrastructure Admin sets the appropriate `--vault-*` flags
+   on the fulfillment-service deployment (see Vault Configuration),
+   including `--vault-namespace` pointing to the parent namespace and
+   `--vault-keycloak-discovery-url` pointing to the Keycloak OIDC
+   discovery endpoint.
+3. On startup, the fulfillment-service authenticates to the parent
+   namespace using its lifecycle credentials and validates the connection
+   by performing a health check against the configured endpoint. If the
    check fails, the service logs an error but continues to start — Hub
    secrets remain functional, and Vault-backed secret creation returns
    `FAILED_PRECONDITION` until the store is reachable.
@@ -128,9 +145,8 @@ OSAC hub cluster.
    cluster spec stores
    `pull_secret_secret = "my-pull-secret"` — no inline credential data.
 4. The cluster reconciler resolves the reference by reading the secret
-   data via the private Secrets API, validates the pull secret format,
-   then provisions the cluster. If the format is invalid, the error is
-   reported in the cluster's status.
+   data via the private Secrets API, validates the pull secret format, 
+   then writes the resolved credential into the ClusterOrder CR.
 
 #### System: Automatic Secret Creation During Cluster Provisioning
 
@@ -153,20 +169,38 @@ available on the hub.
 sequenceDiagram
     participant User as Tenant User
     participant API as Fulfillment Service
+    participant KC as Keycloak
     participant DB as PostgreSQL
-    participant VS as Secret Store
+    participant VS as Secret Store (tenant namespace)
     participant Hub as Hub K8s Cluster
 
-    Note over User,Hub: User-created secret (Vault backend)
-    User->>API: POST /secrets {name, data: {key: bytes}}
-    API->>VS: PUT {kv_mount}/data/{tenant}/{project}/{name}
+    Note over User,Hub: User-created secret (Vault backend, JWT auth)
+    User->>API: POST /secrets {name, data} + Bearer JWT
+    API->>VS: POST {tenant}/auth/jwt/login (forward user JWT)
+    Note over VS,KC: Vault validates JWT via Keycloak JWKS<br/>checks bound_claims: {organization}
+    VS-->>API: Vault token (scoped to tenant namespace)
+    API->>VS: PUT secret/data/{project}/{name}
     API->>DB: INSERT metadata (within gRPC transaction)
     API-->>User: Secret (metadata only)
 
-    User->>API: GET /secrets/{name}
+    Note over User,Hub: User reads secret (same JWT auth path)
+    User->>API: GET /secrets/{name} + Bearer JWT
     API->>DB: SELECT metadata
-    API->>VS: GET {kv_mount}/data/{tenant}/{project}/{name}
-    API-->>User: Secret (metadata + data map)
+    API->>VS: POST {tenant}/auth/jwt/login (forward user JWT)
+    VS-->>API: Vault token (scoped to tenant namespace)
+    API->>VS: GET secret/data/{project}/{name}
+    API-->>User: Secret (metadata + data)
+
+    Note over User,Hub: Controller reads secret (Keycloak-brokered auth)
+    Note over API: Cluster reconciler resolves pull_secret_secret
+    API->>KC: Exchange K8s SA token for Keycloak JWT<br/>(organization: [tenant])
+    KC-->>API: Keycloak JWT (scoped to tenant org)
+    API->>VS: POST {tenant}/auth/jwt/login (Keycloak JWT)
+    Note over VS,KC: Vault validates JWT via Keycloak JWKS<br/>checks bound_claims: {organization}
+    VS-->>API: Vault token (scoped to tenant namespace)
+    API->>DB: SELECT secret metadata
+    API->>VS: GET secret/data/{project}/{name}
+    API->>Hub: Write resolved credential to ClusterOrder CR
 
     Note over User,Hub: System-created secret (Hub backend)
     API->>DB: INSERT metadata (coordinates: hub, ns, secret, key)
@@ -282,20 +316,82 @@ startup flags, following the existing pattern for infrastructure
 dependencies like the database connection:
 
 ```
---vault-endpoint           Vault API endpoint URL (Required)
---vault-role               Vault role for authentication (Required)
---vault-auth-method        Auth method: kubernetes (default) or jwt
---vault-auth-mount-path    Custom mount path (defaults to auth/<method>)
---vault-jwt-token-file     Custom token file path (overrides defaults)
---vault-kv-mount-path      KV v2 secret engine mount path (default: secret)
---vault-ca-cert-file       Path to PEM-encoded CA certificate for Vault TLS
+--vault-endpoint              Vault API endpoint URL (Required)
+--vault-namespace             Parent namespace path within Vault (Required, e.g., "osac")
+--vault-ca-cert-file          Path to PEM-encoded CA certificate for Vault TLS
+--vault-kv-mount-path         KV v2 secret engine mount path within tenant namespaces (default: secret)
+--vault-lifecycle-role        Vault role for lifecycle JWT auth (Required)
+--vault-lifecycle-mount-path  Custom mount path for lifecycle auth (default: auth/jwt)
+--vault-keycloak-discovery-url    Keycloak OIDC discovery URL for tenant JWT auth setup (Required)
+--vault-keycloak-audience         Expected audience claim in Keycloak JWTs (default: osac-api)
+--vault-keycloak-token-endpoint   Keycloak token endpoint for controller token exchange (Required)
+--vault-keycloak-client-id        Keycloak client ID for controller token exchange (Required)
+--vault-keycloak-client-secret-file  Path to Keycloak client secret for controller token exchange (Required)
 ```
 
-The `--vault-auth-method` flag selects the authentication strategy:
+The fulfillment-service uses three distinct authentication paths to
+the secret store, each with different scope:
 
-kubernetes (default) — Exchanges the local pod ServiceAccount token for a Vault token. For cross-cluster setups, Vault must have network access to verify the token against the remote cluster's TokenReview API.
+**Lifecycle auth (parent namespace):** The `--vault-lifecycle-*` flags
+configure how the fulfillment-service authenticates to the parent
+namespace for tenant onboarding/offboarding operations (create/delete
+child namespaces, enable auth methods, configure policies). The
+lifecycle auth uses the same Keycloak JWT mechanism — the
+fulfillment-service authenticates with a Keycloak-issued JWT to the
+parent namespace's `auth/jwt/` endpoint. The policy for this identity
+grants only namespace management — it cannot read or write KV
+data. This is the only credential that operates at the parent namespace
+level.
 
-jwt — Authenticates using a projected ServiceAccount token or OIDC JWT. Vault validates the token's cryptographic signature offline using the remote cluster's public JWKS endpoint. This is preferred for decoupled, cross-cluster setups.
+**User auth (per-tenant, JWT forwarding):** When a user calls the
+Secrets API, the fulfillment-service forwards the user's Keycloak JWT
+to the tenant's child namespace JWT auth endpoint
+(`{parent_namespace}/{tenant}/auth/jwt/login`). Vault validates the JWT
+against Keycloak's public keys (configured via
+`--vault-keycloak-discovery-url` during tenant onboarding) and checks
+`bound_claims: {"organization": ["<tenant>"]}` to enforce that the user
+belongs to the tenant. The resulting Vault token is scoped to that
+single tenant namespace — even a bug in the fulfillment-service cannot
+cross tenant boundaries because Vault itself enforces the claim match.
+
+**Controller auth (per-tenant, Keycloak-brokered):** When a
+fulfillment-service controller needs Vault access (e.g., the cluster
+reconciler resolving a `pull_secret_secret` reference), it first
+exchanges its Kubernetes ServiceAccount token with Keycloak for a
+Keycloak-issued JWT scoped to the target tenant. The exchange uses
+the Keycloak token endpoint (configured via
+`--vault-keycloak-token-endpoint`) with the fulfillment-service's
+client credentials. Keycloak validates the SA token against the
+Kubernetes cluster's OIDC issuer, then issues a standard Keycloak JWT
+with `organization: ["<tenant>"]`. The controller authenticates this
+Keycloak JWT to the same tenant namespace JWT auth endpoint used
+by user requests (`{parent_namespace}/{tenant}/auth/jwt/login`). Vault
+validates the token against Keycloak's public keys and checks
+`bound_claims: {"organization": ["<tenant>"]}` — the same role, same
+mount, same validation as user requests.
+
+This design uses Keycloak as an OIDC broker, insulating Vault from
+any knowledge of the Kubernetes cluster's identity infrastructure. If
+the fulfillment-service migrates to a different cluster, only the
+Keycloak identity provider configuration needs updating — all Vault
+tenant namespace configurations remain untouched.
+
+The lifecycle credential can manage namespaces but cannot read KV
+data. User and controller credentials are both Keycloak JWTs
+authenticated per-tenant by Vault, with tenant binding enforced by
+`bound_claims: {"organization"}` in all cases. The controller
+obtains per-tenant JWTs via Keycloak token exchange using a single
+set of client credentials — Vault enforces the tenant scope via
+claim validation, not credential separation. A compromised set of
+Keycloak client credentials could request JWTs for any tenant, but
+each resulting Vault token remains scoped to a single tenant
+namespace by Vault's `bound_claims` check.
+
+**Extensibility for future consumers:** Services (e.g., AAP/Ansible jobs) 
+can access tenant secrets by obtaining a tenant-scoped JWT via standard OAuth 2.0 
+client credentials from Keycloak and calling the fulfillment-service Secrets gRPC API. 
+The fulfillment-service forwards the JWT through the same user auth path —
+no additional Vault or fulfillment-service configuration required.
 
 The secret store must meet these prerequisites:
 
@@ -303,34 +399,80 @@ The secret store must meet these prerequisites:
   fulfillment-service pods
 - **TLS** — the endpoint must serve TLS; if the CA is not in the
   system trust store, provide the CA certificate via `--vault-ca-cert-file`
-- **Auth method** — one of the supported auth methods must be enabled
-  and configured on the store (see `--vault-auth-method` above)
-- **KV v2 secret engine** — mounted at the path specified in
-  `--vault-kv-mount-path`
+- **Namespace support** — the store must support namespaces, including
+  per-namespace auth method configuration. OpenBao (2.5+ recommended)
+  provides namespace support in its free open-source release. HashiCorp
+  Vault requires an Enterprise license for namespace support.
+- **Parent namespace** — a parent namespace (e.g., `osac/`) must exist
+  with an auth method configured and a policy granting the
+  fulfillment-service lifecycle access only (namespace management, no
+  KV access). See Cloud Infrastructure Admin workflow.
+- **Keycloak connectivity** — Keycloak is the sole OIDC provider trusted
+  by Vault. The secret store must reach Keycloak's OIDC discovery endpoint
+  for JWKS key refresh (cached periodically). The fulfillment-service must
+  reach Keycloak's token endpoint for controller token exchange. Keycloak
+  must be configured with a Kubernetes OIDC identity provider that trusts
+  the fulfillment-service cluster's SA token issuer.
 
-Documentation will cover setup for common implementations.
+**Network requirements:** The following connectivity paths must be
+available:
+
+1. **Fulfillment-service pods → Vault API** (HTTPS) — for all secret
+   operations and tenant namespace lifecycle management.
+2. **Fulfillment-service pods → Keycloak token endpoint** (HTTPS) — for
+   controller token exchange (SA token → tenant-scoped Keycloak JWT).
+3. **Vault → Keycloak OIDC discovery** (HTTPS, Vault-initiated) — for
+   JWKS key refresh used to validate Keycloak JWTs. Vault caches JWKS
+   keys and refreshes periodically, so brief Keycloak outages are
+   tolerated.
+
+In multi-cluster deployments where Vault and the fulfillment-service
+are in different clusters, paths 1 and 3 cross cluster boundaries and
+may require ingress or service mesh configuration.
+
+Per-tenant child namespaces, their KV v2 secret engines, and their auth
+method configurations are created automatically during tenant
+onboarding — the Cloud Infrastructure Admin does not need to configure
+these manually. Documentation will cover parent namespace setup for
+common implementations.
 
 #### Server Implementation
+
+All Vault-backend operations authenticate to the tenant's child
+namespace before dispatching, using the auth path determined by request
+context — user JWT forwarding or controller Keycloak token exchange
+(see Vault Configuration). The resulting Vault token is scoped to a
+single tenant's namespace regardless of path.
+
+**Token caching:** Per-request auth adds latency. The server caches
+Keycloak exchange tokens and Vault tokens:
+- User path: cached by JWT `jti` + tenant name; evicted at the earlier
+  of JWT expiry or Vault token TTL.
+- Controller path: cached by tenant name; evicted prior to TTL expiry.
 
 Private server behavioral specifics:
 
 - **Create:**
   - Sets `backend = VAULT` if not specified
   - Validates data is non-empty (at least one key)
-  - Writes data to Vault, then inserts
-    metadata into PostgreSQL upon successful creation.
+  - Authenticates to the tenant's Vault namespace, writes data, then
+    inserts metadata into PostgreSQL upon successful creation. If the
+    tenant's namespace does not yet exist (onboarding controller has not
+    completed), returns `FAILED_PRECONDITION`.
 - **Get:**
-  - Reads metadata from PostgreSQL, dispatches to backend to fetch data
+  - Reads metadata from PostgreSQL, authenticates to the tenant's
+    Vault namespace, dispatches to backend to fetch data
 - **Update:**
-  - If `spec.data` is non-empty, writes new data to Vault, then
-    updates metadata if needed
+  - If `spec.data` is non-empty, authenticates to the tenant's Vault
+    namespace, writes new data, then updates metadata if needed
 - **Update (Hub-backed):**
   - Metadata-only updates (e.g. labels) are allowed.
   - If `spec.data` is non-empty, returns `FAILED_PRECONDITION` — Hub-backed secret data is system-managed.
 - **Delete:**
   - Vault-backed: deletes metadata within the transaction, then
-    permanently removes all versions from Vault. If Vault delete fails, the transaction rolls back
-    and the secret remains intact.
+    authenticates to the tenant's Vault namespace and permanently removes
+    all versions. If Vault delete fails, the transaction rolls back and
+    the secret remains intact.
   - Hub-backed (public API): returns `FAILED_PRECONDITION` — tenants
     cannot delete system-managed secrets.
   - Hub-backed (private API): deletes the metadata. Used by the
@@ -405,32 +547,92 @@ System-created secrets (e.g., cluster kubeconfigs) will have this label set by t
 This ensures that secrets created by OSAC itself are discoverable
 by type without requiring manual labeling.
 
+#### Tenant Namespace Lifecycle
+
+Each tenant gets a dedicated child namespace in the secret store with
+its own auth methods configured. The tenant onboarding controller
+manages namespace lifecycle as part of Tenant CR reconciliation (see
+the [tenant-onboarding EP](/enhancements/tenant-onboarding)):
+
+**Onboarding (namespace creation):**
+
+1. When the tenant onboarding controller creates a Tenant CR, it also
+   creates a child namespace `{parent_namespace}/{tenant_name}/` in the
+   secret store
+2. Mounts a KV v2 secret engine at `secret/` within the new namespace
+3. Enables JWT auth at `auth/jwt/` within the namespace, configured
+   with:
+   - `oidc_discovery_url` set to the Keycloak OIDC discovery endpoint
+     (from `--vault-keycloak-discovery-url`)
+   - A role with `bound_claims: {"organization": ["<tenant_name>"]}`,
+     `bound_audiences: ["<audience>"]` (from `--vault-keycloak-audience`),
+     and `user_claim: "sub"`
+   - A policy granting read/write/delete access to the KV engine
+
+This is the only auth mount needed per tenant — both user requests and
+controller operations authenticate with Keycloak-issued JWTs through
+the same `auth/jwt/` endpoint. Keycloak acts as the sole OIDC broker,
+so Vault has no direct dependency on the Kubernetes cluster's identity
+infrastructure.
+
+If namespace creation or auth configuration fails (e.g., the secret
+store is temporarily unavailable), the controller retries on the next
+reconciliation loop. The tenant remains functional for non-secret
+operations — Vault-backed secret creation returns
+`FAILED_PRECONDITION` until the namespace is available.
+
+**Offboarding (namespace deletion):**
+
+When a tenant is deleted, the controller deletes the tenant's namespace.
+Namespace deletion is a cascading operation — all secrets, policies, and
+auth methods within the namespace are permanently removed. This provides
+clean tenant data removal without requiring individual secret deletion.
+
+```
+Parent Namespace: osac/
+├── auth/jwt/                     ← lifecycle auth only (namespace mgmt, no KV)
+├── tenant-acme/                  ← created during onboarding for tenant-acme
+│   ├── auth/jwt/                 ← validates Keycloak JWTs
+│   └── secret/ (KV v2)          ← mounted during onboarding
+│       └── data/{project}/{name} ← per-project secret paths
+├── tenant-bigcorp/
+│   ├── auth/jwt/
+│   └── secret/ (KV v2)
+│       └── data/{project}/{name}
+└── ...
+```
+
 #### Credential Migration
 
 A Go binary moves existing inline credentials into the Secrets
-API. The binary maps each inline credential to the appropriate key-value
-structure:
+API. The binary authenticates using the same lifecycle and controller
+auth paths as the fulfillment-service (see Vault Configuration). It
+maps each inline credential to the appropriate key-value structure:
 
-1. Reads all resources with inline credential data from PostgreSQL
-2. For each credential, creates a Secret resource in the same project
+1. For each tenant with inline credential data, ensures the tenant's
+   namespace exists in the secret store with auth configured
+2. Reads all resources with inline credential data from PostgreSQL
+3. For each credential, creates a Secret resource in the same project
    as the parent resource with the appropriate data map:
    - `pull_secret` → data `{".dockerconfigjson": <value>}`
    - `kubeconfig` → data `{"kubeconfig": <value>}`
    - `client_secret`, `bind_credential`, `password` → data
      `{"value": <value>}`
-3. Writes metadata to PostgreSQL and data to the Vault store
-4. Sets the corresponding `*_secret` field on the resource to the new
+4. Writes metadata to PostgreSQL and data to the tenant's namespace in
+   the Vault store
+5. Sets the corresponding `*_secret` field on the resource to the new
    secret's name
-5. Clears the inline credential field
+6. Clears the inline credential field
 
 The binary is idempotent across all steps — safe to re-run if
 interrupted at any point. For each credential it checks whether the
-Secret already exists (skips creation), whether the `*_secret` field is
-already set (skips the update), and whether the inline field is already
-cleared (skips the clear). This ensures a crash between any two steps
-does not leave partial state on rerun. It runs as a one-time job after
-the Vault store is configured and the fulfillment-service is upgraded
-with the new schema.
+tenant namespace exists (skips creation), whether the Secret already
+exists (skips creation), whether the `*_secret` field is already set
+(skips the update), and whether the inline field is already cleared
+(skips the clear). This ensures a crash between any two steps does not
+leave partial state on rerun. It runs as a one-time job after the Vault
+store is configured and the fulfillment-service is upgraded with the
+new schema.
 
 The binary can be manually invoked as a one-time step for currently running clusters
 via a subcommand.  A cleanup task will be created to fully remove the binary at
@@ -441,12 +643,18 @@ a later release once the Vault secret store is fully established.
 **Encryption at rest:** The Vault-compatible secret store provides
 encryption at rest. PostgreSQL stores only metadata (see Proposal).
 
-**Authentication to the secret store:** The fulfillment-service supports
-two auth methods (see Vault Configuration). Both Kubernetes and JWT/OIDC
-auth exchange a short-lived token for a short-lived Vault token scoped to
-the KV mount — no long-lived tokens are stored. Credentials are read
-from files on disk, allowing injection via Kubernetes Secrets or similar
-mechanisms.
+**Tenant isolation:** Each tenant's secrets are stored in a dedicated
+namespace with its own KV v2 engine — physically separate storage that
+prevents cross-tenant data exposure from path-matching bugs or policy
+misconfigurations. The fulfillment-service authenticates per-tenant
+using Keycloak JWTs with `bound_claims` enforcement (see Vault
+Configuration). A compromised or buggy fulfillment-service cannot
+access a tenant's secrets without a valid Keycloak JWT carrying the
+correct `organization` claim for that tenant. The Keycloak client
+credentials used for controller token exchange can request JWTs for
+any tenant, but Vault's per-namespace `bound_claims` check ensures
+each resulting token is scoped to a single tenant. The lifecycle
+credential can manage namespaces but has no KV read/write access.
 
 **Input validation:** Total secret data size is capped at 1 MiB (Vault API default
 max entry size). The server validates that secret data contains at
@@ -481,15 +689,22 @@ returns an error.
 
 #### Per-operation behavior
 
+All Vault operations require per-tenant authentication before
+dispatching (see Server Implementation). If the tenant's namespace does
+not yet exist (onboarding controller has not completed), Vault-backed
+operations return `FAILED_PRECONDITION`. If per-tenant auth fails
+(e.g., invalid JWT claims, Keycloak token exchange failure, or secret store
+unreachable), Vault-backed operations fail with `UNAVAILABLE`.
+
 | Operation | Steps | On Failure |
 |-----------|-------|------------|
-| **Create (Vault)** | Vault write → insert metadata → commit | Vault failure: no record created. Commit failure: orphan in Vault (no metadata). |
+| **Create (Vault)** | Authenticate to tenant namespace → Vault write → insert metadata → commit | Namespace missing: `FAILED_PRECONDITION`. Auth or Vault failure: no record created. Commit failure: orphan in Vault (no metadata). |
 | **Create (Hub)** | Insert metadata with coordinates → commit | Standard DB error handling. |
-| **Get** | Read metadata → fetch data from backend | Return `UNAVAILABLE`. |
-| **Update (Vault data)** | Vault write (overwrite) → update metadata if needed → commit | Vault failure: return error, existing data intact. |
+| **Get** | Read metadata → authenticate to tenant namespace → fetch data from backend | Auth failure: `UNAVAILABLE`. |
+| **Update (Vault data)** | Authenticate to tenant namespace → Vault write (overwrite) → update metadata if needed → commit | Auth or Vault failure: return error, existing data intact. |
 | **Update (Hub metadata)** | Update metadata in PostgreSQL only | Standard DB error handling. |
 | **Update (Hub data)** | N/A — returns `FAILED_PRECONDITION` | Data is system-managed. |
-| **Delete (Vault)** | Delete metadata → Vault metadata delete (permanent, all versions) → commit | Vault failure: rollback restores metadata, secret intact. Commit failure: retry (Vault metadata delete is idempotent on non-existent paths). |
+| **Delete (Vault)** | Delete metadata → authenticate to tenant namespace → Vault metadata delete (permanent, all versions) → commit | Auth or Vault failure: rollback restores metadata, secret intact. Commit failure: retry (Vault metadata delete is idempotent on non-existent paths). |
 | **Delete (Hub, public)** | Returns `FAILED_PRECONDITION` | Tenants cannot delete system-managed secrets. |
 | **Delete (Hub, private)** | Delete metadata → commit | Standard DB error handling. |
 
@@ -520,15 +735,23 @@ catch-all for private API methods.
 The public Secret API does not expose the `backend` field or Hub
 coordinates.
 
-**Secret store path derivation:** All Vault operations use the canonical
-path `{kv_mount_path}/data/{tenant}/{project}/{name}`, where
+**Secret store namespace model:** Each tenant has a dedicated child
+namespace with per-tenant Keycloak JWT auth (see Vault Configuration).
+
+**Secret store path derivation:** Within a tenant's namespace, all Vault
+operations use the path `{kv_mount_path}/data/{project}/{name}`, where
 `kv_mount_path` is set via `--vault-kv-mount-path` (default: `secret`).
-This organizes secret data by tenant, project, and name within the
-store. Access isolation is enforced at the application layer — the
-fulfillment-service only reads or writes paths matching the
-authenticated tenant.  The request handler should drop privileges as early
-as possible so that for a given request being executed it should only be able
-to access secrets for that tenant.
+The full qualified path from the root namespace is
+`{parent_namespace}/{tenant}/secret/data/{project}/{name}`.
+Access isolation is enforced both structurally (namespace isolation —
+each tenant's secrets are in a separate namespace with independent KV
+storage) and by authentication (per-tenant auth methods with Keycloak
+JWT claim binding). A Vault token obtained in one tenant's namespace
+cannot access another tenant's secrets. Project-level isolation within
+a tenant namespace is enforced by the application layer (OPA policies
+and fulfillment-service request routing), not by Vault policies — Vault
+enforces tenant-level isolation via namespace boundaries and JWT claim
+binding.
 
 ### Observability and Monitoring
 
@@ -540,16 +763,22 @@ Secrets API requests use the existing fulfillment-service gRPC metrics and struc
 |------|--------|------------|
 | Secret store becomes a single point of failure for all secret operations | Secret creation and data retrieval fail when the store is down | Vault-compatible stores support HA deployment. The cloud provider is responsible for HA configuration. Metadata remains accessible when the store is down. |
 | Secret store data loss results in unrecoverable secret loss | Secrets with Vault backend become permanently inaccessible | The cloud provider is responsible for backup and disaster recovery of their secret store deployment. Documentation will cover backup recommendations. |
+| Secret store must support namespaces — not all Vault-compatible stores do | Deployments without namespace support cannot use per-tenant isolation | Document the requirement. OpenBao (free, open-source) provides namespace support starting at v2.3.1 (v2.5+ recommended). HashiCorp Vault requires an Enterprise license. |
+| Keycloak Dependency | Vault cannot validate any JWTs, blocking all Vault-backed secret operations | Keycloak is already a hard dependency — user requests fail regardless when it is down. |
 
 ### Drawbacks
 
-Requiring cloud providers to deploy a Vault-compatible store adds an
-external prerequisite. This is justified because encryption at rest
-cannot be met with PostgreSQL alone — building custom encryption would
-duplicate what Vault-compatible stores already provide.
+Requiring cloud providers to deploy a Vault-compatible store with
+namespace support adds an external prerequisite and narrows compatible
+stores to OpenBao or HashiCorp Vault Enterprise. This is justified
+because encryption at rest cannot be met with PostgreSQL alone, and
+structural tenant isolation justifies the namespace requirement.
 
-The two-backend model adds CRUD dispatch and divergent failure handling
-complexity.
+The two-backend model adds CRUD dispatch complexity. The namespace
+model adds tenant lifecycle coordination. Per-request auth adds latency
+(mitigated by token caching). Keycloak becomes the sole OIDC broker —
+a stronger dependency than direct Kubernetes OIDC trust, but Keycloak
+is already a hard dependency for the fulfillment-service.
 
 ## Alternatives (Not Implemented)
 
@@ -562,6 +791,37 @@ dependency and keeps all data in one store.
 **Rejected because:** Key management for envelope encryption is complex —
 the wrapping key must itself be securely stored and rotated. Better to trust
 an industry-standard technology like Vault than build and maintain ourselves.
+
+### Parent-Namespace Service Token (Single Credential)
+
+The fulfillment-service authenticates once to the parent OSAC namespace
+at startup and receives a token that can access all child (tenant)
+namespaces via the `X-Vault-Namespace` header. Tenant isolation is
+enforced by the application layer — the service sets the header to the
+correct tenant namespace on each request.
+
+**Rejected because:** A single credential that can access all tenants'
+secrets creates a broad blast radius. A bug in namespace header routing
+or a compromised service token could access any tenant's data. The
+per-tenant auth model enforces isolation at the Vault layer — Vault
+itself validates that the caller has a legitimate claim to the
+requested tenant's namespace, regardless of what the application
+requests.
+
+### Path-based Tenant Isolation (No Namespaces)
+
+Store all tenants' secrets in a single KV v2 engine, using path
+conventions (`{kv_mount}/data/{tenant}/{project}/{name}`) and
+application-layer enforcement to isolate tenants. The
+fulfillment-service authenticates once with broad credentials and
+restricts access based on the authenticated tenant's path prefix.
+
+**Rejected because:** Isolation is logical (enforced by application
+code) rather than structural. A bug in path-matching logic or a
+misconfigured policy could expose cross-tenant data. Namespace-based
+isolation provides a stronger boundary — each tenant's KV engine is
+physically separate, and a request scoped to one namespace cannot access
+another regardless of the path used.
 
 ### Full backwards compatibility with existing data fields
 
@@ -586,9 +846,14 @@ overhead / ongoing maintainance burden.
 
 **Integration tests (Kind cluster):**
 - Secret CRUD through gRPC with a Vault-compatible store in the Kind cluster
-- Tenant isolation: verify tenant A cannot read tenant B's secrets
+- Per-tenant JWT auth: verify user JWT forwarding to tenant Vault namespace, verify `bound_claims` rejection for mismatched organization
+- Keycloak token exchange: verify controller SA token exchange with Keycloak produces a tenant-scoped JWT, and that JWT authenticates to the tenant's Vault namespace
+- Tenant namespace isolation: verify tenant A cannot read tenant B's secrets across namespaces
+- Namespace lifecycle: verify namespace creation with JWT auth setup during tenant onboarding, deletion during offboarding
+- Token caching: verify cached Vault tokens are reused within TTL and evicted on expiry
 - Hub-backend secrets: create via private API with coordinates, retrieve via public API
-- Migration: Moving data from a cluster with inline pull_secret to the Vault backend
+- Credential resolution: verify cluster reconciler reads pull_secret_secret from Vault via controller auth and writes resolved value to ClusterOrder CR
+- Migration: Moving data from a cluster with inline pull_secret to the Vault backend, including namespace creation
 
 **E2E tests (pytest, osac-test-infra):**
 - Automatic secret creation during cluster provisioning
@@ -629,4 +894,5 @@ OSAC. There is no graceful disable path.
 
 ## Infrastructure Needed
 
-- Vault-compatible secret store instance in the integration test Kind cluster (OpenBao recommended for CI due to its permissive license)
+- Vault-compatible secret store instance with namespace support and per-namespace auth method configuration in the integration test Kind cluster (OpenBao 2.5+ recommended for CI due to its permissive license and free namespace support)
+- Keycloak instance in the integration test cluster (already exists) — the secret store must be able to reach Keycloak's OIDC discovery endpoint for JWT validation

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -147,6 +147,20 @@ available on the hub.
    kubeconfig from the hub cluster — the same retrieval path currently
    implemented in `getHostedClusterSecret()` [Codebase: internal/servers/clusters_server.go].
 
+#### System: Break Glass Credential Creation During Tenant Provisioning
+
+Starting state: A new tenant is being provisioned.
+
+1. The tenant controller generates break glass credentials (username and
+   password) via the IDP manager and creates the IdP user account.
+2. The controller calls the private Secrets API to create a Vault-backed
+   secret with type `OPAQUE` and data
+   `{"username": <value>, "password": <value>}`.
+3. The controller sets `break_glass_credentials_secret` on the
+   tenant status to the new secret's name.
+4. A tenant admin retrieves the break glass password via
+   `osac get secret <name> -o yaml` for initial login.
+
 ```mermaid
 sequenceDiagram
     participant User as Tenant User
@@ -395,6 +409,7 @@ Validation rules:
 | IdentityProvider | `client_secret` | `client_secret_secret` | `OPAQUE` |
 | IdentityProvider | `bind_credential` | `bind_credential_secret` | `OPAQUE` |
 | StorageBackend | `password` | `password_secret` | `OPAQUE` |
+| Tenant | `break_glass_credentials` | `break_glass_credentials_secret` | `OPAQUE` |
 
 
 #### Credential Migration
@@ -411,6 +426,8 @@ structure based on the target secret type:
    - `kubeconfig` → type `KUBECONFIG`, data `{"kubeconfig": <value>}`
    - `client_secret`, `bind_credential`, `password` → type `OPAQUE`,
      data `{"value": <value>}`
+   - `break_glass_credentials` → type `OPAQUE`,
+     data `{"username": <value>, "password": <value>}`
 3. Writes metadata to PostgreSQL and data to the Vault store
 4. Sets the corresponding `*_secret` field on the resource to the new
    secret's name

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -42,11 +42,11 @@ credentials implements its own storage, redaction, and retrieval pattern.
 
 This fragmentation creates three problems:
 
-1. Credential data stored in the PostgreSQL `data` JSONB column is not encrypted at rest — anyone 
+1. Credential data stored in the PostgreSQL `data` JSONB column is not encrypted at rest — anyone
    with database access can read secrets in cleartext.
 2. Tenants cannot manage credentials independently: rotating a pull secret requires updating the
-   cluster that uses it, and there is no way to list all credentials a tenant owns. 
-3. Third, each new resource type that needs credentials must reimplement redaction and retrieval logic, 
+   cluster that uses it, and there is no way to list all credentials a tenant owns.
+3. Third, each new resource type that needs credentials must reimplement redaction and retrieval logic,
    increasing the surface area for mistakes.
 
 ### Goals
@@ -360,14 +360,14 @@ New commands follow existing patterns:
 |---------|-------------|
 | `osac create secret <name> --from-file=<key>=<path>` | Create a secret with a key-value pair from a file |
 | `osac create secret <name> --from-file=<path>` | Create with filename as the key |
-| `osac create secret <name> --from-literal=<key>=<value>` | Create a secret from a literal value |
+| `osac create secret <name> --from-file=-` | Create a secret from stdin |
 | `osac get secrets` | List secrets (metadata only) |
 | `osac get secret <name>` | Get secret (table: metadata only; `-o yaml/json`: includes data) |
 | `osac describe secret <name>` | Detailed secret metadata view |
 | `osac delete secret <name>` | Delete a secret |
 | `osac edit secret <name>` | Edit secret data/metadata in `$EDITOR` |
 
-The `--from-file` and `--from-literal` flags are new to the OSAC CLI.
+The `--from-file` flag is new to the OSAC CLI.
 They follow `kubectl create secret` conventions because secrets hold
 arbitrary key-value data — unlike other OSAC resources which have
 typed fields with dedicated flags. Data values are included in
@@ -399,6 +399,25 @@ Validation rules:
 
 Note: The exact naming, nature, and type of these reference fields may change as a result
 of upcoming type-safe resource references - https://redhat.atlassian.net/browse/OSAC-1330
+
+#### Secret Labels
+
+Users are encouraged to apply the label `osac.openshift.io/secret-type`
+to describe what kind of credential data a secret holds. This label is
+not enforced by the server — it is a recommended convention that enables
+filtering and auditing by secret type.
+
+For example:
+
+```bash
+osac create secret my-pull-secret \
+  --from-file .dockerconfigjson=auth.json \
+  --label osac.openshift.io/secret-type=pull-secret
+```
+
+System-created secrets (e.g., cluster kubeconfigs) will have this label set by the creating controller.
+This ensures that secrets created by OSAC itself are discoverable
+by type without requiring manual labeling.
 
 #### Credential Migration
 
@@ -455,8 +474,10 @@ follow the existing OSAC naming validation (alphanumeric, hyphens, max
 gRPC connections. The CLI displays data only in structured output formats
 (`-o yaml/json`); the default table view shows metadata only.
 
-**No secret data in logs or events:** The RedactFunc strips `spec.data`
+**No secret data in logs, events, or CLIs:** The RedactFunc strips `spec.data`
 from all event payloads. Server-side logging does not include secret data.
+Users should be able to create secrets without having to type secrets in CLI inputs
+that might show up in history or the process table.
 
 ### Failure Handling and Recovery
 
@@ -521,7 +542,9 @@ path `{kv_mount_path}/data/{tenant}/{project}/{name}`, where
 This organizes secret data by tenant, project, and name within the
 store. Access isolation is enforced at the application layer — the
 fulfillment-service only reads or writes paths matching the
-authenticated tenant.
+authenticated tenant.  The request handler should drop privileges as early
+as possible so that for a given request being executed it shoud only be able
+to access secrets for that tenant.
 
 ### Observability and Monitoring
 

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -171,20 +171,20 @@ sequenceDiagram
 
     Note over User,Hub: User-created secret (Vault backend)
     User->>API: POST /secrets {name, data: {key: bytes}}
-    API->>VS: PUT /v1/secret/data/{tenant}/{id} {data}
+    API->>VS: PUT {kv_mount}/data/{tenant}/{project}/{name}
     API->>DB: INSERT metadata (within gRPC transaction)
     API-->>User: Secret (metadata only)
 
-    User->>API: GET /secrets/{id}
+    User->>API: GET /secrets/{name}
     API->>DB: SELECT metadata
-    API->>VS: GET /v1/secret/data/{tenant}/{id}
+    API->>VS: GET {kv_mount}/data/{tenant}/{project}/{name}
     API-->>User: Secret (metadata + data map)
 
     Note over User,Hub: System-created secret (Hub backend)
     API->>DB: INSERT metadata (coordinates: hub, ns, secret, key)
     Note over API: ClusterOrder controller triggers creation
 
-    User->>API: GET /secrets/{id}
+    User->>API: GET /secrets/{name}
     API->>DB: SELECT metadata + coordinates
     API->>Hub: GET Secret via kubeconfig
     API-->>User: Secret (metadata + data)
@@ -329,8 +329,8 @@ Private server behavioral specifics:
 - **Create:**
   - Sets `backend = VAULT` if not specified
   - Validates data is non-empty (at least one key)
-  - Generates the resource ID, writes data to Vault, then inserts
-    metadata into PostgreSQL within the gRPC interceptor transaction
+  - Writes data to Vault, then inserts
+    metadata into PostgreSQL upon successful creation.
 - **Get:**
   - Reads metadata from PostgreSQL, dispatches to backend to fetch data
 - **Update:**
@@ -514,11 +514,13 @@ catch-all for private API methods.
 The public Secret API does not expose the `backend` field or Hub
 coordinates.
 
-**Secret store data organization:** Per-tenant KV paths
-(`{kv_mount_path}/data/{tenant_name}/{project_name}/{name}*`) organize secret data by tenant,
-prject, and name scope within the store.  Acces sisolation is enforced at
-the application layer — the fulfillment-service only reads or writes
-paths matching the authenticated tenant.
+**Secret store path derivation:** All Vault operations use the canonical
+path `{kv_mount_path}/data/{tenant}/{project}/{name}`, where
+`kv_mount_path` is set via `--vault-kv-mount-path` (default: `secret`).
+This organizes secret data by tenant, project, and name within the
+store. Access isolation is enforced at the application layer — the
+fulfillment-service only reads or writes paths matching the
+authenticated tenant.
 
 ### Observability and Monitoring
 

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -85,7 +85,7 @@ Two secret backends exist for 0.2:
   HashiCorp Vault Enterprise). Each tenant's secrets are stored in a
   dedicated child namespace under a parent OSAC namespace, providing
   structural isolation — each namespace has its own KV v2 engine with
-  physically separate storage and its own Keycloak JWT auth method
+  logically separated storage and its own Keycloak JWT auth method
   (see Vault Configuration).
 - **Hub** — system-created secrets whose data lives in Kubernetes Secrets
   on hub clusters (e.g., provisioned cluster kubeconfigs and admin
@@ -145,7 +145,7 @@ Enterprise) and made it reachable from the OSAC hub cluster.
    cluster spec stores
    `pull_secret_secret = "my-pull-secret"` — no inline credential data.
 4. The cluster reconciler resolves the reference by reading the secret
-   data via the private Secrets API, validates the pull secret format, 
+   data via the private Secrets API, validates the pull secret format,
    then writes the resolved credential into the ClusterOrder CR.
 
 #### System: Automatic Secret Creation During Cluster Provisioning
@@ -315,7 +315,7 @@ The Vault-compatible store connection is configured via fulfillment-service
 startup flags, following the existing pattern for infrastructure
 dependencies like the database connection:
 
-```
+```text
 --vault-endpoint              Vault API endpoint URL (Required)
 --vault-namespace             Parent namespace path within Vault (Required, e.g., "osac")
 --vault-ca-cert-file          Path to PEM-encoded CA certificate for Vault TLS
@@ -387,9 +387,9 @@ Keycloak client credentials could request JWTs for any tenant, but
 each resulting Vault token remains scoped to a single tenant
 namespace by Vault's `bound_claims` check.
 
-**Extensibility for future consumers:** Services (e.g., AAP/Ansible jobs) 
-can access tenant secrets by obtaining a tenant-scoped JWT via standard OAuth 2.0 
-client credentials from Keycloak and calling the fulfillment-service Secrets gRPC API. 
+**Extensibility for future consumers:** Services (e.g., AAP/Ansible jobs)
+can access tenant secrets by obtaining a tenant-scoped JWT via standard OAuth 2.0
+client credentials from Keycloak and calling the fulfillment-service Secrets gRPC API.
 The fulfillment-service forwards the JWT through the same user auth path —
 no additional Vault or fulfillment-service configuration required.
 
@@ -588,7 +588,7 @@ Namespace deletion is a cascading operation — all secrets, policies, and
 auth methods within the namespace are permanently removed. This provides
 clean tenant data removal without requiring individual secret deletion.
 
-```
+```text
 Parent Namespace: osac/
 ├── auth/jwt/                     ← lifecycle auth only (namespace mgmt, no KV)
 ├── tenant-acme/                  ← created during onboarding for tenant-acme
@@ -694,13 +694,13 @@ dispatching (see Server Implementation). If the tenant's namespace does
 not yet exist (onboarding controller has not completed), Vault-backed
 operations return `FAILED_PRECONDITION`. If per-tenant auth fails
 (e.g., invalid JWT claims, Keycloak token exchange failure, or secret store
-unreachable), Vault-backed operations fail with `UNAVAILABLE`.
+unreachable), Vault-backed operations fail with appropriate status.
 
 | Operation | Steps | On Failure |
 |-----------|-------|------------|
 | **Create (Vault)** | Authenticate to tenant namespace → Vault write → insert metadata → commit | Namespace missing: `FAILED_PRECONDITION`. Auth or Vault failure: no record created. Commit failure: orphan in Vault (no metadata). |
 | **Create (Hub)** | Insert metadata with coordinates → commit | Standard DB error handling. |
-| **Get** | Read metadata → authenticate to tenant namespace → fetch data from backend | Auth failure: `UNAVAILABLE`. |
+| **Get** | Read metadata → authenticate to tenant namespace → fetch data from backend | Return status code based on issue. |
 | **Update (Vault data)** | Authenticate to tenant namespace → Vault write (overwrite) → update metadata if needed → commit | Auth or Vault failure: return error, existing data intact. |
 | **Update (Hub metadata)** | Update metadata in PostgreSQL only | Standard DB error handling. |
 | **Update (Hub data)** | N/A — returns `FAILED_PRECONDITION` | Data is system-managed. |

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -524,6 +524,7 @@ Validation rules:
 | IdentityProvider | `client_secret` | `client_secret_secret` |
 | IdentityProvider | `bind_credential` | `bind_credential_secret` |
 | StorageBackend | `password` | `password_secret` |
+| Tenant | `break_glass_credentials` | `break_glass_credentials_secret` |
 
 Note: The exact naming, nature, and type of these reference fields may change as a result
 of upcoming type-safe resource references - https://redhat.atlassian.net/browse/OSAC-1330
@@ -618,6 +619,8 @@ maps each inline credential to the appropriate key-value structure:
    - `kubeconfig` → data `{"kubeconfig": <value>}`
    - `client_secret`, `bind_credential`, `password` → data
      `{"value": <value>}`
+   - `break_glass_credentials` → data
+     `{"username": <value>, "password": <value>}`
 4. Writes metadata to PostgreSQL and data to the tenant's namespace in
    the Vault store
 5. Sets the corresponding `*_secret` field on the resource to the new

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -96,7 +96,7 @@ Starting state: The cloud provider has deployed a Vault-compatible secret
 store (e.g., OpenBao or HashiCorp Vault) and made it reachable from the
 OSAC hub cluster.
 
-1. The Cloud Infrastructure Admin sets the appropriate `--vault-*` flags 
+1. The Cloud Infrastructure Admin sets the appropriate `--vault-*` flags
    on the fulfillment-service deployment (see Vault Configuration)
 2. On startup, the fulfillment-service validates the connection by
    performing a health check against the configured endpoint. If the
@@ -346,15 +346,15 @@ Documentation will cover setup for common implementations.
 
 Private server behavioral specifics:
 
-- **Create:** 
+- **Create:**
   - Sets `backend = VAULT` if not specified
   - Validates data against the secret type (see Secret Types)
   - Dispatches to vault to store the data
-- **Get:** 
+- **Get:**
   - Reads from Postgres, if include_data is true dispatches to backend to fetch data
 - **Update:**
   - If `spec.data` is non-empty on the update, validate against the secret type and write to backend
-- **Delete:** 
+- **Delete:**
   - Dispatches to backend to delete stored data.
   - After data is removed from backend, deletes postgres data.
   - Note: Hub data is never removed from the backend as part of this action (underlying K8s secret not deleted)
@@ -443,7 +443,7 @@ authenticates via the Kubernetes auth method [Assumption: Vault-compatible
 stores support K8s auth]. The ServiceAccount token is exchanged for a
 short-lived token scoped to the KV mount. No long-lived tokens are stored.
 
-**Input validation:** Total secret data size is capped at 1 MiB (Vault API default 
+**Input validation:** Total secret data size is capped at 1 MiB (Vault API default
 max entry size). For typed secrets, the server validates both the
 required keys and the value format (see Secret Types). Secret names
 follow the existing OSAC naming validation (alphanumeric, hyphens, max
@@ -578,14 +578,17 @@ overhead / ongoing maintainance burden.
 - Secret proto validation (required fields, name format, data size limits)
 - Backend interface: mock Vault and Hub backends to test Store/Fetch/Delete dispatch
 - Server logic: Create with backend write, Get with/without include_data, Update with data replacement, Delete with backend cleanup
+- State transitions: Ensure failure states (e.g. write to backend results in record stuck `PENDING` or update `ERROR`) written
 - Public↔private type mapping: verify `backend` and `hub_coordinates` are stripped in public responses
 - RedactFunc: verify data is stripped from event payloads
 - OPA policy: verify role-based access for Secret methods
+- Migration: Test idempotency logic + expected generated payloads
 
 **Integration tests (Kind cluster):**
 - Secret CRUD through gRPC with a Vault-compatible store in the Kind cluster
 - Tenant isolation: verify tenant A cannot read tenant B's secrets
 - Hub-backend secrets: create via private API with coordinates, retrieve via public API
+- Migration: Moving data from a cluster with inline pull_secret to the Vault backend
 
 **E2E tests (pytest, osac-test-infra):**
 - Automatic secret creation during cluster provisioning

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -125,7 +125,7 @@ OSAC hub cluster.
    `osac create cluster my-cluster --pull-secret my-pull-secret`
 3. The fulfillment-service validates that `my-pull-secret` exists and is
    type `PULL_SECRET`. The cluster spec stores
-   `pull_secret_ref = "my-pull-secret"` — no inline credential data.
+   `pull_secret_secret = "my-pull-secret"` — no inline credential data.
 4. The cluster reconciler resolves the reference by reading the secret
    data via the private Secrets API, then provisions the cluster with
    the pull secret.
@@ -389,12 +389,12 @@ Validation rules:
 
 | Resource | Inline Field (deprecated) | Reference Field | Secret Type |
 |----------|--------------------------|-----------------|-------------|
-| Cluster | `pull_secret` | `pull_secret_ref` | `PULL_SECRET` |
-| ClusterTemplate | `pull_secret` | `pull_secret_ref` | `PULL_SECRET` |
-| Hub | `kubeconfig` | `kubeconfig_ref` | `KUBECONFIG` |
-| IdentityProvider | `client_secret` | `client_secret_ref` | `OPAQUE` |
-| IdentityProvider | `bind_credential` | `bind_credential_ref` | `OPAQUE` |
-| StorageBackend | `password` | `password_ref` | `OPAQUE` |
+| Cluster | `pull_secret` | `pull_secret_secret` | `PULL_SECRET` |
+| ClusterTemplate | `pull_secret` | `pull_secret_secret` | `PULL_SECRET` |
+| Hub | `kubeconfig` | `kubeconfig_secret` | `KUBECONFIG` |
+| IdentityProvider | `client_secret` | `client_secret_secret` | `OPAQUE` |
+| IdentityProvider | `bind_credential` | `bind_credential_secret` | `OPAQUE` |
+| StorageBackend | `password` | `password_secret` | `OPAQUE` |
 
 
 #### Credential Migration
@@ -412,13 +412,13 @@ structure based on the target secret type:
    - `client_secret`, `bind_credential`, `password` → type `OPAQUE`,
      data `{"value": <value>}`
 3. Writes metadata to PostgreSQL and data to the Vault store
-4. Sets the corresponding `*_ref` field on the resource to the new
+4. Sets the corresponding `*_secret` field on the resource to the new
    secret's name
 5. Clears the inline credential field
 
 The script is idempotent across all steps — safe to re-run if
 interrupted at any point. For each credential it checks whether the
-Secret already exists (skips creation), whether the `*_ref` field is
+Secret already exists (skips creation), whether the `*_secret` field is
 already set (skips the update), and whether the inline field is already
 cleared (skips the clear). This ensures a crash between any two steps
 does not leave partial state on rerun. It runs as a one-time job after

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -1,0 +1,629 @@
+---
+title: secret-management
+authors:
+  - dcrowder@redhat.com
+creation-date: 2026-07-07
+last-updated: 2026-07-07
+tracking-link:
+  - https://redhat.atlassian.net/browse/OSAC-1567
+prd:
+  - "prd.md"
+see-also:
+  - "/enhancements/tenant-onboarding"
+  - "/enhancements/organizations"
+replaces:
+  - N/A
+superseded-by:
+  - N/A
+---
+
+# Secret Management
+
+## Summary
+
+This enhancement introduces a Secret resource that provides a uniform API
+over different secret sources — a Vault-compatible secret store for
+encrypted-at-rest storage and Hub clusters for on-demand Kubernetes
+credential retrieval — giving all OSAC personas a single interface for
+creating, retrieving, and managing credentials through the
+fulfillment-service gRPC/REST API and CLI. See [PRD](prd.md) for detailed
+requirements.
+
+## Motivation
+
+Credentials in OSAC are currently scattered across resource types.
+Cluster kubeconfigs are retrieved via dedicated `GetKubeconfig` and
+`GetPassword` RPCs that reach into hub Kubernetes clusters at request time
+[Codebase: internal/servers/clusters_server.go].
+Pull secrets, OIDC client secrets, and storage backend passwords are stored
+inline in their parent resource's spec, redacted on read and stripped on
+update through ad-hoc server-side logic. Each resource type that touches
+credentials implements its own storage, redaction, and retrieval pattern.
+
+This fragmentation creates three problems. First, credential data stored in
+the PostgreSQL `data` JSONB column is not encrypted at rest — anyone with
+database access can read secrets in cleartext. Second, tenants cannot manage
+credentials independently: rotating a pull secret requires updating the
+cluster that uses it, and there is no way to list all credentials a tenant
+owns. Third, each new resource type that needs credentials must reimplement
+redaction and retrieval logic, increasing the surface area for mistakes.
+
+### Goals
+
+- Keep the Secret data storage path (store/retrieve bytes) separate from the metadata path (CRUD in PostgreSQL) so that secret bytes never transit PostgreSQL.
+- Reuse the existing GenericServer/GenericDAO patterns for Secret CRUD metadata, adding backend dispatch only for data storage and retrieval [Codebase: internal/servers/generic_server.go].
+- Maintain tenant isolation guarantees consistent with all other OSAC resources (OPA policies, tenant-scoped metadata, per-tenant backend isolation).
+
+### Non-Goals
+
+- Secret rotation automation — users can update secret values manually, but scheduled or event-driven rotation workflows are out of scope.
+- UI support — secret management is CLI and API only for 0.2.
+- Secret store deployment and operations — the cloud provider is responsible for deploying and operating the Vault-compatible secret store. OSAC connects to it; OSAC does not manage its lifecycle.
+
+## Proposal
+
+A single new resource type is introduced:
+
+**Secret** is a tenant- and project-scoped resource that holds credential
+metadata in PostgreSQL and delegates data storage to a backend determined
+by the secret's source. Secrets appear in both the public and private APIs.
+The public API provides a uniform CRUD interface — tenants
+interact with secrets without knowing which backend stores them. The
+private API exposes the `backend` field and source-specific fields (e.g.,
+Hub coordinates) for admin visibility and system-created secrets.
+
+Secret data bytes never pass through PostgreSQL. On Create, the server
+writes metadata to PostgreSQL and data bytes to the backend. On Get, the
+server fetches data from the backend only when `include_data=true` (see
+Proto Schema). List responses return metadata only.
+
+Two secret backends exist for 0.2:
+
+- **Vault** — user-created and system-created secrets stored in a
+  Vault-compatible secret store. The store's connection parameters are
+  configured via fulfillment-service startup flags, like the database
+  connection.
+- **Hub** — system-created secrets whose data lives in Kubernetes Secrets
+  on hub clusters (e.g., cluster kubeconfigs, admin passwords). The
+  fulfillment-service retrieves data on demand using the existing Hub
+  kubeconfig infrastructure.
+
+### Workflow Description
+
+#### Cloud Infrastructure Admin: Configure the Secret Store
+
+Starting state: The cloud provider has deployed a Vault-compatible secret
+store (e.g., OpenBao or HashiCorp Vault) and made it reachable from the
+OSAC hub cluster.
+
+1. The Cloud Infrastructure Admin sets the appropriate `--vault-*` flags 
+   on the fulfillment-service deployment (see Vault Configuration)
+2. On startup, the fulfillment-service validates the connection by
+   performing a health check against the configured endpoint. If the
+   check fails, the service logs an error but continues to start — Hub
+   secrets remain functional, and Vault-backed secret creation returns
+   `FAILED_PRECONDITION` until the store is reachable.
+
+#### Tenant User: Create and Retrieve a Secret
+
+1. The tenant user creates a secret:
+   `osac create secret my-ssh-key --from-file id_rsa=~/.ssh/id_rsa`
+2. The fulfillment-service writes metadata to PostgreSQL and stores the
+   key-value data (`{"id_rsa": <bytes>}`) in the secret store under the
+   tenant's KV path.
+3. The CLI confirms creation and displays the secret metadata (no data).
+4. To retrieve the data:
+   `osac get secret my-ssh-key --include-data`
+5. The fulfillment-service reads metadata from PostgreSQL, fetches data
+   from the secret store, and writes the key-value pairs to stdout.
+
+#### Tenant User: Create a Cluster with a Secret Reference
+
+1. The tenant user creates a secret for container image registry auth:
+   `osac create secret my-pull-secret --type pull-secret --from-file auth.json`
+2. The tenant user creates a cluster referencing the secret:
+   `osac create cluster my-cluster --pull-secret my-pull-secret`
+3. The fulfillment-service validates that `my-pull-secret` exists and is
+   type `PULL_SECRET`. The cluster spec stores
+   `pull_secret_ref = "my-pull-secret"` — no inline credential data.
+4. The cluster reconciler resolves the reference by reading the secret
+   data via the private Secrets API, then provisions the cluster with
+   the pull secret.
+
+#### System: Automatic Secret Creation During Cluster Provisioning
+
+Starting state: A cluster has been provisioned and a kubeconfig is
+available on the hub.
+
+1. When the ClusterOrder controller detects that the HostedCluster has a
+   ready kubeconfig, it calls the fulfillment-service private Secrets API
+   to create a Hub-backed secret.
+2. The fulfillment-service stores the secret metadata in PostgreSQL with
+   backend `HUB` and the coordinates (hub ID, namespace, Kubernetes Secret
+   name, key) needed to retrieve the data on demand.
+3. The secret is associated with the cluster's tenant and annotated with
+   the cluster's owner reference.
+4. When a tenant user retrieves the secret
+   (`osac get secret cluster-kubeconfig --include-data`), the
+   fulfillment-service follows the Hub coordinates to retrieve the
+   kubeconfig from the hub cluster — the same retrieval path currently
+   implemented in `getHostedClusterSecret()` [Codebase: internal/servers/clusters_server.go].
+
+```mermaid
+sequenceDiagram
+    participant User as Tenant User
+    participant API as Fulfillment Service
+    participant DB as PostgreSQL
+    participant VS as Secret Store
+    participant Hub as Hub K8s Cluster
+
+    Note over User,Hub: User-created secret (Vault backend)
+    User->>API: POST /secrets {name, data: {key: bytes}}
+    API->>DB: INSERT metadata (id, name, tenant, type, backend)
+    API->>VS: PUT /v1/secret/data/{tenant}/{id} {key: b64}
+    API-->>User: Secret (metadata only)
+
+    User->>API: GET /secrets/{id}?include_data=true
+    API->>DB: SELECT metadata
+    API->>VS: GET /v1/secret/data/{tenant}/{id}
+    API-->>User: Secret (metadata + data map)
+
+    Note over User,Hub: System-created secret (Hub backend)
+    API->>DB: INSERT metadata (coordinates: hub, ns, secret, key)
+    Note over API: ClusterOrder controller triggers creation
+
+    User->>API: GET /secrets/{id}?include_data=true
+    API->>DB: SELECT metadata + coordinates
+    API->>Hub: GET Secret via kubeconfig
+    API-->>User: Secret (metadata + data)
+```
+
+In both paths, the tenant user interacts with the same public API — the
+backend is transparent.
+
+#### Error Handling
+
+Errors are returned as gRPC status codes. See **Failure Handling and
+Recovery** for the state machine and per-operation behavior.
+
+### API Extensions
+
+**New gRPC services:**
+
+| Service | API | Purpose |
+|---------|-----|---------|
+| `osac.private.v1.Secrets` | Private | Full Secret CRUD with backend visibility |
+| `osac.public.v1.Secrets` | Public | Uniform Secret CRUD for tenants |
+
+**Modified resources:**
+
+- `osac.private.v1.Event`: Add `Secret secret` to the payload oneof.
+- `osac.public.v1.Clusters`: `GetKubeconfig` and `GetPassword` RPCs are
+  deprecated then removed.
+
+### Implementation Details/Notes/Constraints
+
+#### Proto Schema: Secret
+
+```proto
+// private/osac/private/v1/secret_type.proto
+
+message Secret {
+  string id = 1;
+  Metadata metadata = 2;
+  SecretSpec spec = 3;
+  SecretStatus status = 4;
+}
+
+message SecretSpec {
+  map<string, bytes> data = 1;
+  SecretBackend backend = 2;
+  SecretType type = 3;
+  HubCoordinates hub_coordinates = 4;
+}
+
+enum SecretBackend {
+  SECRET_BACKEND_UNSPECIFIED = 0;
+  SECRET_BACKEND_VAULT = 1;
+  SECRET_BACKEND_HUB = 2;
+}
+
+enum SecretType {
+  SECRET_TYPE_UNSPECIFIED = 0;
+  SECRET_TYPE_OPAQUE = 1;
+  SECRET_TYPE_PULL_SECRET = 2;
+  SECRET_TYPE_KUBECONFIG = 3;
+}
+
+message HubCoordinates {
+  string hub = 1;
+  string namespace = 2;
+  string secret_name = 3;
+  string key = 4;
+}
+
+message SecretStatus {
+  SecretState state = 1;
+  optional string message = 2;
+}
+
+enum SecretState {
+  SECRET_STATE_UNSPECIFIED = 0;
+  SECRET_STATE_PENDING = 1;
+  SECRET_STATE_READY = 2;
+  SECRET_STATE_ERROR = 3;
+}
+```
+
+The public Secret (`public/osac/public/v1/secret_type.proto`) uses the
+same structure but omits `backend` and `hub_coordinates` from
+`SecretSpec`. The `data` field is a `map<string, bytes>` modeled after
+Kubernetes Secret `Data`. It is write-only by default: provided on
+Create/Update, returned on Get only with `include_data=true`, never
+included in List. The server strips `data` unless explicitly requested.
+
+The `type` field is set at creation and immutable. The server validates
+data keys and value format based on type.
+
+#### Secret Types
+
+| Type | Required Keys | Format Validation | Notes |
+|------|--------------|-------------------|-------|
+| `OPAQUE` (default) | At least one arbitrary key | None | Passwords, tokens, API keys |
+| `PULL_SECRET` | `.dockerconfigjson` | Valid JSON with top-level `auths` object | Key name follows the `kubernetes.io/dockerconfigjson` convention; all major runtimes (podman, CRI-O, containerd) use this format |
+| `KUBECONFIG` | `kubeconfig` | Valid YAML with `apiVersion: v1`, `kind: Config` | Structure validated, not connectivity |
+
+For Hub-backed secrets (system-created), the `data` map is populated on
+demand from the Kubernetes Secret — the key matches the Kubernetes
+Secret's `Data` field key (typically `kubeconfig` or `password`).
+
+These three types cover the credential migration scope. Additional types
+(e.g., TLS, SSH key) can be added when needed.
+
+The `backend` field is set by the server, not the caller:
+- Public API Create: server sets `backend = VAULT` automatically.
+- Private API Create: caller can set `backend = HUB` with
+  `hub_coordinates` for system-created secrets.
+
+#### Proto Schema: Service RPCs
+
+Both public and private Secrets services follow the standard CRUD pattern:
+
+```proto
+service Secrets {
+  rpc List(SecretsListRequest) returns (SecretsListResponse);
+  rpc Get(SecretsGetRequest) returns (SecretsGetResponse);
+  rpc Create(SecretsCreateRequest) returns (SecretsCreateResponse);
+  rpc Update(SecretsUpdateRequest) returns (SecretsUpdateResponse);
+  rpc Delete(SecretsDeleteRequest) returns (SecretsDeleteResponse);
+}
+```
+
+The public `SecretsGetRequest` adds `bool include_data = 2` alongside
+the standard `string id = 1` (see Proto Schema: Secret for semantics).
+
+#### Database Schema
+
+A new migration will create the `secrets` table.
+
+Secrets are tenant- and project-scoped, following the `objects` table
+pattern.
+
+The `data` JSONB column stores the SecretSpec proto JSON (`backend`,
+`type`, `hub_coordinates`) — not secret bytes (see Proposal).
+
+#### Vault Configuration
+
+The Vault-compatible store connection is configured via fulfillment-service
+startup flags, following the existing pattern for infrastructure
+dependencies like the database connection:
+
+```
+--vault-endpoint        Vault-compatible API endpoint URL
+--vault-auth-mount-path Kubernetes auth method mount path (default: auth/kubernetes)
+--vault-kv-mount-path   KV v2 secret engine mount path (default: secret)
+--vault-role            Role for fulfillment-service authentication
+```
+
+When these flags are set, the VaultBackend is constructed at startup and
+injected into the PrivateSecretsServer. When unset, the VaultBackend is
+nil and user-created secret operations return `FAILED_PRECONDITION`.
+
+The secret store must meet these prerequisites:
+
+- **Reachable endpoint** — the store's API must be reachable from the
+  fulfillment-service pods
+- **TLS** — the endpoint must serve TLS; the CA certificate must be
+  trusted by the fulfillment-service
+- **Kubernetes auth method** — enabled and configured to trust the
+  fulfillment-service ServiceAccount for token exchange
+- **KV v2 secret engine** — mounted at the path specified in
+  `--vault-kv-mount-path`
+
+Documentation will cover setup for common implementations.
+
+#### Server Implementation
+
+Private server behavioral specifics:
+
+- **Create:** 
+  - Sets `backend = VAULT` if not specified
+  - Validates data against the secret type (see Secret Types)
+  - Dispatches to vault to store the data
+- **Get:** 
+  - Reads from Postgres, if include_data is true dispatches to backend to fetch data
+- **Update:**
+  - If `spec.data` is non-empty on the update, validate against the secret type and write to backend
+- **Delete:** 
+  - Dispatches to backend to delete stored data.
+  - After data is removed from backend, deletes postgres data.
+  - Note: Hub data is never removed from the backend as part of this action (underlying K8s secret not deleted)
+
+Public server wraps the private server and ensures `backend` and `hub_coordinates` are stripped, and
+`include_data` passed as needed.
+
+For more specific state transitions, see Per-operation behavior section below.
+
+#### CLI Commands
+
+New commands follow existing patterns:
+
+| Command | Description |
+|---------|-------------|
+| `osac create secret <name> --from-file=<key>=<path>` | Create a secret with a key-value pair from a file |
+| `osac create secret <name> --from-file=<path>` | Create with filename as the key |
+| `osac create secret <name> --from-literal=<key>=<value>` | Create a secret from a literal value |
+| `osac create secret <name> --type=pull-secret --from-file=<path>` | Create a typed secret (auto-maps to required key) |
+| `osac get secrets` | List secrets (metadata only) |
+| `osac get secret <name>` | Get secret metadata |
+| `osac get secret <name> --include-data` | Get secret with data (writes key-value pairs to stdout) |
+| `osac describe secret <name>` | Detailed secret metadata view |
+| `osac delete secret <name>` | Delete a secret |
+| `osac edit secret <name>` | Edit secret data/metadata in `$EDITOR` (base64-encoded, per kubectl convention) |
+
+The `--from-file`, `--from-literal`, and `--type` flags are new to the
+OSAC CLI. They follow `kubectl create secret` conventions because secrets
+hold arbitrary key-value data — unlike other OSAC resources which have
+typed fields with dedicated flags (e.g., `--pull-secret-file`). `--type`
+defaults to `opaque`. `--include-data` is a boolean flag that composes
+with the standard `--output`/`-o` format flag.
+
+#### Secret References
+
+Resources that currently embed credentials as inline fields gain a new reference field that holds the name of
+a Secret resource. The existing inline field is deprecated / removed after data migration.
+
+Validation rules:
+- Referenced Secret must exist and match the expected type
+- Referenced secret must be in the same project or an ancestor project
+
+**All credential reference fields:**
+
+| Resource | Inline Field (deprecated) | Reference Field | Secret Type |
+|----------|--------------------------|-----------------|-------------|
+| Cluster | `pull_secret` | `pull_secret_ref` | `PULL_SECRET` |
+| ClusterTemplate | `pull_secret` | `pull_secret_ref` | `PULL_SECRET` |
+| Hub | `kubeconfig` | `kubeconfig_ref` | `KUBECONFIG` |
+| IdentityProvider | `client_secret` | `client_secret_ref` | `OPAQUE` |
+| IdentityProvider | `bind_credential` | `bind_credential_ref` | `OPAQUE` |
+| StorageBackend | `password` | `password_ref` | `OPAQUE` |
+
+
+#### Credential Migration
+
+A Go migration script moves existing inline credentials into the Secrets
+API. The script maps each inline credential to the appropriate key-value
+structure based on the target secret type:
+
+1. Reads all resources with inline credential data from PostgreSQL
+2. For each credential, creates a Secret resource in the same project
+   as the parent resource, with the correct type and data map:
+   - `pull_secret` → type `PULL_SECRET`, data
+     `{".dockerconfigjson": <value>}`
+   - `kubeconfig` → type `KUBECONFIG`, data `{"kubeconfig": <value>}`
+   - `client_secret`, `bind_credential`, `password` → type `OPAQUE`,
+     data `{"value": <value>}`
+3. Writes metadata to PostgreSQL and data to the Vault store
+4. Sets the corresponding `*_ref` field on the resource to the new
+   secret's name
+5. Clears the inline credential field
+
+The script is idempotent — safe to re-run if interrupted. It checks
+whether a secret already exists for each credential before creating a
+duplicate. It runs as a one-time job after the Vault store is configured
+and the fulfillment-service is upgraded with the new schema.
+
+### Security Considerations
+
+**Encryption at rest:** The Vault-compatible secret store provides
+encryption at rest. PostgreSQL stores only metadata (see Proposal).
+
+**Authentication to the secret store:** The fulfillment-service
+authenticates via the Kubernetes auth method [Assumption: Vault-compatible
+stores support K8s auth]. The ServiceAccount token is exchanged for a
+short-lived token scoped to the KV mount. No long-lived tokens are stored.
+
+**Input validation:** Total secret data size is capped at 1 MiB (Vault API default 
+max entry size). For typed secrets, the server validates both the
+required keys and the value format (see Secret Types). Secret names
+follow the existing OSAC naming validation (alphanumeric, hyphens, max
+253 characters).
+
+**Data exposure in transit:** Secret data is transmitted over TLS-encrypted
+gRPC connections. The `include_data=true` parameter is an explicit opt-in.
+
+**No secret data in logs or events:** The RedactFunc strips `spec.data`
+from all event payloads. Server-side logging does not include secret data.
+
+### Failure Handling and Recovery
+
+Secret state reflects the result of the last write operation, not current
+backend reachability. Three states:
+
+- **PENDING** — metadata exists in PostgreSQL, no data in the backend.
+  Creation did not complete. The user can delete the record.
+- **READY** — metadata and backend data are consistent. Normal operating
+  state.
+- **ERROR** — last data write failed. Previous data in the backend is
+  still intact and retrievable. The user can retry or delete.
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING : Create (insert metadata)
+    PENDING --> READY : Vault write succeeds
+    PENDING --> [*] : Vault write fails + rollback succeeds
+    PENDING --> PENDING : Vault write fails + rollback fails (stuck)
+    PENDING --> [*] : User deletes
+    READY --> READY : Update data succeeds
+    READY --> ERROR : Update data fails
+    READY --> [*] : Delete succeeds
+    ERROR --> READY : Retry update succeeds
+    ERROR --> ERROR : Retry update fails
+    ERROR --> [*] : Delete succeeds
+```
+
+PENDING is normally transient. It becomes observable only if both the
+backend write and the rollback delete fail (stuck incomplete creation).
+
+#### Per-operation behavior
+
+| Operation | Steps | On Failure |
+|-----------|-------|------------|
+| **Create (Vault)** | Insert metadata as `PENDING` → write data to store → set `READY` | Attempt rollback (delete metadata). If rollback fails, record stays `PENDING` for manual cleanup. |
+| **Create (Hub)** | Insert metadata with coordinates as `READY` | N/A — no backend write |
+| **Get** (`include_data`) | Read metadata → fetch data from backend | Return `UNAVAILABLE`. State unchanged — reflects last write, not reachability. |
+| **Update (data)** | Write new data to store → set `READY` | Set `ERROR` with message. Previous data in store is intact. |
+| **Update (metadata)** | Update metadata in PostgreSQL only | Standard DB error handling. State unchanged. |
+| **Delete** | Delete data from backend → delete metadata | Return `UNAVAILABLE`, secret remains intact (prevents orphaned store data). Hub delete is a no-op. |
+
+### RBAC / Tenancy
+
+**Tenant isolation metadata:** Secrets include
+`osac.openshift.io/tenant` and `osac.openshift.io/owner-reference`
+annotations, enforced by the existing GenericServer tenancy logic.
+
+**OPA policy additions:**
+
+```rego
+# Public API — tenant users and tenant admins
+has_client_permissions {
+    grpc_method in {
+        "/osac.public.v1.Secrets/List",
+        "/osac.public.v1.Secrets/Get",
+        "/osac.public.v1.Secrets/Create",
+        "/osac.public.v1.Secrets/Update",
+        "/osac.public.v1.Secrets/Delete",
+    }
+}
+```
+
+The private Secrets API is admin-only, handled by the existing `is_admin`
+catch-all for private API methods.
+
+**Visibility:** Tenants see only their own secrets, scoped by project.
+The public Secret API does not expose the `backend` field or Hub
+coordinates.
+
+**Secret store data organization:** Per-tenant KV paths
+(`{kv_mount_path}/data/{tenant_name}/*`) organize secret data by tenant
+within the store. Tenant isolation is enforced at
+the application layer — the fulfillment-service only reads or writes
+paths matching the authenticated tenant.
+
+### Observability and Monitoring
+
+Secrets API requests use the existing fulfillment-service gRPC metrics and structured logging.
+
+### Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Secret store becomes a single point of failure for all secret operations | Secret creation and data retrieval fail when the store is down | Vault-compatible stores support HA deployment. The cloud provider is responsible for HA configuration. Metadata remains accessible when the store is down. |
+| Secret store data loss results in unrecoverable secret loss | Secrets with Vault backend become permanently inaccessible | The cloud provider is responsible for backup and disaster recovery of their secret store deployment. Documentation will cover backup recommendations. |
+
+### Drawbacks
+
+Requiring cloud providers to deploy a Vault-compatible store adds an
+external prerequisite. This is justified because encryption at rest
+cannot be met with PostgreSQL alone — building custom encryption would
+duplicate what Vault-compatible stores already provide.
+
+The two-backend model adds CRUD dispatch and divergent failure handling
+complexity.
+
+## Alternatives (Not Implemented)
+
+### Database Envelope Encryption
+
+Store secret data in PostgreSQL, encrypted using envelope encryption
+(RSA wrapping an AES data key). This avoids the external secret store
+dependency and keeps all data in one store.
+
+**Rejected because:** Key management for envelope encryption is complex —
+the wrapping key must itself be securely stored and rotated. Better to trust
+an industry-standard technology like Vault than build and maintain ourselves.
+
+### Full backwards compatibility with existing data fields
+
+Rather than having an explicit migration step, data can be left in Postgres
+and lazily migrated.  A shim layer is introduced that knows how/where to read
+secret data.  On read if data is in Postgres it will be migrated to Vault.
+
+**Rejected because:** Project maturity level does not necessitate this kind of
+overhead / ongoing maintainance burden.
+
+## Test Plan
+
+**Unit tests (Ginkgo):**
+- Secret proto validation (required fields, name format, data size limits)
+- Backend interface: mock Vault and Hub backends to test Store/Fetch/Delete dispatch
+- Server logic: Create with backend write, Get with/without include_data, Update with data replacement, Delete with backend cleanup
+- Public↔private type mapping: verify `backend` and `hub_coordinates` are stripped in public responses
+- RedactFunc: verify data is stripped from event payloads
+- OPA policy: verify role-based access for Secret methods
+
+**Integration tests (Kind cluster):**
+- Secret CRUD through gRPC with a Vault-compatible store in the Kind cluster
+- Tenant isolation: verify tenant A cannot read tenant B's secrets
+- Hub-backend secrets: create via private API with coordinates, retrieve via public API
+
+**E2E tests (pytest, osac-test-infra):**
+- Automatic secret creation during cluster provisioning
+
+## Graduation Criteria
+
+**Dev Preview (0.2):** Full Secret CRUD, Vault and Hub backends, CLI
+commands.
+
+## Upgrade / Downgrade Strategy
+
+**Upgrade** requires deploying a Vault-compatible secret store, then
+setting the `--vault-*` flags on the fulfillment-service. After the
+service is running with the new schema, the credential migration
+script runs (see Credential Migration) to move inline credentials into the
+Secrets API.
+
+**Downgrade** is not supported once secrets are in Vault.
+
+## Version Skew Strategy
+
+OSAC is pre-GA — all components (fulfillment-service, osac-operator,
+CLI) are expected to be deployed together at matching versions. An
+up-to-date CLI is required for new operations such as creating Secrets
+and attaching them to other resources.
+
+## Support Procedures
+
+**Detecting failures:**
+Fulfillment-service logs at ERROR level for backend operation failures,
+including the backend type, tenant, and error message.
+
+**Disabling the feature:**
+Not supported once secrets are in use. Removing the `--vault-*` flags
+prevents new secret creation but leaves existing secret metadata in
+PostgreSQL and data in the secret store with no way to access it through
+OSAC. There is no graceful disable path.
+
+## Infrastructure Needed
+
+- Vault-compatible secret store instance in the integration test Kind cluster (OpenBao recommended for CI due to its permissive license)

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -354,10 +354,12 @@ Private server behavioral specifics:
   - Reads from Postgres, if include_data is true dispatches to backend to fetch data
 - **Update:**
   - If `spec.data` is non-empty on the update, validate against the secret type and write to backend
+- **Update (Hub-backed):**
+  - Metadata-only updates (labels, annotations) are allowed.
+  - If `spec.data` is non-empty, returns `FAILED_PRECONDITION` — Hub-backed secret data is system-managed.
 - **Delete:**
-  - Dispatches to backend to delete stored data.
-  - After data is removed from backend, deletes postgres data.
-  - Note: Hub data is never removed from the backend as part of this action (underlying K8s secret not deleted)
+  - Vault-backed: dispatches to backend to delete stored data, then deletes PostgreSQL metadata.
+  - Hub-backed: returns `FAILED_PRECONDITION` — Hub-backed secrets are system-managed. They are cleaned up when the parent resource (e.g., HostedCluster) is deleted.
 
 Public server wraps the private server and ensures `backend` and `hub_coordinates` are stripped, and
 `include_data` passed as needed.
@@ -428,10 +430,14 @@ structure based on the target secret type:
    secret's name
 5. Clears the inline credential field
 
-The script is idempotent — safe to re-run if interrupted. It checks
-whether a secret already exists for each credential before creating a
-duplicate. It runs as a one-time job after the Vault store is configured
-and the fulfillment-service is upgraded with the new schema.
+The script is idempotent across all steps — safe to re-run if
+interrupted at any point. For each credential it checks whether the
+Secret already exists (skips creation), whether the `*_ref` field is
+already set (skips the update), and whether the inline field is already
+cleared (skips the clear). This ensures a crash between any two steps
+does not leave partial state on rerun. It runs as a one-time job after
+the Vault store is configured and the fulfillment-service is upgraded
+with the new schema.
 
 ### Security Considerations
 
@@ -484,6 +490,9 @@ stateDiagram-v2
 
 PENDING is normally transient. It becomes observable only if both the
 backend write and the rollback delete fail (stuck incomplete creation).
+Hub-backed secrets skip this state machine entirely — they are created as
+`READY`, their data is immutable, and they cannot be deleted through the
+API (metadata updates like labels are still allowed).
 
 #### Per-operation behavior
 
@@ -492,9 +501,12 @@ backend write and the rollback delete fail (stuck incomplete creation).
 | **Create (Vault)** | Insert metadata as `PENDING` → write data to store → set `READY` | Attempt rollback (delete metadata). If rollback fails, record stays `PENDING` for manual cleanup. |
 | **Create (Hub)** | Insert metadata with coordinates as `READY` | N/A — no backend write |
 | **Get** (`include_data`) | Read metadata → fetch data from backend | Return `UNAVAILABLE`. State unchanged — reflects last write, not reachability. |
-| **Update (data)** | Write new data to store → set `READY` | Set `ERROR` with message. Previous data in store is intact. |
-| **Update (metadata)** | Update metadata in PostgreSQL only | Standard DB error handling. State unchanged. |
-| **Delete** | Delete data from backend → delete metadata | Return `UNAVAILABLE`, secret remains intact (prevents orphaned store data). Hub delete is a no-op. |
+| **Update (Vault data)** | Write new data to store → set `READY` | Set `ERROR` with message. Previous data in store is intact. |
+| **Update (Vault metadata)** | Update metadata in PostgreSQL only | Standard DB error handling. State unchanged. |
+| **Update (Hub metadata)** | Update metadata in PostgreSQL only | Standard DB error handling. State unchanged. |
+| **Update (Hub data)** | N/A — returns `FAILED_PRECONDITION` | Data is system-managed; not modifiable through the API. |
+| **Delete (Vault)** | Delete data from backend → delete metadata | Return `UNAVAILABLE`, secret remains intact (prevents orphaned store data). |
+| **Delete (Hub)** | N/A — returns `FAILED_PRECONDITION` | System-managed; cleaned up with parent resource. |
 
 ### RBAC / Tenancy
 

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -342,8 +342,8 @@ Private server behavioral specifics:
   - Metadata-only updates (e.g. labels) are allowed.
   - If `spec.data` is non-empty, returns `FAILED_PRECONDITION` — Hub-backed secret data is system-managed.
 - **Delete:**
-  - Vault-backed: deletes metadata within the transaction, then deletes
-    data from Vault. If Vault delete fails, the transaction rolls back
+  - Vault-backed: deletes metadata within the transaction, then
+    permanently removes all versions from Vault. If Vault delete fails, the transaction rolls back
     and the secret remains intact.
   - Hub-backed (public API): returns `FAILED_PRECONDITION` — tenants
     cannot delete system-managed secrets.
@@ -425,6 +425,10 @@ does not leave partial state on rerun. It runs as a one-time job after
 the Vault store is configured and the fulfillment-service is upgraded
 with the new schema.
 
+The script can be manually invoked as a one-time step for currently running clusters
+via a subcommand.  A cleanup task will be created to fully remove the script at
+a later release once the Vault secret store is fully established.
+
 ### Security Considerations
 
 **Encryption at rest:** The Vault-compatible secret store provides
@@ -476,7 +480,7 @@ returns an error.
 | **Update (Vault data)** | Vault write (overwrite) → update metadata if needed → commit | Vault failure: return error, existing data intact. |
 | **Update (Hub metadata)** | Update metadata in PostgreSQL only | Standard DB error handling. |
 | **Update (Hub data)** | N/A — returns `FAILED_PRECONDITION` | Data is system-managed. |
-| **Delete (Vault)** | Delete metadata → Vault delete → commit | Vault failure: rollback restores metadata, secret intact. Commit failure: retry (Vault delete idempotent). |
+| **Delete (Vault)** | Delete metadata → Vault metadata delete (permanent, all versions) → commit | Vault failure: rollback restores metadata, secret intact. Commit failure: retry (Vault metadata delete is idempotent on non-existent paths). |
 | **Delete (Hub, public)** | Returns `FAILED_PRECONDITION` | Tenants cannot delete system-managed secrets. |
 | **Delete (Hub, private)** | Delete metadata → commit | Standard DB error handling. |
 

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -74,8 +74,8 @@ Hub coordinates) for admin visibility and system-created secrets.
 
 Secret data bytes never pass through PostgreSQL. On Create, the server
 writes metadata to PostgreSQL and data bytes to the backend. On Get, the
-server fetches data from the backend only when `include_data=true` (see
-Proto Schema). List responses return metadata only.
+server fetches metadata from PostgreSQL and data from the backend. List
+responses return metadata only.
 
 Two secret backends exist for 0.2:
 
@@ -113,9 +113,9 @@ OSAC hub cluster.
    tenant's KV path.
 3. The CLI confirms creation and displays the secret metadata (no data).
 4. To retrieve the data:
-   `osac get secret my-ssh-key --include-data`
-5. The fulfillment-service reads metadata from PostgreSQL, fetches data
-   from the secret store, and writes the key-value pairs to stdout.
+   `osac get secret my-ssh-key -o yaml`
+5. The fulfillment-service reads metadata from PostgreSQL and fetches
+   data from the secret store.
 
 #### Tenant User: Create a Cluster with a Secret Reference
 
@@ -144,7 +144,7 @@ available on the hub.
 3. The secret is associated with the cluster's tenant and annotated with
    the cluster's owner reference.
 4. When a tenant user retrieves the secret
-   (`osac get secret cluster-kubeconfig --include-data`), the
+   (`osac get secret cluster-kubeconfig -o yaml`), the
    fulfillment-service follows the Hub coordinates to retrieve the
    kubeconfig from the hub cluster — the same retrieval path currently
    implemented in `getHostedClusterSecret()` [Codebase: internal/servers/clusters_server.go].
@@ -163,7 +163,7 @@ sequenceDiagram
     API->>VS: PUT /v1/secret/data/{tenant}/{id} {key: b64}
     API-->>User: Secret (metadata only)
 
-    User->>API: GET /secrets/{id}?include_data=true
+    User->>API: GET /secrets/{id}
     API->>DB: SELECT metadata
     API->>VS: GET /v1/secret/data/{tenant}/{id}
     API-->>User: Secret (metadata + data map)
@@ -172,7 +172,7 @@ sequenceDiagram
     API->>DB: INSERT metadata (coordinates: hub, ns, secret, key)
     Note over API: ClusterOrder controller triggers creation
 
-    User->>API: GET /secrets/{id}?include_data=true
+    User->>API: GET /secrets/{id}
     API->>DB: SELECT metadata + coordinates
     API->>Hub: GET Secret via kubeconfig
     API-->>User: Secret (metadata + data)
@@ -258,9 +258,11 @@ enum SecretState {
 The public Secret (`public/osac/public/v1/secret_type.proto`) uses the
 same structure but omits `backend` and `hub_coordinates` from
 `SecretSpec`. The `data` field is a `map<string, bytes>` modeled after
-Kubernetes Secret `Data`. It is write-only by default: provided on
-Create/Update, returned on Get only with `include_data=true`, never
-included in List. The server strips `data` unless explicitly requested.
+Kubernetes Secret `Data`. It is provided on Create/Update, returned on
+Get, and omitted from List. The CLI controls display: the default table
+view shows metadata only, while structured output formats (`-o yaml/json`)
+include base64-encoded data values — following the same convention as
+`kubectl get secret`.
 
 The `type` field is set at creation and immutable. The server validates
 data keys and value format based on type.
@@ -298,9 +300,6 @@ service Secrets {
   rpc Delete(SecretsDeleteRequest) returns (SecretsDeleteResponse);
 }
 ```
-
-The public `SecretsGetRequest` adds `bool include_data = 2` alongside
-the standard `string id = 1` (see Proto Schema: Secret for semantics).
 
 #### Database Schema
 
@@ -351,7 +350,7 @@ Private server behavioral specifics:
   - Validates data against the secret type (see Secret Types)
   - Dispatches to vault to store the data
 - **Get:**
-  - Reads from Postgres, if include_data is true dispatches to backend to fetch data
+  - Reads metadata from Postgres, dispatches to backend to fetch data
 - **Update:**
   - If `spec.data` is non-empty on the update, validate against the secret type and write to backend
 - **Update (Hub-backed):**
@@ -361,8 +360,8 @@ Private server behavioral specifics:
   - Vault-backed: dispatches to backend to delete stored data, then deletes PostgreSQL metadata.
   - Hub-backed: returns `FAILED_PRECONDITION` — Hub-backed secrets are system-managed. They are cleaned up when the parent resource (e.g., HostedCluster) is deleted.
 
-Public server wraps the private server and ensures `backend` and `hub_coordinates` are stripped, and
-`include_data` passed as needed.
+Public server wraps the private server and ensures `backend` and
+`hub_coordinates` are stripped from responses.
 
 For more specific state transitions, see Per-operation behavior section below.
 
@@ -377,8 +376,7 @@ New commands follow existing patterns:
 | `osac create secret <name> --from-literal=<key>=<value>` | Create a secret from a literal value |
 | `osac create secret <name> --type=pull-secret --from-file=<path>` | Create a typed secret (auto-maps to required key) |
 | `osac get secrets` | List secrets (metadata only) |
-| `osac get secret <name>` | Get secret metadata |
-| `osac get secret <name> --include-data` | Get secret with data (writes key-value pairs to stdout) |
+| `osac get secret <name>` | Get secret (table: metadata only; `-o yaml/json`: includes data) |
 | `osac describe secret <name>` | Detailed secret metadata view |
 | `osac delete secret <name>` | Delete a secret |
 | `osac edit secret <name>` | Edit secret data/metadata in `$EDITOR` (base64-encoded, per kubectl convention) |
@@ -387,8 +385,9 @@ The `--from-file`, `--from-literal`, and `--type` flags are new to the
 OSAC CLI. They follow `kubectl create secret` conventions because secrets
 hold arbitrary key-value data — unlike other OSAC resources which have
 typed fields with dedicated flags (e.g., `--pull-secret-file`). `--type`
-defaults to `opaque`. `--include-data` is a boolean flag that composes
-with the standard `--output`/`-o` format flag.
+defaults to `opaque`. Data values are included in structured output
+formats (`-o yaml/json`) as base64-encoded strings, following kubectl
+conventions. The default table view shows metadata only.
 
 #### Secret References
 
@@ -456,7 +455,8 @@ follow the existing OSAC naming validation (alphanumeric, hyphens, max
 253 characters).
 
 **Data exposure in transit:** Secret data is transmitted over TLS-encrypted
-gRPC connections. The `include_data=true` parameter is an explicit opt-in.
+gRPC connections. The CLI displays data only in structured output formats
+(`-o yaml/json`); the default table view shows metadata only.
 
 **No secret data in logs or events:** The RedactFunc strips `spec.data`
 from all event payloads. Server-side logging does not include secret data.
@@ -500,7 +500,7 @@ API (metadata updates like labels are still allowed).
 |-----------|-------|------------|
 | **Create (Vault)** | Insert metadata as `PENDING` → write data to store → set `READY` | Attempt rollback (delete metadata). If rollback fails, record stays `PENDING` for manual cleanup. |
 | **Create (Hub)** | Insert metadata with coordinates as `READY` | N/A — no backend write |
-| **Get** (`include_data`) | Read metadata → fetch data from backend | Return `UNAVAILABLE`. State unchanged — reflects last write, not reachability. |
+| **Get** | Read metadata → fetch data from backend | Return `UNAVAILABLE`. State unchanged — reflects last write, not reachability. |
 | **Update (Vault data)** | Write new data to store → set `READY` | Set `ERROR` with message. Previous data in store is intact. |
 | **Update (Vault metadata)** | Update metadata in PostgreSQL only | Standard DB error handling. State unchanged. |
 | **Update (Hub metadata)** | Update metadata in PostgreSQL only | Standard DB error handling. State unchanged. |
@@ -589,7 +589,7 @@ overhead / ongoing maintainance burden.
 **Unit tests (Ginkgo):**
 - Secret proto validation (required fields, name format, data size limits)
 - Backend interface: mock Vault and Hub backends to test Store/Fetch/Delete dispatch
-- Server logic: Create with backend write, Get with/without include_data, Update with data replacement, Delete with backend cleanup
+- Server logic: Create with backend write, Get with backend data fetch, Update with data replacement, Delete with backend cleanup
 - State transitions: Ensure failure states (e.g. write to backend results in record stuck `PENDING` or update `ERROR`) written
 - Public↔private type mapping: verify `backend` and `hub_coordinates` are stripped in public responses
 - RedactFunc: verify data is stripped from event payloads

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -70,7 +70,7 @@ by the secret's source. Secrets appear in both the public and private APIs.
 The public API provides a uniform CRUD interface — tenants
 interact with secrets without knowing which backend stores them. The
 private API exposes the `backend` field and source-specific fields (e.g.,
-Hub coordinates) for admin visibility and system-created secrets.
+backend coordinates) for admin visibility and system-created secrets.
 
 Secret data bytes never pass through PostgreSQL. On Create, the server
 writes metadata to PostgreSQL and data bytes to the backend. On Get, the
@@ -143,7 +143,7 @@ available on the hub.
    name, key) needed to retrieve the data on demand.
 3. When a tenant user retrieves the secret
    (`osac get secret cluster-kubeconfig -o yaml`), the
-   fulfillment-service follows the Hub coordinates to retrieve the
+   fulfillment-service follows the backend coordinates to retrieve the
    kubeconfig from the hub cluster — the same retrieval path currently
    implemented in `getHostedClusterSecret()` [Codebase: internal/servers/clusters_server.go].
 
@@ -217,7 +217,7 @@ message SecretSpec {
   map<string, bytes> data = 1;
   SecretBackend backend = 2;
   SecretType type = 3;
-  HubCoordinates hub_coordinates = 4;
+  map<string, string> coordinates = 4;
 }
 
 enum SecretBackend {
@@ -231,13 +231,6 @@ enum SecretType {
   SECRET_TYPE_OPAQUE = 1;
   SECRET_TYPE_PULL_SECRET = 2;
   SECRET_TYPE_KUBECONFIG = 3;
-}
-
-message HubCoordinates {
-  string hub = 1;
-  string namespace = 2;
-  string secret_name = 3;
-  string key = 4;
 }
 
 message SecretStatus {
@@ -254,7 +247,7 @@ enum SecretState {
 ```
 
 The public Secret (`public/osac/public/v1/secret_type.proto`) uses the
-same structure but omits `backend` and `hub_coordinates` from
+same structure but omits `backend` and `coordinates` from
 `SecretSpec`. The `data` field is a `map<string, bytes>` modeled after
 Kubernetes Secret `Data`. It is provided on Create/Update, returned on
 Get, and omitted from List. The CLI controls display: the default table
@@ -282,7 +275,7 @@ These three types cover the credential migration scope. Additional types
 The `backend` field is set by the server, not the caller:
 - Public API Create: server sets `backend = VAULT` automatically.
 - Private API Create: caller can set `backend = HUB` with
-  `hub_coordinates` for system-created secrets.
+  `coordinates` for system-created secrets.
 
 #### Proto Schema: Service RPCs
 
@@ -306,7 +299,7 @@ Secrets are tenant- and project-scoped, following the `objects` table
 pattern.
 
 The `data` JSONB column stores the SecretSpec proto JSON (`backend`,
-`type`, `hub_coordinates`) — not secret bytes (see Proposal).
+`type`, `coordinates`) — not secret bytes (see Proposal).
 
 #### Vault Configuration
 
@@ -358,7 +351,7 @@ Private server behavioral specifics:
   - Hub-backed: returns `FAILED_PRECONDITION` — Hub-backed secrets are system-managed. The controller that created them (e.g., ClusterOrder) deletes the metadata when the parent resource is deleted.
 
 Public server wraps the private server and ensures `backend` and
-`hub_coordinates` are stripped from responses.
+`coordinates` are stripped from responses.
 
 For more specific state transitions, see Per-operation behavior section below.
 
@@ -586,7 +579,7 @@ overhead / ongoing maintainance burden.
 - Backend interface: mock Vault and Hub backends to test Store/Fetch/Delete dispatch
 - Server logic: Create with backend write, Get with backend data fetch, Update with data replacement, Delete with backend cleanup
 - State transitions: Ensure failure states (e.g. write to backend results in record stuck `PENDING` or update `ERROR`) written
-- Public↔private type mapping: verify `backend` and `hub_coordinates` are stripped in public responses
+- Public↔private type mapping: verify `backend` and `coordinates` are stripped in public responses
 - RedactFunc: verify data is stripped from event payloads
 - OPA policy: verify role-based access for Secret methods
 - Migration: Test idempotency logic + expected generated payloads

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -157,8 +157,8 @@ sequenceDiagram
 
     Note over User,Hub: User-created secret (Vault backend)
     User->>API: POST /secrets {name, data: {key: bytes}}
-    API->>DB: INSERT metadata (id, name, tenant, type, backend)
-    API->>VS: PUT /v1/secret/data/{tenant}/{id} {key: b64}
+    API->>VS: PUT /v1/secret/data/{tenant}/{id} {data}
+    API->>DB: INSERT metadata (within gRPC transaction)
     API-->>User: Secret (metadata only)
 
     User->>API: GET /secrets/{id}
@@ -182,7 +182,7 @@ backend is transparent.
 #### Error Handling
 
 Errors are returned as gRPC status codes. See **Failure Handling and
-Recovery** for the state machine and per-operation behavior.
+Recovery** for per-operation behavior.
 
 ### API Extensions
 
@@ -210,7 +210,6 @@ message Secret {
   string id = 1;
   Metadata metadata = 2;
   SecretSpec spec = 3;
-  SecretStatus status = 4;
 }
 
 message SecretSpec {
@@ -233,17 +232,6 @@ enum SecretType {
   SECRET_TYPE_KUBECONFIG = 3;
 }
 
-message SecretStatus {
-  SecretState state = 1;
-  optional string message = 2;
-}
-
-enum SecretState {
-  SECRET_STATE_UNSPECIFIED = 0;
-  SECRET_STATE_PENDING = 1;
-  SECRET_STATE_READY = 2;
-  SECRET_STATE_ERROR = 3;
-}
 ```
 
 The public Secret (`public/osac/public/v1/secret_type.proto`) uses the
@@ -343,22 +331,27 @@ Private server behavioral specifics:
 - **Create:**
   - Sets `backend = VAULT` if not specified
   - Validates data against the secret type (see Secret Types)
-  - Dispatches to vault to store the data
+  - Generates the resource ID, writes data to Vault, then inserts
+    metadata into PostgreSQL within the gRPC interceptor transaction
 - **Get:**
-  - Reads metadata from Postgres, dispatches to backend to fetch data
+  - Reads metadata from PostgreSQL, dispatches to backend to fetch data
 - **Update:**
-  - If `spec.data` is non-empty on the update, validate against the secret type and write to backend
+  - If `spec.data` is non-empty, validates against the secret type,
+    writes new data to Vault, then updates metadata if needed
 - **Update (Hub-backed):**
   - Metadata-only updates (e.g. labels) are allowed.
   - If `spec.data` is non-empty, returns `FAILED_PRECONDITION` — Hub-backed secret data is system-managed.
 - **Delete:**
-  - Vault-backed: dispatches to backend to delete stored data, then deletes PostgreSQL metadata.
-  - Hub-backed: returns `FAILED_PRECONDITION` — Hub-backed secrets are system-managed. The controller that created them (e.g., ClusterOrder) deletes the metadata when the parent resource is deleted.
+  - Vault-backed: deletes metadata within the transaction, then deletes
+    data from Vault. If Vault delete fails, the transaction rolls back
+    and the secret remains intact.
+  - Hub-backed (public API): returns `FAILED_PRECONDITION` — tenants
+    cannot delete system-managed secrets.
+  - Hub-backed (private API): deletes the metadata. Used by the
+    controllers to clean up when the parent resource is deleted.
 
 Public server wraps the private server and ensures `backend` and
 `coordinates` are stripped from responses.
-
-For more specific state transitions, see Per-operation behavior section below.
 
 #### CLI Commands
 
@@ -459,50 +452,33 @@ from all event payloads. Server-side logging does not include secret data.
 
 ### Failure Handling and Recovery
 
-Secret state reflects the result of the last write operation, not current
-backend reachability. Three states:
+PostgreSQL and Vault cannot participate in distributed transactions.
+An eventually consistent approach (writing to Vault via an asynchronous
+controller) would require temporarily storing secret data somewhere
+between the user request and the controller write — contradicting the
+goal of keeping secret bytes out of PostgreSQL. Instead, the server
+writes to Vault first, then commits the metadata insert within the
+gRPC interceptor's database transaction
 
-- **PENDING** — metadata exists in PostgreSQL, no data in the backend.
-  Creation did not complete. The user can delete the record.
-- **READY** — metadata and backend data are consistent. Normal operating
-  state.
-- **ERROR** — last data write failed. Previous data in the backend is
-  still intact and retrievable. The user can retry or delete.
-
-```mermaid
-stateDiagram-v2
-    [*] --> PENDING : Create (insert metadata)
-    PENDING --> READY : Vault write succeeds
-    PENDING --> [*] : Vault write fails + rollback succeeds
-    PENDING --> PENDING : Vault write fails + rollback fails (stuck)
-    PENDING --> [*] : User deletes
-    READY --> READY : Update data succeeds
-    READY --> ERROR : Update data fails
-    READY --> [*] : Delete succeeds
-    ERROR --> READY : Retry update succeeds
-    ERROR --> ERROR : Retry update fails
-    ERROR --> [*] : Delete succeeds
-```
-
-PENDING is normally transient. It becomes observable only if both the
-backend write and the rollback delete fail (stuck incomplete creation).
-Hub-backed secrets skip this state machine entirely — they are created as
-`READY`, their data is immutable, and they cannot be deleted through the
-API (metadata updates like labels are still allowed).
+If the Vault write fails, no database record is created — the request
+fails cleanly. If the database commit fails after a successful Vault
+write, an orphaned entry remains in Vault with no metadata pointing to
+it. This does not affect user-visible behavior — the Create simply
+returns an error.
 
 #### Per-operation behavior
 
 | Operation | Steps | On Failure |
 |-----------|-------|------------|
-| **Create (Vault)** | Insert metadata as `PENDING` → write data to store → set `READY` | Attempt rollback (delete metadata). If rollback fails, record stays `PENDING` for manual cleanup. |
-| **Create (Hub)** | Insert metadata with coordinates as `READY` | N/A — no backend write |
-| **Get** | Read metadata → fetch data from backend | Return `UNAVAILABLE`. State unchanged — reflects last write, not reachability. |
-| **Update (Vault data)** | Write new data to store → set `READY` | Set `ERROR` with message. Previous data in store is intact. |
-| **Update (Vault metadata)** | Update metadata in PostgreSQL only | Standard DB error handling. State unchanged. |
-| **Update (Hub metadata)** | Update metadata in PostgreSQL only | Standard DB error handling. State unchanged. |
-| **Update (Hub data)** | N/A — returns `FAILED_PRECONDITION` | Data is system-managed; not modifiable through the API. |
-| **Delete (Vault)** | Delete data from backend → delete metadata | Return `UNAVAILABLE`, secret remains intact (prevents orphaned store data). |
-| **Delete (Hub)** | N/A — returns `FAILED_PRECONDITION` | System-managed; creating controller deletes metadata when parent is removed. |
+| **Create (Vault)** | Vault write → insert metadata → commit | Vault failure: no record created. Commit failure: orphan in Vault (no metadata). |
+| **Create (Hub)** | Insert metadata with coordinates → commit | Standard DB error handling. |
+| **Get** | Read metadata → fetch data from backend | Return `UNAVAILABLE`. |
+| **Update (Vault data)** | Vault write (overwrite) → update metadata if needed → commit | Vault failure: return error, existing data intact. |
+| **Update (Hub metadata)** | Update metadata in PostgreSQL only | Standard DB error handling. |
+| **Update (Hub data)** | N/A — returns `FAILED_PRECONDITION` | Data is system-managed. |
+| **Delete (Vault)** | Delete metadata → Vault delete → commit | Vault failure: rollback restores metadata, secret intact. Commit failure: retry (Vault delete idempotent). |
+| **Delete (Hub, public)** | Returns `FAILED_PRECONDITION` | Tenants cannot delete system-managed secrets. |
+| **Delete (Hub, private)** | Delete metadata → commit | Standard DB error handling. |
 
 ### RBAC / Tenancy
 
@@ -585,7 +561,7 @@ overhead / ongoing maintainance burden.
 - Secret proto validation (required fields, name format, data size limits)
 - Backend interface: mock Vault and Hub backends to test Store/Fetch/Delete dispatch
 - Server logic: Create with backend write, Get with backend data fetch, Update with data replacement, Delete with backend cleanup
-- State transitions: Ensure failure states (e.g. write to backend results in record stuck `PENDING` or update `ERROR`) written
+- Failure handling: Vault write failure returns error with no DB record; Vault delete failure rolls back metadata deletion
 - Public↔private type mapping: verify `backend` and `coordinates` are stripped in public responses
 - RedactFunc: verify data is stripped from event payloads
 - OPA policy: verify role-based access for Secret methods

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -141,9 +141,7 @@ available on the hub.
 2. The fulfillment-service stores the secret metadata in PostgreSQL with
    backend `HUB` and the coordinates (hub ID, namespace, Kubernetes Secret
    name, key) needed to retrieve the data on demand.
-3. The secret is associated with the cluster's tenant and annotated with
-   the cluster's owner reference.
-4. When a tenant user retrieves the secret
+3. When a tenant user retrieves the secret
    (`osac get secret cluster-kubeconfig -o yaml`), the
    fulfillment-service follows the Hub coordinates to retrieve the
    kubeconfig from the hub cluster — the same retrieval path currently
@@ -354,11 +352,11 @@ Private server behavioral specifics:
 - **Update:**
   - If `spec.data` is non-empty on the update, validate against the secret type and write to backend
 - **Update (Hub-backed):**
-  - Metadata-only updates (labels, annotations) are allowed.
+  - Metadata-only updates (e.g. labels) are allowed.
   - If `spec.data` is non-empty, returns `FAILED_PRECONDITION` — Hub-backed secret data is system-managed.
 - **Delete:**
   - Vault-backed: dispatches to backend to delete stored data, then deletes PostgreSQL metadata.
-  - Hub-backed: returns `FAILED_PRECONDITION` — Hub-backed secrets are system-managed. They are cleaned up when the parent resource (e.g., HostedCluster) is deleted.
+  - Hub-backed: returns `FAILED_PRECONDITION` — Hub-backed secrets are system-managed. The controller that created them (e.g., ClusterOrder) deletes the metadata when the parent resource is deleted.
 
 Public server wraps the private server and ensures `backend` and
 `hub_coordinates` are stripped from responses.
@@ -506,13 +504,12 @@ API (metadata updates like labels are still allowed).
 | **Update (Hub metadata)** | Update metadata in PostgreSQL only | Standard DB error handling. State unchanged. |
 | **Update (Hub data)** | N/A — returns `FAILED_PRECONDITION` | Data is system-managed; not modifiable through the API. |
 | **Delete (Vault)** | Delete data from backend → delete metadata | Return `UNAVAILABLE`, secret remains intact (prevents orphaned store data). |
-| **Delete (Hub)** | N/A — returns `FAILED_PRECONDITION` | System-managed; cleaned up with parent resource. |
+| **Delete (Hub)** | N/A — returns `FAILED_PRECONDITION` | System-managed; creating controller deletes metadata when parent is removed. |
 
 ### RBAC / Tenancy
 
-**Tenant isolation metadata:** Secrets include
-`osac.openshift.io/tenant` and `osac.openshift.io/owner-reference`
-annotations, enforced by the existing GenericServer tenancy logic.
+**Tenant isolation metadata:** Secrets carry tenant and project scope in
+standard `Metadata` fields.
 
 **OPA policy additions:**
 

--- a/enhancements/secret-management/design.md
+++ b/enhancements/secret-management/design.md
@@ -40,13 +40,14 @@ inline in their parent resource's spec, redacted on read and stripped on
 update through ad-hoc server-side logic. Each resource type that touches
 credentials implements its own storage, redaction, and retrieval pattern.
 
-This fragmentation creates three problems. First, credential data stored in
-the PostgreSQL `data` JSONB column is not encrypted at rest — anyone with
-database access can read secrets in cleartext. Second, tenants cannot manage
-credentials independently: rotating a pull secret requires updating the
-cluster that uses it, and there is no way to list all credentials a tenant
-owns. Third, each new resource type that needs credentials must reimplement
-redaction and retrieval logic, increasing the surface area for mistakes.
+This fragmentation creates three problems:
+
+1. Credential data stored in the PostgreSQL `data` JSONB column is not encrypted at rest — anyone 
+   with database access can read secrets in cleartext.
+2. Tenants cannot manage credentials independently: rotating a pull secret requires updating the
+   cluster that uses it, and there is no way to list all credentials a tenant owns. 
+3. Third, each new resource type that needs credentials must reimplement redaction and retrieval logic, 
+   increasing the surface area for mistakes.
 
 ### Goals
 
@@ -401,8 +402,8 @@ of upcoming type-safe resource references - https://redhat.atlassian.net/browse/
 
 #### Credential Migration
 
-A Go migration script moves existing inline credentials into the Secrets
-API. The script maps each inline credential to the appropriate key-value
+A Go binary moves existing inline credentials into the Secrets
+API. The binary maps each inline credential to the appropriate key-value
 structure:
 
 1. Reads all resources with inline credential data from PostgreSQL
@@ -419,7 +420,7 @@ structure:
    secret's name
 5. Clears the inline credential field
 
-The script is idempotent across all steps — safe to re-run if
+The binary is idempotent across all steps — safe to re-run if
 interrupted at any point. For each credential it checks whether the
 Secret already exists (skips creation), whether the `*_secret` field is
 already set (skips the update), and whether the inline field is already
@@ -428,8 +429,8 @@ does not leave partial state on rerun. It runs as a one-time job after
 the Vault store is configured and the fulfillment-service is upgraded
 with the new schema.
 
-The script can be manually invoked as a one-time step for currently running clusters
-via a subcommand.  A cleanup task will be created to fully remove the script at
+The binary can be manually invoked as a one-time step for currently running clusters
+via a subcommand.  A cleanup task will be created to fully remove the binary at
 a later release once the Vault secret store is fully established.
 
 ### Security Considerations
@@ -595,7 +596,7 @@ commands.
 **Upgrade** requires deploying a Vault-compatible secret store, then
 setting the `--vault-*` flags on the fulfillment-service. After the
 service is running with the new schema, the credential migration
-script runs (see Credential Migration) to move inline credentials into the
+binary runs (see Credential Migration) to move inline credentials into the
 Secrets API.
 
 **Downgrade** is not supported once secrets are in Vault.


### PR DESCRIPTION
Secret Management Design Proposal

Introduces a `Secret` resource
- `Secret` Metadata stored in Postgres, data bytes in backend (never in Postgres)
- Requires the cloud provider to manage and deploy a vault-compatible store (e.g. Hashicorp Vault, OpenBao) as a new infrastructure prerequisite backend
- Supported by two backends:
  - Vault-compatible store, as mentioned above (used for user created secrets)
  - Hub (system created secrets like cluster kubeconfigs, fetched on demand)
- Existing inline data (e.g. pull_secret) are replaced with references pointing to a specific `Secret`
- Credential Migration performed via a one-time idempotent process to move current inline secret data into the vault-compatible store
- CLI exposes a new `create secret` command with kubectl-like flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an OSAC “Secret Management” design document for tenant-/project-scoped Secret resources with separated secret-byte storage and public metadata visibility.
  * Documented vault-backed secret workflows, secret-reference usage during cluster provisioning, and break-glass behavior.
  * Specified updated Secret CRUD semantics, public vs private Get/List responses, and security/redaction requirements.
* **Documentation**
  * Described CLI and migration guidance to move from inline credentials to `*_ref` secret references, including upgrade/downgrade and version-skew considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->