### PR TITLE
OSAC-2946: align CI review pipeline and docs with two-document flow

### DIFF
--- a/.github/scripts/ep_hooks.py
+++ b/.github/scripts/ep_hooks.py
@@ -89,10 +89,6 @@ class EPHooks:
         diff = self._gh(["pr", "diff", pr_number, "--repo", self.repo])
         (context_dir / "pr-diff.txt").write_text(diff)
 
-        template_file = Path("guidelines/enhancement_template.md")
-        if template_file.exists():
-            (context_dir / "template.md").write_text(template_file.read_text())
-
         skill_path = ticket.get("_skill_path", "")
         skill_file = Path(self.skills_path) / skill_path
         if skill_file.exists():
@@ -113,8 +109,7 @@ class EPHooks:
         return (
             PROMPT_INJECTION_BOUNDARY +
             "Review the document in .context/pr-diff.txt using the review criteria "
-            "in .context/skill-prompt.md. Use .context/template.md as the template reference "
-            "if available.\n\n"
+            "in .context/skill-prompt.md.\n\n"
             "Apply the review dimensions from skill-prompt.md, then map your assessment "
             "to these 5 standard scoring criteria:\n\n"
             "- what (0-2): Does the document clearly describe the desired outcome?\n"
@@ -142,8 +137,7 @@ class EPHooks:
         return (
             PROMPT_INJECTION_BOUNDARY +
             "Review the design document in .context/pr-diff.txt using the review criteria "
-            "in .context/skill-prompt.md. Use .context/template.md as the template reference "
-            "if available.\n\n"
+            "in .context/skill-prompt.md.\n\n"
             "Apply the review dimensions from skill-prompt.md, then map your assessment "
             "to these 4 scoring criteria:\n\n"
             "- feasibility (0-2): Is the design technically feasible and implementable?\n"

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ OSAC uses a two-document flow: a **PRD** (Product Requirements Document) describ
 
 The [osac-workspace](https://github.com/osac-project/osac-workspace) provides AI-assisted workflows that guide you through the process:
 
-1. **PRD**: Run `/prd:ingest` to start a PRD, then `/prd:draft` and `/prd:publish` to create it in this repo as `enhancements/<feature-slug>/prd.md`.
-2. **Design**: Run `/design:ingest` to start the design, then `/design:draft` and `/design:publish` to create it as `enhancements/<feature-slug>/design.md`.
+1. **PRD**: Run `/prd:ingest` to start a PRD, then `/prd:draft` and `/prd:publish` to create it in this repo as `enhancements/OSAC-NNNN-feature-slug/prd.md`.
+2. **Design**: Run `/design:ingest` to start the design, then `/design:draft` and `/design:publish` to create it as `enhancements/OSAC-NNNN-feature-slug/design.md`.
 
 See the osac-workspace [AGENTS.md](https://github.com/osac-project/osac-workspace/blob/main/AGENTS.md) for full workflow details.
 
@@ -45,7 +45,7 @@ See the osac-workspace [AGENTS.md](https://github.com/osac-project/osac-workspac
 1. Create a new directory inside the `enhancements` directory:
 
     ```sh
-    mkdir enhancements/my-nifty-feature
+    mkdir enhancements/OSAC-1234-my-nifty-feature
     ```
 
 2. Create your PRD (`prd.md`) and design document (`design.md`) in that directory. Use `guidelines/enhancement_template.md` as a starting point for the design if needed (note: this template predates the two-document split and includes sections like User Stories that now belong in the PRD).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,18 @@ If you are not sure if the proposed work requires an enhancement, file an issue 
 
 ## How do I create an enhancement proposal?
 
-To create an enhancement proposal:
+OSAC uses a two-document flow: a **PRD** (Product Requirements Document) describes WHAT and WHY, and a **design document** describes HOW.
+
+### Recommended: AI-assisted workflow (osac-workspace)
+
+The [osac-workspace](https://github.com/osac-project/osac-workspace) provides AI-assisted workflows that guide you through the process:
+
+1. **PRD**: Run `/prd:ingest` to start a PRD, then `/prd:draft` and `/prd:publish` to create it in this repo as `enhancements/<feature-slug>/prd.md`.
+2. **Design**: Run `/design:ingest` to start the design, then `/design:draft` and `/design:publish` to create it as `enhancements/<feature-slug>/design.md`.
+
+See the osac-workspace [AGENTS.md](https://github.com/osac-project/osac-workspace/blob/main/AGENTS.md) for full workflow details.
+
+### Manual workflow
 
 1. Create a new directory inside the `enhancements` directory:
 
@@ -37,19 +48,13 @@ To create an enhancement proposal:
     mkdir enhancements/my-nifty-feature
     ```
 
-2. Copy `guidelines/enhancement_template.md` to `README.md` in your new directory:
+2. Create your PRD (`prd.md`) and design document (`design.md`) in that directory. Use `guidelines/enhancement_template.md` as a starting point for the design if needed (note: this template predates the two-document split and includes sections like User Stories that now belong in the PRD).
 
-    ```sh
-    cp guidelines/enhancement_template.md enhancements/my-nitfy-feature/README.md
-    ```
+3. If your proposal requires additional assets -- images, sample configuration files, etc -- include them in the same directory.
 
-3. Edit `enhancements/my-nitfy-feature/README.md`, following the embedded instructions. If a section does not apply to your proposal, mark it `N/A` rather than removing it.
+4. Create a pull request with your changes against the main branch of the [enhancement proposals] repository.
 
-4. If your proposal requires additional assets -- images, sample configuration files, etc -- include them in the same directory as the `README.md`.
-
-5. Create a pull request with your changes against the main branch of the [enhancement proposals] repository.
-
-6. Select at least three reviewers for your pull request.
+5. Select at least three reviewers for your pull request.
 
 ## How are enhancement proposals reviewed and approved?
 

--- a/guidelines/enhancement_template.md
+++ b/guidelines/enhancement_template.md
@@ -14,6 +14,12 @@ superseded-by:
   - "/enhancements/our-past-effort"
 ---
 
+> **Note:** OSAC now uses a two-document flow: a PRD (`prd.md`) for WHAT/WHY and
+> a design document (`design.md`) for HOW. New enhancements should use the
+> AI-assisted workflows in [osac-workspace](https://github.com/osac-project/osac-workspace)
+> (`/prd:ingest` → `/design:ingest`). This template is retained for reference by
+> older enhancements. See the [README](../README.md) for details.
+
 To get started with this template:
 1. **Create a directory.** Create the directory for your enhancement proposal.
 1. **Make a copy of this template.** Copy this template into the directory for


### PR DESCRIPTION
## Summary
- Remove legacy `enhancement_template.md` from CI review context — its User Stories section confused the LLM into penalizing designs for missing user stories
- Clean up prompt text that referenced the now-removed template file
- Update README to describe the PRD + design two-document flow as the primary path
- Add deprecation note to legacy `enhancement_template.md`

## Context
The `write_pr_context` method in `ep_hooks.py` unconditionally loaded `guidelines/enhancement_template.md` as `.context/template.md` for both PRD and design reviews. For design reviews, this template's User Stories section caused the bot to penalize designs for not including user stories — which belong in the PRD, not the design.

The skill prompt (`.context/skill-prompt.md`) already contains the complete review rubric, so the template was redundant supplementary context — and in the design-review case, actively harmful.

**Companion PR:** osac-project/osac-workspace#142 (design-review skill update)

## Test plan
- [ ] Verify EP review bot still runs on new PRs (skill prompt is sufficient context)
- [ ] Verify design reviews no longer reference `.context/template.md`
- [ ] Check README renders correctly with new two-document flow section

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated enhancement proposal guidance to use separate PRD and design documents covering the “what/why” and “how.”
  - Added recommended AI-assisted and manual workflows for creating and publishing enhancements.
  - Clarified directory structure, review expectations, and pull request steps.
  - Noted that the existing enhancement template remains available as a reference for older proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->