### PR TITLE
OSAC-2132: Fix rubric table Notes column truncated at 200 chars

### DIFF
--- a/.github/scripts/ep_hooks.py
+++ b/.github/scripts/ep_hooks.py
@@ -248,7 +248,7 @@ class EPHooks:
         ]
         for key in scores:
             note = self._sanitize_text(
-                notes.get(key, ""), 200
+                notes.get(key, "")
             ).replace("|", "\\|").replace("\n", " ")
             lines.append(f"| {key.capitalize()} | {scores[key]}/2 | {note} |")
 


### PR DESCRIPTION
## Summary

- Remove the explicit `200` char limit on `_sanitize_text()` in the rubric table Notes column, letting it use the default `500` char limit
- One-line change in `ep_hooks.py` line 251

## Verification

Tested end-to-end on [fork PR #19](https://github.com/ItzikEzra-rh/enhancement-proposals/pull/19) using the same PRD content from EP-70 that originally showed truncation:

| Criterion | Before (200 limit) | After (500 default) |
|-----------|-------------------|-------------------|
| What | 200 chars, cut: `...Services are implied thr` | 312 chars, complete sentence |
| Why | 200 chars, cut: `...placement controls), and` | 307 chars, complete sentence |
| How | 199 chars, cut: `...deployment topology (control plane` | 379 chars, complete sentence |
| Task | 200 chars, cut: `...new API surfaces (AZ entity, A` | 166 chars, complete sentence |
| Size | 200 chars, cut: `...personas and workflows — a tenan` | 250 chars, complete sentence |

Fixes: [OSAC-2131](https://redhat.atlassian.net/browse/OSAC-2131)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated “Notes” text handling in labels and comments to use the standard sanitization limit, ensuring consistent truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->