### PR TITLE
OSAC-1895: Update IdP configuration user story in organizations enhancement

### DIFF
--- a/enhancements/organizations/README.md
+++ b/enhancements/organizations/README.md
@@ -35,8 +35,7 @@ This enhancement is critical for enabling OSAC to provide a true multi-tenant ex
 
 * As a Cloud Provider Admin, I want to create and manage Organizations through OSAC APIs, so that I can provide isolated multi-tenant services to different customers or business units.
 
-* As a Cloud Provider Admin, I want to configure an IdP (LDAP/AD/OIDC/SAML) for the *`System`* Organization, so that Cloud Provider Admin users can authenticate using their existing corporate credentials.
-
+* As a Cloud Infrastructure Admin, I want to configure the Keycloak instance that will act as an IdP broker, and will be used by Cloud Provider Admin users to authenticate.
 
 * As a Cloud Provider Admin, I want OSAC to provide one break-glass account per organization (including `System` organization) with limited privileges to manage IdP configuration and assign roles, so that I can recover from IdP failures or misconfigurations and restore normal authentication, including setting up role mappings for other users.
 


### PR DESCRIPTION
## Summary

- Replace the generic IdP configuration user story (LDAP/AD/OIDC/SAML for the System
  Organization) with a more specific one that refers to configuring a Keycloak instance acting
  as an IdP broker.
- Change the persona from Cloud Provider Admin to Cloud Infrastructure Admin to better reflect
  who is responsible for this infrastructure-level task.

## Test plan

- [ ] Verify the updated user story reads correctly in context.
- [ ] Confirm no other references to the old story need updating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “User Stories” content to replace the Cloud Provider Admin identity provider configuration story.
  * Added a Cloud Infrastructure Admin story focused on configuring the Keycloak instance that serves as the identity provider broker for Cloud Provider Admin authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->