### PR TITLE
OSAC-2815: Run EP review from osac-workspace context

### DIFF
--- a/.github/scripts/ep_hooks.py
+++ b/.github/scripts/ep_hooks.py
@@ -195,7 +195,7 @@ class EPHooks:
             expected_keys = PRD_KEYS
         else:
             skill = (ticket or {}).get("_skill_name", "")
-            expected_keys = DESIGN_KEYS if skill == "ep-review" else PRD_KEYS
+            expected_keys = DESIGN_KEYS if skill == "design-review" else PRD_KEYS
         unexpected = actual_keys - expected_keys
         missing = expected_keys - actual_keys
         if unexpected:

--- a/.github/scripts/ep_review.py
+++ b/.github/scripts/ep_review.py
@@ -9,6 +9,7 @@ structured review comment on the PR.
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -58,7 +59,7 @@ def detect_skills(files):
     if has_prd:
         skills.append(("prd-review", "skills/prd-review/SKILL.md"))
     if has_design:
-        skills.append(("ep-review", "skills/ep-review/SKILL.md"))
+        skills.append(("design-review", "skills/design-review/SKILL.md"))
     return skills
 
 
@@ -174,7 +175,10 @@ def main():
     for skill_name, skill_path in skills:
         ticket_key = f"EP-{pr_number}"
         work_dir = Path(f"workdir-{skill_name}")
-        work_dir.mkdir(parents=True, exist_ok=True)
+        if work_dir.exists():
+            shutil.rmtree(work_dir)
+        shutil.copytree(SKILLS_PATH, work_dir,
+                        ignore=shutil.ignore_patterns('.git'))
 
         print(f"\nRunning {skill_name}...")
         try:

--- a/.github/workflows/ep-review.yml
+++ b/.github/workflows/ep-review.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r .github/scripts/requirements.txt
 
-      - name: Clone skills repo
+      - name: Clone workspace
         run: git clone --depth 1 https://github.com/osac-project/osac-workspace /opt/skills
 
       - name: Set up GCP credentials


### PR DESCRIPTION
## Summary

- Copy the osac-workspace clone as the workdir base so Claude Code starts its session with full project context (CLAUDE.md, AGENTS.md, `.claude/rules/`, skills/)
- Fix stale `ep-review` -> `design-review` references in `detect_skills()` and `validate_scores()` (closes [OSAC-2814](https://redhat.atlassian.net/browse/OSAC-2814))
- Rename workflow step "Clone skills repo" -> "Clone workspace"

## Problem

The EP review GitHub Action cloned osac-workspace only to grab skill files, but Claude Code ran from a bare `/workspace` with no project context. After the skill rename (ep-review -> design-review in [OSAC-1986](https://redhat.atlassian.net/browse/OSAC-1986)), the skill file copy also broke silently — Claude reviewed without any skill criteria.

OTEL evidence from [run 29440385042](https://github.com/osac-project/enhancement-proposals/actions/runs/29440385042):
- `Read /workspace/.context/skill-prompt.md` -> "File does not exist"
- First LLM call `cache_read=0` (no project context loaded)

## Fix

Instead of `work_dir.mkdir()`, copy the osac-workspace clone as the workdir base via `shutil.copytree`. When agentic-ci mounts it as `/workspace`, Claude Code sees the full workspace natively.

## Verified

Tested on fork PR [ItzikEzra-rh#20](https://github.com/ItzikEzra-rh/enhancement-proposals/pull/20) — OTEL from [run 29493446005](https://github.com/ItzikEzra-rh/enhancement-proposals/actions/runs/29493446005):
- `Read /workspace/.context/skill-prompt.md` -> success (no errors)
- First LLM call `cache_read=28,861` (CLAUDE.md + AGENTS.md + rules loaded)
- Zero tool errors
- `verdict.json` written successfully

Closes: [OSAC-2814](https://redhat.atlassian.net/browse/OSAC-2814)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review handling for design-focused evaluations.
  * Corrected score validation when determining the appropriate review type.
  * Ensured each review runs with a refreshed workspace for more consistent results.

* **Chores**
  * Updated workflow labeling to reflect workspace setup more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->