### PR TITLE
OSAC-1765: publish PRD template and author guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,39 @@ It is unlikely to require an enhancement if it:
 
 If you are not sure if the proposed work requires an enhancement, file an issue and ask!
 
+## How do I create a PRD?
+
+A PRD (Product Requirements Document) defines **what** a feature delivers and
+**why**, from the user's perspective. PRDs are merged before design work begins.
+For detailed guidance on writing PRDs, the PRD vs design EP boundary, personas,
+and good/bad examples, see [guidelines/prd_guide.md](guidelines/prd_guide.md).
+
+The recommended way to create a PRD is using the `/prd` skill in an AI-assisted
+development tool (Claude Code, Cursor, or similar):
+
+1. Run `/prd:ingest` with your Jira ticket to gather requirements.
+2. Run `/prd:clarify` to resolve ambiguities through guided Q&A.
+3. Run `/prd:draft` to generate the PRD from the project template.
+4. Run `/prd:publish` to create a PR on this repository.
+
+The skill produces a PRD that follows [guidelines/prd_template.md](guidelines/prd_template.md),
+addresses OSAC feature dimensions, and can be validated with `/prd-review`
+before submission.
+
+If you prefer to write manually, copy the template and follow the instructions
+inside it:
+
+```sh
+mkdir enhancements/storage-backend-osac-1111
+cp guidelines/prd_template.md enhancements/storage-backend-osac-1111/prd.md
+```
+
+Use the naming convention `<area>-<description>-<ticket-id>`, all lowercase
+with hyphens. Create a pull request against `main` when ready.
+
+After the PRD is merged, create the design EP (`design.md`) in the same
+directory. See "How do I create an enhancement proposal?" below.
+
 ## How do I create an enhancement proposal?
 
 To create an enhancement proposal:
@@ -37,15 +70,15 @@ To create an enhancement proposal:
     mkdir enhancements/my-nifty-feature
     ```
 
-2. Copy `guidelines/enhancement_template.md` to `README.md` in your new directory:
+2. Copy `guidelines/enhancement_template.md` to `design.md` in your new directory:
 
     ```sh
-    cp guidelines/enhancement_template.md enhancements/my-nitfy-feature/README.md
+    cp guidelines/enhancement_template.md enhancements/my-nifty-feature/design.md
     ```
 
-3. Edit `enhancements/my-nitfy-feature/README.md`, following the embedded instructions. If a section does not apply to your proposal, mark it `N/A` rather than removing it.
+3. Edit `enhancements/my-nifty-feature/design.md`, following the embedded instructions. If a section does not apply to your proposal, mark it `N/A` rather than removing it.
 
-4. If your proposal requires additional assets -- images, sample configuration files, etc -- include them in the same directory as the `README.md`.
+4. If your proposal requires additional assets -- images, sample configuration files, etc -- include them in the same directory as the `design.md`.
 
 5. Create a pull request with your changes against the main branch of the [enhancement proposals] repository.
 

--- a/guidelines/enhancement_template.md
+++ b/guidelines/enhancement_template.md
@@ -17,7 +17,7 @@ superseded-by:
 To get started with this template:
 1. **Create a directory.** Create the directory for your enhancement proposal.
 1. **Make a copy of this template.** Copy this template into the directory for
-   the proposal as `README.md`.
+   the proposal as `design.md`.
 1. **Fill out the metadata at the top.** The embedded YAML document is
    checked by the linter.
 1. **Fill out the "overview" sections.** This includes the Summary and

--- a/guidelines/prd_guide.md
+++ b/guidelines/prd_guide.md
@@ -1,0 +1,180 @@
+# PRD Author Guide
+
+This guide explains how to write a Product Requirements Document (PRD) for
+OSAC. It covers what a PRD is, how it differs from a design enhancement
+proposal (EP), the personas to write for, and common mistakes to avoid.
+
+## What is a PRD?
+
+A PRD describes **what** the product must do and **why**, from the user's
+perspective. It defines user-facing capabilities, outcomes, and success
+criteria. It does not describe how the system implements those capabilities.
+
+A PRD answers:
+- Who is affected?
+- What pain exists today?
+- What can users do after this ships?
+- How will we know it works?
+
+## PRD vs Design EP
+
+OSAC uses a two-stage enhancement process. The PRD comes first and defines
+the requirements. The design EP follows and specifies the implementation.
+
+| | **PRD** (`prd.md`) | **Design EP** (`design.md`) |
+|---|---|---|
+| **Audience** | Product managers, reviewers, stakeholders | Engineers, architects |
+| **Focus** | User-facing capabilities and outcomes | Architecture, API fields, reconciliation logic |
+| **Content** | User stories, in/out of scope, success criteria | CRD schemas, controller design, playbook parameters |
+| **Lifecycle** | Merged before design work begins | Merged before implementation begins |
+
+**Litmus test:** Could a product manager verify this by using the product?
+If yes, it belongs in the PRD. If it requires reading source code, it
+belongs in the design EP.
+
+### What belongs where
+
+| PRD (user-observable) | Design EP (implementation) |
+|---|---|
+| "Tenants can create persistent volumes on CaaS clusters" | CRD fields, conditions, finalizers |
+| "Storage readiness is visible on the cluster status" | Controller reconcile logic |
+| "Clusters are reachable without manual networking setup" | Playbook names, API schemas |
+| "Admins can see storage readiness across all tenants" | Helm/installer changes |
+
+### Platform vocabulary is not design leakage
+
+Referencing OSAC platform terms by name is acceptable context in a PRD:
+
+- **Platform:** OpenShift, Kubernetes, Hosted Control Planes
+- **Services:** BMaaS, CaaS, VMaaS, MaaS, Enclave
+- **User-facing resources:** ClusterOrder, ComputeInstance, Tenant,
+  VirtualNetwork, Subnet, SecurityGroup, PublicIPPool, PublicIP,
+  StorageClass
+- **Tools:** kubectl, grpcurl, Helm
+
+Naming these is fine. Mandating which internal component solves a problem
+or describing controller logic is not.
+
+## OSAC Personas
+
+Use these exact names in user stories. Every PRD should identify which
+personas are affected.
+
+| Persona | Role | Examples |
+|---------|------|----------|
+| **Cloud Provider Admin** | Works for the cloud provider. Handles tenant onboarding, sets quotas, manages global catalogs. Super-user who can see all tenants. | Tenant onboarding, quota management, global template catalogs |
+| **Cloud Infrastructure Admin** | Works for the cloud provider. Manages core infrastructure: network, firewall, compute, storage. Integrates control plane with local infrastructure. | Network classes, IP pools, storage tiers, DNS, Netris/VAST/ESI integration |
+| **Tenant Admin** | Works for the tenant organization. Manages their org's config, users, IDP, quotas, and org-specific catalogs. Can only see their own organization. | Create networking objects, manage tenant resources, onboard users |
+| **Tenant User** | Works for the tenant organization. Self-service provisions cloud resources, manages full lifecycle. Prefers click-ops but wants API/CLI for automation. | Order machines/clusters/VMs, manage instance lifecycle, view quota |
+
+## Writing Good User Stories
+
+Use the standard formula:
+
+> As a **{persona}**, I want **{capability}** so that **{outcome}**.
+
+Ground each story in concrete artifacts, workflows, or scenarios. Name the
+specific things users interact with.
+
+### Good examples
+
+- "As a Tenant User, I want to retrieve cluster kubeconfig and admin
+  password via the secrets API, so that I can access my provisioned
+  cluster without asking an administrator."
+- "As a Cloud Infrastructure Admin, I want to configure a storage backend
+  once per deployment, so that tenants get persistent storage on new
+  clusters automatically."
+- "As a Tenant Admin, I want to store OIDC client secrets for IDP
+  integration, so that my team's identity provider credentials are
+  centrally managed."
+
+### Bad examples
+
+- "As a user, I want to create and manage secrets." (Too vague. Which
+  secrets? SSH keypairs? OIDC credentials? Kubeconfigs? "User" is not an
+  OSAC persona.)
+- "As a Tenant User, I want the controller to reconcile storage within
+  30 seconds." (Design leakage. Users do not observe controllers.)
+- "As an admin, I want storage support." (Vague persona, vague
+  capability. Which admin? What does "support" mean?)
+
+### Tips
+
+- One capability per story. If a story has "and", split it.
+- Name the artifacts: "SSH keypairs and OIDC client secrets" not "secrets."
+- State the outcome in terms of what the user can then do, not what the
+  system does internally.
+
+## Common Mistakes
+
+### Design leakage
+
+The most common PRD failure mode. Symptoms:
+
+- Naming controllers, reconcilers, or finalizers
+- Describing playbook parameters or AAP job templates
+- Specifying internal API conditions or environment variables
+- Mandating which component solves the problem
+
+**Fix:** Describe the user-observable outcome. "Storage is automatically
+available on new clusters" instead of "The storage controller invokes
+osac-create-tenant-cluster-storage with provisioning_target=hcp_data_plane."
+
+### Vague requirements
+
+- "Storage should be available" (which clusters? what does "available"
+  mean to the user?)
+- "Networking should work" (which networking objects? for which services?)
+
+**Fix:** Be specific about what users can do and see. "Tenants can create
+persistent volumes using StorageClasses on their CaaS cluster within
+5 minutes of the cluster becoming ready."
+
+### Missing personas
+
+A PRD that names no personas has an unclear audience. Every user story
+must use an OSAC persona name from the table above.
+
+### Bundling unrelated capabilities
+
+A PRD that covers storage provisioning, networking policy enforcement,
+and cluster monitoring is three features, not one. Test independence:
+could each ship on its own and provide value? If yes, split them.
+
+## Workflow
+
+### Using the `/prd` skill (recommended)
+
+If you are using an AI-assisted development tool (Claude Code, Cursor, or
+similar), the `/prd` workflow automates PRD creation:
+
+1. **`/prd:ingest`** with your Jira ticket to gather requirements
+2. **`/prd:clarify`** to resolve ambiguities through Q&A
+3. **`/prd:draft`** to generate the PRD from the template
+4. **`/prd:publish`** to create a PR on enhancement-proposals
+
+The skill produces a PRD that follows the
+[prd_template.md](prd_template.md) and can be reviewed with `/prd-review`.
+
+### Manual workflow
+
+1. Create a directory: `mkdir enhancements/<area>-<description>/`
+2. Copy the template: `cp guidelines/prd_template.md enhancements/<area>-<description>/prd.md`
+3. Fill out all sections
+4. Self-review using `/prd-review` if available, or check against the
+   common mistakes above
+5. Create a pull request against `main`
+6. After the PRD is merged, create the design EP (`design.md`) in the
+   same directory using `guidelines/enhancement_template.md`
+
+## Review
+
+PRDs are reviewed against five criteria: clear user-facing need, business
+justification, freedom from design leakage, focused scope, and testable
+requirements. Use `/prd-review` for a detailed automated assessment before
+submitting your PR.
+
+## External References
+
+- [Perforce: How to Write a PRD](https://www.perforce.com/blog/alm/how-write-product-requirements-document-prd)
+- [Atlassian: Agile Product Requirements](https://www.atlassian.com/agile/product-management/requirements)

--- a/guidelines/prd_template.md
+++ b/guidelines/prd_template.md
@@ -1,0 +1,105 @@
+---
+title: feature-name
+authors:
+  - TBD
+creation-date: yyyy-mm-dd
+last-updated: yyyy-mm-dd
+tracking-link:
+  - TBD
+---
+
+To get started with this template:
+1. **Create a directory.** Create a directory inside `enhancements/` using
+   the naming convention `<area>-<description>-<ticket-id>`, all lowercase
+   with hyphens (e.g., `enhancements/storage-backend-osac-1111/`). The
+   ticket ID suffix is optional but recommended when a tracking issue exists.
+
+   Common area prefixes:
+
+   | Area | Scope |
+   |------|-------|
+   | `bmaas` | Bare metal provisioning and lifecycle |
+   | `caas` | Kubernetes cluster provisioning (Hosted Control Planes) |
+   | `vmaas` | KubeVirt-based virtual machine instances |
+   | `networking` | VirtualNetwork, Subnet, SecurityGroup, DNS, PublicIP |
+   | `storage` | StorageTier, StorageBackend, CSI, persistent volumes |
+   | `compute` | ComputeInstance fields, instance types, snapshots |
+   | `metering` | Usage tracking, billing, quota |
+   | `infra` | Installation, Helm charts, platform prerequisites |
+   | `core` | Tenant, secrets, RBAC, catalog, cross-cutting platform |
+   | `ui` | Console features, wizards, dashboards |
+2. **Make a copy of this template.** Copy this file into your directory
+   as `prd.md`.
+3. **Fill out the metadata** at the top (YAML front matter and the table
+   below).
+4. **Fill out each section.** If a section does not apply, mark it `N/A`
+   rather than removing it.
+5. **Create a pull request** against the main branch of this repository.
+6. After the PRD is merged, create the design EP (`design.md`) in the
+   same directory.
+
+**Using the `/prd` skill (recommended):** If you are using an AI-assisted
+development tool (Claude Code, Cursor, or similar), use the `/prd` workflow
+instead of copying this template manually. Run `/prd:ingest` with your Jira
+ticket to start the guided flow: ingest, clarify, draft, publish. The skill
+produces a PRD that follows this template and publishes it as a PR.
+
+For detailed authoring guidance, PRD vs design EP boundaries, personas,
+and good/bad examples, see [prd_guide.md](prd_guide.md).
+
+# {Title}
+
+| Field       | Value   |
+|-------------|---------|
+| Author(s)   |         |
+| Jira        |         |
+| Date        |         |
+
+## Problem Statement
+
+Who is affected, what pain exists today, and what happens if this is not
+addressed? Write from the user's perspective, not the system's.
+
+## In Scope
+
+What this PRD delivers. List user-facing capabilities and outcomes.
+
+- {capability or outcome}
+
+## Out of Scope
+
+What is explicitly excluded to prevent scope creep. Include items that
+readers might reasonably expect but are deferred or intentionally omitted.
+
+- {excluded item and brief reason}
+
+## User Stories
+
+Group stories by persona. Use the standard formula:
+"As a {persona}, I want {capability} so that {outcome}."
+
+Ground each story in concrete artifacts, workflows, or scenarios. Name
+the specific things users interact with. See [prd_guide.md](prd_guide.md)
+for OSAC personas and good/bad examples.
+
+### {Persona name}
+
+- As a {persona}, I want {capability} so that {outcome}.
+
+## Assumptions
+
+<!-- Optional: omit this section if no unverified assumptions underpin
+the requirements. -->
+
+Statements believed to be true but not yet verified. If an assumption
+turns out to be wrong, it may change the scope or approach.
+
+- {assumption}
+
+## Dependencies
+
+<!-- Optional: omit if no external dependencies exist. -->
+
+External teams, services, or milestones that this work depends on.
+
+- **{Dependency name}:** {What it provides and any ordering constraints}


### PR DESCRIPTION
## Summary

[OSAC-1765](https://redhat.atlassian.net/browse/OSAC-1765): Publishes PRD template, author guide, and README section in the
enhancement-proposals repo, closing the discoverability gap for PRD authors.

## Why

The enhancement-proposals repo documented only the design EP path. PRDs had
no published template, author guide, or README section. Authors had to read
osac-workspace internals to learn how to write a PRD. This is the second half
of [OSAC-1763](https://redhat.atlassian.net/browse/OSAC-1763) (after [OSAC-1764](https://redhat.atlassian.net/browse/OSAC-1764) landed the workspace-side changes in PR #75).

## What changed

- `guidelines/prd_template.md`: PRD template synced from the workspace, with
  inline instructions, directory naming convention with area prefixes, and
  `/prd` skill callout
- `guidelines/prd_guide.md`: Author guide covering PRD vs design EP boundaries,
  OSAC personas, good/bad user story examples, common mistakes, and workflow
- `README.md`: New "How do I create a PRD?" section promoting the `/prd` skill
  as the primary workflow
- `guidelines/enhancement_template.md` and `README.md`: Updated EP references
  from `README.md` to `design.md` to match the convention used by newer
  enhancements

## Testing

Visual review of all four files for consistency, correct cross-references,
and alignment with the workspace PRD template and `/prd-review` rubric.

## Ticket

[OSAC-1765](https://redhat.atlassian.net/browse/OSAC-1765)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded PRD guidance with clearer scope definitions, user-story standards, common pitfalls, review criteria, and AI-assisted and manual authoring workflows.
  - Added a structured PRD template covering metadata, problem statements, scope, personas, user stories, assumptions, and dependencies.
  - Corrected enhancement proposal instructions to use `design.md`, including guidance for templates, content, and supporting assets.
  - Updated the enhancement template to reflect the corrected file-naming guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->