### PR TITLE
NO-ISSUE: update catalog items PRD to reflect team decisions

### DIFF
--- a/enhancements/catalog-items/README.md
+++ b/enhancements/catalog-items/README.md
@@ -150,7 +150,7 @@ created. Both will have similar properties, so we'll use Cluster as an example:
 
 ClusterCatalogItem
 * references an existing ClusterTemplate by ID
-* includes a list of field definitions covering all fields from the resource spec (e.g., ClusterSpec or ComputeInstanceSpec). Each field definition specifies a field by dot-notation path, whether it is editable by the user, an optional default value, and an optional JSON Schema validation rule. The field set is fixed per resource type — it does not vary by template.
+* includes a list of field definitions, each of which specifies a field by dot-notation path, whether it is editable by the user, an optional default value, and an optional JSON Schema validation rule. The UI always includes all fields from the resource spec, but the API accepts partial field lists (e.g., CLI-created items may include only a subset).
 * includes a new selector field `published` that takes values TRUE and FALSE
 * includes a tenant identifier that defines which tenant this CatalogItem is visible to. Defaults to all tenants if not set.
 
@@ -222,9 +222,10 @@ Two new message types will be added to the proto definitions in
 - `title` (string) - human-friendly short name for display in UIs and CLIs
 - `description` (string) - markdown-formatted long description
 - `template` (string) - references a `ClusterTemplate` by ID
-- `fields` (repeated FieldDefinition) - ordered list of field definitions
-  covering all fields from the resource spec, each configured as pre-defined
-  by the admin or editable by the user
+- `fields` (repeated FieldDefinition) - ordered list of field definitions that
+  specify which resource spec fields are pre-defined by the admin and which are
+  editable by the user. The UI includes all resource spec fields; the API
+  accepts partial lists for CLI and programmatic use
 - `published` (bool) - when false (the default), the item is hidden from Tenant
   Users; Cloud Provider Admins and Tenant Admins can see unpublished items
 - `tenant` (string) - internal field, not exposed through the public API. Scopes
@@ -260,12 +261,11 @@ Both types will have corresponding `ClusterCatalogItemsService` and
 #### API Behavior
 
 The `fields` list defines the contract between the admin and the user for a
-given catalog item. The field set is fixed per resource type — it covers
-all fields from the resource spec (e.g., all fields in `ComputeInstanceSpec`
-for a `ComputeInstanceCatalogItem`). The admin configures each field (editable
-toggle, default value, validation constraints) but does not add or remove
-fields. The server rejects catalog items that reference fields not defined in
-the resource spec.
+given catalog item. The UI includes all fields from the resource spec (e.g.,
+all fields in `ComputeInstanceSpec` for a `ComputeInstanceCatalogItem`), but
+the API accepts partial field lists — not all fields need to be included.
+Fields not listed in `fields` are not managed by the catalog item. The server
+rejects catalog items that reference fields not defined in the resource spec.
 
 The dot-notation `path` references fields within the resource spec. Nested
 fields and map entries are supported. For example:

--- a/enhancements/catalog-items/README.md
+++ b/enhancements/catalog-items/README.md
@@ -3,7 +3,7 @@ title: catalog-items
 authors:
   - mhrivnak
 creation-date: 2026-01-12
-last-updated: 2026-07-16
+last-updated: 2026-07-22
 tracking-link: # link to the tracking ticket (for example: Github issue) that corresponds to this enhancement
 see-also:
 replaces:
@@ -43,7 +43,7 @@ don't have the ability to add or modify ansible roles.
 
 * As a Cloud Provider Admin, I need to create a catalog item by selecting a resource type and choosing an existing template for that type, so the catalog item is backed by a known, working template.
 
-* As a Cloud Provider Admin, I need to configure which resource fields are pre-set vs. editable when creating a catalog item. I select which fields from the resource spec to include in the catalog item and configure each one. Fields not included in the field definitions are not exposed to the user and are not constrained by the catalog item.
+* As a Cloud Provider Admin, I need to configure which resource fields are pre-set vs. editable when creating a catalog item. The system presents all fields from the resource spec (e.g., ComputeInstanceSpec or ClusterSpec), and I configure each one — I do not need to manually specify field paths. By default, fields are non-editable except for `ssh_public_key` and `pull_secret`, which default to editable. Default values are pre-populated from the selected template when they exist.
 
 * As a Cloud Provider Admin, for each editable field I need to optionally provide a default value and define validation constraints, so I can guide tenant input while enforcing guardrails. Validation constraints are specified as a JSON Schema (draft 2020-12) object stored in the field definition's `validation_schema` field. Constraint types and examples:
 
@@ -59,10 +59,10 @@ don't have the ability to add or modify ansible roles.
   - **Combinations**: multiple constraints can be combined in a single schema.
     Example: `boot_disk.size_gib` with `{"minimum": 50, "maximum": 500}` combined with a default of 100.
 
-  **Resource reference constraints:**
-  - Fields that reference backend resources (such as `instance_type` referencing an InstanceType, or `image_type` referencing an ImageType) use `enum` constraints. The UI fetches available resources from the corresponding API endpoint and presents them as a selectable list. The admin can restrict the set to a subset of available resources by specifying an `enum` with only the allowed values.
-    Example: `instance_type` with `{"enum": ["cx3.xlarge", "cx3.2xlarge", "cx3.4xlarge"]}` — the UI fetches available InstanceType resources and presents the allowed subset as a dropdown.
-    Example: `image_type` with `{"enum": ["rhel-10", "rhel-9"]}` — limits image selection to the specified types.
+  **Resource reference fields:**
+  - Fields that reference backend resources (such as `instance_type` referencing an InstanceType, or `image_type` referencing an ImageType) do not have validation constraints in the catalog item creation UI. Instead, the admin selects a default value from a dropdown of existing resources fetched from the corresponding API endpoint. The backend validates that the selected value is a valid, existing resource at provisioning time.
+    Example: `instance_type` — the UI fetches available InstanceType resources and presents them as a dropdown for the admin to select a default value.
+    Example: `image_type` — the UI fetches available ImageType resources for default value selection.
 
   **List and map constraints:**
   - **Item count** (`minItems`, `maxItems`): control whether users can add or remove entries in repeated fields. Setting `minItems` and `maxItems` to the same value locks the list length, preventing users from adding or removing items while still allowing edits to each item's fields.
@@ -72,22 +72,13 @@ don't have the ability to add or modify ansible roles.
   - **Map entry count** (`minProperties`, `maxProperties`): same pattern for map fields.
     Example: `node_sets` with `{"minProperties": 2, "maxProperties": 2}` locks a cluster to exactly two node sets (e.g., control-plane + workers) — the user can edit each node set's `size` but cannot add or remove node sets.
 
-  **Complex object constraints:**
-  - **Nested properties** (`properties`, `required`): validate sub-fields within complex objects. When a field definition targets a complex field like `network_attachments[*]`, the validation schema can constrain its sub-fields individually.
-    Example: each `network_attachments` item with `{"properties": {"security_groups": {"minItems": 1}}, "required": ["subnet"]}` requires a subnet and at least one security group per attachment.
-  - **Item schema** (`items`): apply a schema to every element of a repeated field.
-    Example: `additional_disks` with `{"items": {"properties": {"size_gib": {"minimum": 10, "maximum": 1000}}}}` constrains every additional disk's size.
-
-  The UI presents these constraint types through two editing modes:
-  - **Basic mode** (default): structured form controls for each supported constraint type (numeric bounds, enum, string length, pattern, item count, nested properties, item schemas) so admins can configure validation without writing JSON by hand.
-  - **Advanced mode**: a raw JSON Schema textarea for schemas that use keywords beyond the Basic editor's supported set (e.g., `if/then/else`, `oneOf`, `$ref`), or for admins who prefer to write JSON Schema directly.
-  The editor auto-detects which mode to open: schemas using only Basic-supported keywords open in Basic mode; schemas with other keywords open in Advanced mode. Admins can switch between modes — switching from Advanced to Basic warns that unsupported keywords will be stripped.
+  The UI provides structured form controls for supported simple constraint types (numeric bounds, allowed values, string length, pattern, item count). If a field has an existing validation schema that uses keywords beyond what the UI supports (e.g., `if/then/else`, `oneOf`, nested properties, item schemas), the UI displays a read-only message indicating that this validation cannot be edited through the UI and must be managed via the OSAC CLI. Admins who need full JSON Schema expressiveness use the CLI directly.
 
 * As a Cloud Provider Admin, I need the system to provide sensible default validation schemas for common field types when I create a catalog item, so I can configure validation quickly without manually constructing JSON Schema for every field. For example:
   - `ssh_public_key` and `pull_secret` should have default pattern-based validation (the admin can accept the default or customize it)
   - `user_data` should have a default maximum length constraint
   - `node_sets.<name>.size` should default to a minimum/maximum integer constraint
-  - Fields referencing backend resources (`instance_type`, `image_type`) should automatically populate `enum` with available resources as selectable options
+  - Fields referencing backend resources (`instance_type`, `image_type`) should present available resources as a selectable dropdown for default value selection
   The backend is responsible for providing these defaults based on the field type; the admin can override or tighten them.
 
 * As a Cloud Provider Admin, I need to provide identifying information for the catalog item, so tenants can understand what the offering provides when browsing the catalog.
@@ -159,7 +150,7 @@ created. Both will have similar properties, so we'll use Cluster as an example:
 
 ClusterCatalogItem
 * references an existing ClusterTemplate by ID
-* includes a list of field definitions for the resource spec fields the admin wants to expose or constrain. Each field definition specifies a field by dot-notation path, whether it is editable by the user, an optional default value, and an optional JSON Schema validation rule. Not all fields need to be included — only those the admin wants to configure.
+* includes a list of field definitions covering all fields from the resource spec (e.g., ClusterSpec or ComputeInstanceSpec). Each field definition specifies a field by dot-notation path, whether it is editable by the user, an optional default value, and an optional JSON Schema validation rule. The field set is fixed per resource type — it does not vary by template.
 * includes a new selector field `published` that takes values TRUE and FALSE
 * includes a tenant identifier that defines which tenant this CatalogItem is visible to. Defaults to all tenants if not set.
 
@@ -231,9 +222,9 @@ Two new message types will be added to the proto definitions in
 - `title` (string) - human-friendly short name for display in UIs and CLIs
 - `description` (string) - markdown-formatted long description
 - `template` (string) - references a `ClusterTemplate` by ID
-- `fields` (repeated FieldDefinition) - ordered list of field definitions that
-  specify which resource spec fields are pre-defined by the admin and which are
-  editable by the user
+- `fields` (repeated FieldDefinition) - ordered list of field definitions
+  covering all fields from the resource spec, each configured as pre-defined
+  by the admin or editable by the user
 - `published` (bool) - when false (the default), the item is hidden from Tenant
   Users; Cloud Provider Admins and Tenant Admins can see unpublished items
 - `tenant` (string) - internal field, not exposed through the public API. Scopes
@@ -269,12 +260,12 @@ Both types will have corresponding `ClusterCatalogItemsService` and
 #### API Behavior
 
 The `fields` list defines the contract between the admin and the user for a
-given catalog item. The admin chooses which resource spec fields to include
-and configures each one (editable toggle, default value, validation
-constraints). Not all fields from the resource spec need to be included —
-only those the admin wants to expose or constrain. Fields not listed in
-`fields` are not managed by the catalog item. The server rejects catalog
-items that reference fields not defined in the resource spec.
+given catalog item. The field set is fixed per resource type — it covers
+all fields from the resource spec (e.g., all fields in `ComputeInstanceSpec`
+for a `ComputeInstanceCatalogItem`). The admin configures each field (editable
+toggle, default value, validation constraints) but does not add or remove
+fields. The server rejects catalog items that reference fields not defined in
+the resource spec.
 
 The dot-notation `path` references fields within the resource spec. Nested
 fields and map entries are supported. For example:
@@ -292,9 +283,10 @@ The `validation_schema` field accepts any valid
 [JSON Schema (draft 2020-12)](https://json-schema.org/draft/2020-12/json-schema-validation)
 object. The server validates user-provided field values against the full schema
 at provisioning time using a standard JSON Schema validator — no keywords are
-restricted. The UI provides structured form controls (Basic mode) for common
-constraint types and a raw JSON Schema textarea (Advanced mode) for schemas that
-use the full JSON Schema vocabulary.
+restricted. The UI provides structured form controls for simple constraint
+types (numeric bounds, enum, string length, pattern, item count). For schemas
+that use keywords beyond the UI's supported set, the UI displays a read-only
+message directing the admin to use the OSAC CLI.
 
 #### Public vs. Private API Split
 

--- a/enhancements/catalog-items/README.md
+++ b/enhancements/catalog-items/README.md
@@ -99,11 +99,9 @@ don't have the ability to add or modify ansible roles.
 
 #### Tenant Admin — Catalog Item Creation
 
-* As a Tenant Admin, I need to create organization-specific catalog items by selecting from existing published global catalog items — not from templates. I am not aware of templates; I only see catalog items that the Cloud Provider Admin has already published.
+* As a Tenant Admin, I need to create organization-specific catalog items by selecting a resource type and choosing an existing template, using the same creation flow as a Cloud Provider Admin.
 
-* As a Tenant Admin, I need to configure which fields are pre-set vs. editable, starting from the base global catalog item's configuration. I can further restrict fields for my organization but cannot make a non-editable field editable — I can only be equal or more restrictive than the base.
-
-* As a Tenant Admin, for each field I keep editable, I need to optionally change the default value or tighten validation constraints, so I can tailor the offering to my organization's standards.
+* As a Tenant Admin, I need to configure which resource fields are pre-set vs. editable when creating a catalog item, using the same field definitions editor as a Cloud Provider Admin.
 
 * As a Tenant Admin, I need to provide identifying information for the catalog item, so my organization's users can distinguish it from other offerings in the catalog.
 
@@ -113,7 +111,7 @@ don't have the ability to add or modify ansible roles.
 
 * As a Tenant Admin, I need to publish or unpublish catalog items scoped to my organization to control whether my users can see and provision from them.
 
-* As a Tenant Admin, I need to edit organization-scoped catalog items to update their title, description, publication status, and field definition defaults or validation constraints (tightening only). I cannot add or remove field definitions, loosen constraints beyond the base item's settings, or modify global catalog items created by Cloud Provider Admins.
+* As a Tenant Admin, I need to edit organization-scoped catalog items to update their name, description, publication status, and field definitions. I cannot modify global catalog items created by Cloud Provider Admins.
 
 * As a Tenant Admin, I need to view a catalog item's full configuration and see which resources in my organization have been provisioned from it.
 
@@ -266,6 +264,12 @@ all fields in `ComputeInstanceSpec` for a `ComputeInstanceCatalogItem`), but
 the API accepts partial field lists — not all fields need to be included.
 Fields not listed in `fields` are not managed by the catalog item. The server
 rejects catalog items that reference fields not defined in the resource spec.
+
+Networking fields (`network_attachments`) are not shown in the catalog item
+creation wizard. Instead, the UI automatically includes `network_attachments`
+in the API payload as an editable field with no default value and no validation
+schema. This allows the tenant user to configure network attachments during
+provisioning without requiring the admin to explicitly manage them.
 
 The dot-notation `path` references fields within the resource spec. Nested
 fields and map entries are supported. For example:

--- a/enhancements/catalog-items/README.md
+++ b/enhancements/catalog-items/README.md
@@ -83,7 +83,7 @@ don't have the ability to add or modify ansible roles.
 
 * As a Cloud Provider Admin, I need to provide identifying information for the catalog item, so tenants can understand what the offering provides when browsing the catalog.
 
-* As a Cloud Provider Admin, I need to choose whether the catalog item is global (visible to all tenants) or scoped to a specific tenant, so I can create targeted offerings for specific organizations.
+* As a Cloud Provider Admin, I need to choose the scope of the catalog item — either General (visible to all tenants) or Organization (scoped to a specific tenant) — so I can create targeted offerings for specific organizations. When publishing or unpublishing, the action applies only within the selected scope.
 
 #### Cloud Provider Admin — Catalog Item Lifecycle
 
@@ -99,25 +99,25 @@ don't have the ability to add or modify ansible roles.
 
 #### Tenant Admin — Catalog Item Creation
 
-* As a Tenant Admin, I need to create organization-specific catalog items by selecting a resource type and choosing an existing template, using the same creation flow as a Cloud Provider Admin.
+* As a Tenant Admin, I need to create organization-scoped or project-scoped catalog items by selecting a resource type and choosing an existing template, using the same creation flow as a Cloud Provider Admin.
 
 * As a Tenant Admin, I need to configure which resource fields are pre-set vs. editable when creating a catalog item, using the same field definitions editor as a Cloud Provider Admin.
 
 * As a Tenant Admin, I need to provide identifying information for the catalog item, so my organization's users can distinguish it from other offerings in the catalog.
 
-* As a Tenant Admin, the catalog item I create is automatically scoped to my organization — I do not control the tenant assignment.
+* As a Tenant Admin, I need to choose the scope of the catalog item — either Organization (visible to all projects within my tenant) or Project (scoped to a specific project) — so I can create targeted offerings at the right level. The tenant assignment is automatic; I control whether the item is organization-wide or project-specific.
 
 #### Tenant Admin — Catalog Item Lifecycle
 
-* As a Tenant Admin, I need to publish or unpublish catalog items scoped to my organization to control whether my users can see and provision from them.
+* As a Tenant Admin, I need to publish or unpublish catalog items scoped to my organization or project to control whether my users can see and provision from them. Publication applies only within the configured scope.
 
-* As a Tenant Admin, I need to edit organization-scoped catalog items to update their name, description, publication status, and field definitions. I cannot modify global catalog items created by Cloud Provider Admins.
+* As a Tenant Admin, I need to edit organization-scoped and project-scoped catalog items to update their name, description, publication status, and field definitions. I cannot modify general (global) catalog items created by Cloud Provider Admins.
 
 * As a Tenant Admin, I need to view a catalog item's full configuration and see which resources in my organization have been provisioned from it.
 
-* As a Tenant Admin, I need to delete an organization-scoped catalog item that is no longer needed, subject to the same provisioned-resource blocking as global items.
+* As a Tenant Admin, I need to delete an organization-scoped or project-scoped catalog item that is no longer needed, subject to the same provisioned-resource blocking as general items.
 
-* As a Tenant Admin, I need to see my organization's catalog items alongside global items, with a clear distinction between global (read-only) and organization-scoped (manageable) items.
+* As a Tenant Admin, I need to see my organization's catalog items alongside general (global) items, with a clear distinction between general (read-only), organization-scoped (manageable), and project-scoped (manageable) items.
 
 #### Tenant User — Catalog Browsing and Provisioning
 
@@ -151,6 +151,7 @@ ClusterCatalogItem
 * includes a list of field definitions, each of which specifies a field by dot-notation path, whether it is editable by the user, an optional default value, and an optional JSON Schema validation rule. The UI always includes all fields from the resource spec, but the API accepts partial field lists (e.g., CLI-created items may include only a subset).
 * includes a new selector field `published` that takes values TRUE and FALSE
 * includes a tenant identifier that defines which tenant this CatalogItem is visible to. Defaults to all tenants if not set.
+* includes an optional project identifier that further scopes visibility to a specific project within the tenant. When empty, the item is visible to all projects within the tenant.
 
 The field definitions use dot-notation paths to reference fields in the
 underlying resource spec.
@@ -229,6 +230,11 @@ Two new message types will be added to the proto definitions in
 - `tenant` (string) - internal field, not exposed through the public API. Scopes
   visibility to a single tenant organization; when empty the item is visible to
   all tenants. Set automatically by the server for Tenant Admin creates.
+- `project` (string) - optional field for project-level scoping. When set
+  alongside `tenant`, the item is visible only within that project. When empty
+  (with `tenant` set), the item is visible to all projects within the tenant.
+  Set by the Tenant Admin during creation; CSP Admins do not create
+  project-scoped items.
 
 `ComputeInstanceCatalogItem`:
 - Same top-level structure as `ClusterCatalogItem` but references a
@@ -334,10 +340,10 @@ additional steps before writing the object:
 
 #### Tenancy and Authorization
 
-The `tenant` field on `CatalogItem` is enforced at two layers:
+The `tenant` and `project` fields on `CatalogItem` are enforced at two layers:
 
-1. **Read**: The public `CatalogItems_List` and `CatalogItems_Get` operations always filter by `tenant = "" OR tenant = <caller_tenant>`. When the caller is a Tenant User, the public server additionally injects `published = true`, with one exception: a Tenant User may `Get` a catalog item referenced by one of their existing CNAs even if that item is unpublished. Tenant Admins see all items in their tenant regardless of publication status. This is implemented in the public server before delegating to the private server, using the same filter-injection mechanism the other public servers use for tenancy.
-2. **Write**: Cloud Provider Admins set `tenant` explicitly; `tenant = ""` creates a global item. For Tenant Admins, the public server injects `tenant` from the caller's identity — the field is not accepted from the caller. Tenant Admins can only Update or Delete catalog items scoped to their own tenant (i.e., where `tenant` equals the caller's tenant); they cannot modify global items (`tenant = ""`) or items belonging to another tenant.
+1. **Read**: The public `CatalogItems_List` and `CatalogItems_Get` operations always filter by `tenant = "" OR tenant = <caller_tenant>`. When `project` is set on a catalog item, visibility is further restricted to users within that project. When the caller is a Tenant User, the public server additionally injects `published = true`, with one exception: a Tenant User may `Get` a catalog item referenced by one of their existing CNAs even if that item is unpublished. Tenant Admins see all items in their tenant regardless of publication status. This is implemented in the public server before delegating to the private server, using the same filter-injection mechanism the other public servers use for tenancy.
+2. **Write**: Cloud Provider Admins set `tenant` explicitly; `tenant = ""` creates a general (global) item. CSP Admins choose between General (global) or Organization (tenant-scoped). For Tenant Admins, the public server injects `tenant` from the caller's identity — the field is not accepted from the caller. Tenant Admins set `project` explicitly to create project-scoped items, or leave it empty for organization-scoped items. Tenant Admins can only Update or Delete catalog items scoped to their own tenant; they cannot modify general items (`tenant = ""`) or items belonging to another tenant. The server validates that a specified `project` belongs to the caller's tenant.
 
 A tenant with a CNA that was published from a Catalog Item that has since been
 unpublished should still be able to read that Catalog Item through a direct GET

--- a/enhancements/catalog-items/README.md
+++ b/enhancements/catalog-items/README.md
@@ -151,7 +151,7 @@ ClusterCatalogItem
 * includes a list of field definitions, each of which specifies a field by dot-notation path, whether it is editable by the user, an optional default value, and an optional JSON Schema validation rule. The UI always includes all fields from the resource spec, but the API accepts partial field lists (e.g., CLI-created items may include only a subset).
 * includes a new selector field `published` that takes values TRUE and FALSE
 * includes a tenant identifier that defines which tenant this CatalogItem is visible to. Defaults to all tenants if not set.
-* includes an optional project identifier that further scopes visibility to a specific project within the tenant. When empty, the item is visible to all projects within the tenant.
+* uses the existing `metadata.project` field (available on all OSAC resources) to optionally scope visibility to a specific project within the tenant. When `metadata.project` is empty, the item is visible to all projects within the tenant.
 
 The field definitions use dot-notation paths to reference fields in the
 underlying resource spec.
@@ -230,7 +230,8 @@ Two new message types will be added to the proto definitions in
 - `tenant` (string) - internal field, not exposed through the public API. Scopes
   visibility to a single tenant organization; when empty the item is visible to
   all tenants. Set automatically by the server for Tenant Admin creates.
-- `project` (string) - optional field for project-level scoping. When set
+Note: Project-level scoping uses the existing `metadata.project` field (field 10
+  on `Metadata`, available on all OSAC resources). When `metadata.project` is set
   alongside `tenant`, the item is visible only within that project. When empty
   (with `tenant` set), the item is visible to all projects within the tenant.
   Set by the Tenant Admin during creation; CSP Admins do not create
@@ -340,10 +341,10 @@ additional steps before writing the object:
 
 #### Tenancy and Authorization
 
-The `tenant` and `project` fields on `CatalogItem` are enforced at two layers:
+The `tenant` field and `metadata.project` on `CatalogItem` are enforced at two layers:
 
-1. **Read**: The public `CatalogItems_List` and `CatalogItems_Get` operations always filter by `tenant = "" OR tenant = <caller_tenant>`. When `project` is set on a catalog item, visibility is further restricted to users within that project. When the caller is a Tenant User, the public server additionally injects `published = true`, with one exception: a Tenant User may `Get` a catalog item referenced by one of their existing CNAs even if that item is unpublished. Tenant Admins see all items in their tenant regardless of publication status. This is implemented in the public server before delegating to the private server, using the same filter-injection mechanism the other public servers use for tenancy.
-2. **Write**: Cloud Provider Admins set `tenant` explicitly; `tenant = ""` creates a general (global) item. CSP Admins choose between General (global) or Organization (tenant-scoped). For Tenant Admins, the public server injects `tenant` from the caller's identity — the field is not accepted from the caller. Tenant Admins set `project` explicitly to create project-scoped items, or leave it empty for organization-scoped items. Tenant Admins can only Update or Delete catalog items scoped to their own tenant; they cannot modify general items (`tenant = ""`) or items belonging to another tenant. The server validates that a specified `project` belongs to the caller's tenant.
+1. **Read**: The public `CatalogItems_List` and `CatalogItems_Get` operations always filter by `tenant = "" OR tenant = <caller_tenant>`. When `metadata.project` is set on a catalog item, visibility is further restricted to users within that project. When the caller is a Tenant User, the public server additionally injects `published = true`, with one exception: a Tenant User may `Get` a catalog item referenced by one of their existing CNAs even if that item is unpublished. Tenant Admins see all items in their tenant regardless of publication status. This is implemented in the public server before delegating to the private server, using the same filter-injection mechanism the other public servers use for tenancy.
+2. **Write**: Cloud Provider Admins set `tenant` explicitly; `tenant = ""` creates a general (global) item. CSP Admins choose between General (global) or Organization (tenant-scoped). For Tenant Admins, the public server injects `tenant` from the caller's identity — the field is not accepted from the caller. Tenant Admins set `metadata.project` explicitly to create project-scoped items, or leave it empty for organization-scoped items. Tenant Admins can only Update or Delete catalog items scoped to their own tenant; they cannot modify general items (`tenant = ""`) or items belonging to another tenant. The server validates that a specified `project` belongs to the caller's tenant.
 
 A tenant with a CNA that was published from a Catalog Item that has since been
 unpublished should still be able to read that Catalog Item through a direct GET


### PR DESCRIPTION
## Summary

Updates the catalog items PRD (`enhancements/catalog-items/README.md`) to reflect team decisions from the catalog items design call:

- **All fields shown**: Field definitions now cover all fields from the resource spec (fixed per resource type). Admins configure each field but do not add or remove fields.
- **Default non-editable**: Fields default to non-editable except `ssh_public_key` and `pull_secret`. Default values are pre-populated from the selected template.
- **Simplified validation**: The UI provides structured controls for simple constraint types (numeric bounds, enum, string length, pattern, item count). Complex validation schemas display a read-only message directing admins to use the OSAC CLI. Removes Basic/Advanced mode editor concept.
- **Resource reference fields**: No validation constraints in the UI. Admins select default values from a dropdown of existing resources.
- **Removed complex object constraints**: Nested properties, item schemas, and recursive constraint editing removed from UI scope.

## Test plan

- [ ] Review that PRD changes are consistent with the team decisions
- [ ] Verify no unrelated sections were modified


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated catalog item creation guidance to reflect a fixed resource-spec field set in the UI, partial field lists in the API, and rejection of fields not present at provisioning.
  * Clarified default preset/editable behavior, including template-derived exceptions for `ssh_public_key` and `pull_secret`.
  * Documented resource-reference fields (`instance_type`, `image_type`) using dropdown defaults, with validation deferred to provisioning.
  * Reworked validation schema editor instructions to focus on supported constraint types; unsupported JSON Schema changes now require the OSAC CLI.
  * Clarified tenant workflows and networking field behavior (`network_attachments` omitted from the wizard, auto-included for provisioning).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->