### PR TITLE
OSAC-2921: PRD — Add standardized display_name and description fields to resource Metadata

### DIFF
--- a/enhancements/OSAC-2921-metadata-display-name/prd.md
+++ b/enhancements/OSAC-2921-metadata-display-name/prd.md
@@ -1,0 +1,59 @@
+# Add Standardized display_name and description Fields to Resource Metadata
+
+| Field       | Value   |
+|-------------|---------|
+| Author(s)   | Udi Shkalim |
+| Jira        | https://redhat.atlassian.net/browse/OSAC-2921 |
+| Date        | 2026-07-21 |
+
+## Problem Statement
+
+OSAC resources use `metadata.name` as the primary human-visible identifier, but this field is constrained to DNS-label format (lowercase alphanumeric and hyphens, max 63 characters), making it unsuitable as a user-friendly label. Some resource types (Project, Role, NetworkClass, catalog items, templates) work around this with per-resource `title` and `description` fields, while most resources (ComputeInstance, VirtualNetwork, Subnet, PublicIP, BlockVolume) have no friendly name at all. This inconsistency forces repeated per-resource-type discussions about whether to add display fields and produces an uneven user experience across VMs, virtual networks, public IPs, and other resources.
+
+## In Scope
+
+- `display_name` (optional string, max 63 characters) and `description` (optional string, max 256 characters) added to the shared Metadata, automatically inherited by every resource type `[Clarify: R2.Q1, R4.Q4]`
+- Removal of existing `title` and `description` fields from the spec of spec-based resources: Project, Role, IdentityProvider, and InstanceType (description only) `[Clarify: R1.Q1, R4.Q2, R5.Q2]`
+- Both fields are optional, mutable after creation, and clearable `[Clarify: R3.Q1]`
+- Users can filter and sort resource lists by `display_name` across UI, CLI, and API `[Clarify: R2.Q2]`
+- UI displays `display_name` in place of `metadata.name` when set; falls back to `metadata.name` when `display_name` is not set — this applies uniformly across list views, detail pages, breadcrumbs, and search results `[Clarify: R4.Q1, R5.Q1]`
+- E2E test coverage for create, update, and clear of `display_name` and `description` across representative resource types
+- Documentation updated to describe the new fields and fallback behavior
+
+## Out of Scope
+
+- Making `display_name` or `description` required for any resource type
+- Renaming or removing existing `metadata.name` semantics
+- Enforcing uniqueness constraints on `display_name`
+- Template parameter `title`/`description` fields within ComputeInstanceTemplate, BaremetalInstanceTemplate, and ClusterTemplate — only resource-level fields are affected `[Clarify: R1.Q3]`
+- Flat-shape, platform-defined resources that already have top-level `title`/`description` fields: ClusterTemplate, ComputeInstanceTemplate, BareMetalInstanceTemplate, NetworkClass, HostType, ComputeInstanceCatalogItem, BareMetalInstanceCatalogItem, and ClusterCatalogItem — these keep their existing fields unchanged `[Clarify: R4.Q2, R5.Q2]`
+
+## User Stories
+
+### Cloud Provider Admin
+
+- As a Cloud Provider Admin, I want resources across all tenant organizations to show a consistent, human-readable `display_name` and `description` so that I can quickly identify and audit resources when reviewing or supporting tenants, regardless of resource type.
+- As a Cloud Provider Admin, I want to filter and sort resource lists by `display_name` so that I can locate specific resources across tenants without memorizing DNS-label names. `[Clarify: R2.Q2]`
+
+### Tenant Admin
+
+- As a Tenant Admin, I want all resource types I manage (VMs, virtual networks, public IPs, security groups, etc.) to support a friendly `display_name` and `description` so that I can label and document resources meaningfully instead of being limited by `metadata.name` restrictions.
+- As a Tenant Admin, I want to update or clear `display_name` and `description` on existing resources so that I can correct labels or remove outdated descriptions as resources evolve. `[Clarify: R3.Q1]`
+
+### Tenant User
+
+- As a Tenant User, I want to give my resources a friendly `display_name` (up to 63 characters) and `description` when creating them so that I can identify and organize them more easily than relying on the constrained `metadata.name` field. `[Clarify: R2.Q1]`
+- As a Tenant User, I want list views to show `display_name` when set and fall back to `metadata.name` when it is not, so that I always see the most useful identifier regardless of whether a display name was provided.
+
+## Dependencies
+
+- **fulfillment-service proto and server changes:** Must land before UI and E2E test changes, since both depend on the updated Metadata definition and API behavior.
+
+---
+
+## Provenance
+
+Authored: revise @ prd 0.5.0 - 92734a2, workspace main @ aac0f8e
+Phases: draft, revise
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.5.0","ai_workflows":"92734a2","source_repo":"aac0f8e","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise"],"authoring_modes":["skill"],"context_changed":false} -->

--- a/enhancements/OSAC-2921-metadata-display-name/prd.md
+++ b/enhancements/OSAC-2921-metadata-display-name/prd.md
@@ -13,8 +13,9 @@ OSAC resources use `metadata.name` as the primary human-visible identifier, but 
 ## In Scope
 
 - `display_name` (optional string, max 63 characters) and `description` (optional string, max 256 characters) added to the shared Metadata, automatically inherited by every resource type `[Clarify: R2.Q1, R4.Q4]`
-- Removal of existing `title` and `description` fields from the spec of spec-based resources: Project, Role, IdentityProvider, and InstanceType (description only) `[Clarify: R1.Q1, R4.Q2, R5.Q2]`
+- Removal of existing per-resource `title` and `description` fields from all resource types that currently have them: Project, Role, IdentityProvider, InstanceType (description only), ClusterTemplate, ComputeInstanceTemplate, BareMetalInstanceTemplate, NetworkClass, HostType, ComputeInstanceCatalogItem, BareMetalInstanceCatalogItem, and ClusterCatalogItem `[Clarify: R1.Q1, PR review: sk-ilya, ygalblum]`
 - Both fields are optional, mutable after creation, and clearable `[Clarify: R3.Q1]`
+- `display_name` does not have to be unique across resources `[Clarify: R2.Q2, PR review: sk-ilya]`
 - Users can filter and sort resource lists by `display_name` across UI, CLI, and API `[Clarify: R2.Q2]`
 - UI displays `display_name` in place of `metadata.name` when set; falls back to `metadata.name` when `display_name` is not set — this applies uniformly across list views, detail pages, breadcrumbs, and search results `[Clarify: R4.Q1, R5.Q1]`
 - E2E test coverage for create, update, and clear of `display_name` and `description` across representative resource types
@@ -22,11 +23,8 @@ OSAC resources use `metadata.name` as the primary human-visible identifier, but 
 
 ## Out of Scope
 
-- Making `display_name` or `description` required for any resource type
 - Renaming or removing existing `metadata.name` semantics
-- Enforcing uniqueness constraints on `display_name`
-- Template parameter `title`/`description` fields within ComputeInstanceTemplate, BaremetalInstanceTemplate, and ClusterTemplate — only resource-level fields are affected `[Clarify: R1.Q3]`
-- Flat-shape, platform-defined resources that already have top-level `title`/`description` fields: ClusterTemplate, ComputeInstanceTemplate, BareMetalInstanceTemplate, NetworkClass, HostType, ComputeInstanceCatalogItem, BareMetalInstanceCatalogItem, and ClusterCatalogItem — these keep their existing fields unchanged `[Clarify: R4.Q2, R5.Q2]`
+- Template parameter `title`/`description` fields within ComputeInstanceTemplate, BareMetalInstanceTemplate, and ClusterTemplate — only resource-level fields are affected `[Clarify: R1.Q3]`
 
 ## User Stories
 
@@ -34,6 +32,10 @@ OSAC resources use `metadata.name` as the primary human-visible identifier, but 
 
 - As a Cloud Provider Admin, I want resources across all tenant organizations to show a consistent, human-readable `display_name` and `description` so that I can quickly identify and audit resources when reviewing or supporting tenants, regardless of resource type.
 - As a Cloud Provider Admin, I want to filter and sort resource lists by `display_name` so that I can locate specific resources across tenants without memorizing DNS-label names. `[Clarify: R2.Q2]`
+
+### Cloud Infrastructure Admin
+
+- As a Cloud Infrastructure Admin, I want platform-defined resources I manage (NetworkClass, HostType, catalog items, templates) to use the same `metadata.display_name` and `metadata.description` fields as all other resources, so that naming conventions are consistent across platform and tenant resources. `[PR review: sk-ilya, ygalblum]`
 
 ### Tenant Admin
 
@@ -53,7 +55,7 @@ OSAC resources use `metadata.name` as the primary human-visible identifier, but 
 
 ## Provenance
 
-Authored: revise @ prd 0.5.0 - 92734a2, workspace main @ aac0f8e
-Phases: draft, revise
+Authored: respond @ prd 0.5.0 - 7b6dfe0, workspace main @ 280ee0f
+Phases: draft, revise, respond
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.5.0","ai_workflows":"92734a2","source_repo":"aac0f8e","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise"],"authoring_modes":["skill"],"context_changed":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.5.0","ai_workflows":"7b6dfe0","source_repo":"280ee0f","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise","respond"],"authoring_modes":["skill"],"context_changed":false} -->

--- a/enhancements/OSAC-2921-metadata-display-name/prd.md
+++ b/enhancements/OSAC-2921-metadata-display-name/prd.md
@@ -29,7 +29,7 @@ OSAC resources use `metadata.name` as the primary human-visible identifier, but 
 ### Cloud Provider Admin
 
 - As a Cloud Provider Admin, I want resources across all tenant organizations to show a consistent, human-readable `display_name` and `description` so that I can quickly identify and audit resources when reviewing or supporting tenants, regardless of resource type.
-- As a Cloud Provider Admin, I want to filter and sort resource lists by `display_name` so that I can locate specific resources across tenants without memorizing DNS-label names. `[Clarify: R2.Q2]`
+- As a Cloud Provider Admin, I want to filter and sort resource lists by `display_name` so that I can find resources across tenants using natural-language terms. `[Clarify: R2.Q2, PR review: mhrivnak]`
 
 ### Cloud Infrastructure Admin
 
@@ -37,7 +37,7 @@ OSAC resources use `metadata.name` as the primary human-visible identifier, but 
 
 ### Tenant Admin
 
-- As a Tenant Admin, I want all resource types I manage (VMs, virtual networks, public IPs, security groups, etc.) to support a friendly `display_name` and `description` so that I can label and document resources meaningfully instead of being limited by `metadata.name` restrictions.
+- As a Tenant Admin, I want all resource types I manage (VMs, virtual networks, public IPs, security groups, etc.) to support a friendly `display_name` and `description` so that I can give resources a natural-language name and description that are not constrained to DNS-label format. `[PR review: mhrivnak]`
 - As a Tenant Admin, I want to update or clear `display_name` and `description` on existing resources so that I can correct labels or remove outdated descriptions as resources evolve. `[Clarify: R3.Q1]`
 
 ### Tenant User
@@ -57,4 +57,4 @@ Final: respond @ prd 0.6.0 - 7b6dfe0, workspace main @ 280ee0f
 
 > Context changed between draft and respond.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.0","ai_workflows":"7b6dfe0","source_repo":"280ee0f","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise","respond"],"authoring_modes":["skill"],"context_changed":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.0","ai_workflows":"7b6dfe0","source_repo":"280ee0f","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise","respond","respond"],"authoring_modes":["skill"],"context_changed":true} -->

--- a/enhancements/OSAC-2921-metadata-display-name/prd.md
+++ b/enhancements/OSAC-2921-metadata-display-name/prd.md
@@ -16,7 +16,6 @@ OSAC resources use `metadata.name` as the primary human-visible identifier, but 
 - Two new shared Metadata fields: `display_name` (optional, max 63 characters) and `description` (optional, max 256 characters) — both mutable, clearable, and not required to be unique `[Clarify: R2.Q1, R3.Q1, R4.Q4, PR review: sk-ilya]`
 - Reconciliation of existing per-resource `title`/`description` fields — removed from all 12 resource types that currently have them: Project, Role, IdentityProvider, InstanceType (description only), ClusterTemplate, ComputeInstanceTemplate, BareMetalInstanceTemplate, NetworkClass, HostType, ComputeInstanceCatalogItem, BareMetalInstanceCatalogItem, ClusterCatalogItem `[Clarify: R1.Q1, PR review: sk-ilya, ygalblum]`
 - Filtering and sorting by `display_name` `[Clarify: R2.Q2]`
-- E2E test coverage and documentation
 
 ## Out of Scope
 
@@ -53,8 +52,8 @@ OSAC resources use `metadata.name` as the primary human-visible identifier, but 
 ## Provenance
 
 Authored: draft @ prd 0.5.0 - 92734a2, workspace main @ aac0f8e
-Final: respond @ prd 0.6.0 - 7b6dfe0, workspace main @ 280ee0f
+Final: respond @ prd 0.6.1 - 96de078, workspace main @ 7b4fff2
 
 > Context changed between draft and respond.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.0","ai_workflows":"7b6dfe0","source_repo":"280ee0f","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise","respond","respond"],"authoring_modes":["skill"],"context_changed":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.1","ai_workflows":"96de078","source_repo":"7b4fff2","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise","respond","respond","respond"],"authoring_modes":["skill"],"context_changed":true} -->

--- a/enhancements/OSAC-2921-metadata-display-name/prd.md
+++ b/enhancements/OSAC-2921-metadata-display-name/prd.md
@@ -12,18 +12,16 @@ OSAC resources use `metadata.name` as the primary human-visible identifier, but 
 
 ## In Scope
 
-- `display_name` (optional string, max 63 characters) and `description` (optional string, max 256 characters) added to the shared Metadata, automatically inherited by every resource type `[Clarify: R2.Q1, R4.Q4]`
-- Removal of existing per-resource `title` and `description` fields from all resource types that currently have them: Project, Role, IdentityProvider, InstanceType (description only), ClusterTemplate, ComputeInstanceTemplate, BareMetalInstanceTemplate, NetworkClass, HostType, ComputeInstanceCatalogItem, BareMetalInstanceCatalogItem, and ClusterCatalogItem `[Clarify: R1.Q1, PR review: sk-ilya, ygalblum]`
-- Both fields are optional, mutable after creation, and clearable `[Clarify: R3.Q1]`
-- `display_name` does not have to be unique across resources `[Clarify: R2.Q2, PR review: sk-ilya]`
-- Users can filter and sort resource lists by `display_name` across UI, CLI, and API `[Clarify: R2.Q2]`
-- UI displays `display_name` in place of `metadata.name` when set; falls back to `metadata.name` when `display_name` is not set — this applies uniformly across list views, detail pages, breadcrumbs, and search results `[Clarify: R4.Q1, R5.Q1]`
-- E2E test coverage for create, update, and clear of `display_name` and `description` across representative resource types
-- Documentation updated to describe the new fields and fallback behavior
+- Consistent, user-friendly resource naming across all OSAC resource types, all personas, and all client interfaces (API, CLI, Web UI) `[PR review: mhrivnak]`
+- Two new shared Metadata fields: `display_name` (optional, max 63 characters) and `description` (optional, max 256 characters) — both mutable, clearable, and not required to be unique `[Clarify: R2.Q1, R3.Q1, R4.Q4, PR review: sk-ilya]`
+- Reconciliation of existing per-resource `title`/`description` fields — removed from all 12 resource types that currently have them: Project, Role, IdentityProvider, InstanceType (description only), ClusterTemplate, ComputeInstanceTemplate, BareMetalInstanceTemplate, NetworkClass, HostType, ComputeInstanceCatalogItem, BareMetalInstanceCatalogItem, ClusterCatalogItem `[Clarify: R1.Q1, PR review: sk-ilya, ygalblum]`
+- Filtering and sorting by `display_name` `[Clarify: R2.Q2]`
+- E2E test coverage and documentation
 
 ## Out of Scope
 
-- Renaming or removing existing `metadata.name` semantics
+- Resource identity — `metadata.name` remains the unique identifier `[PR review: mhrivnak]`
+- Display behavior (how clients present `display_name` vs `metadata.name`) — deferred to UX and design phase `[PR review: mhrivnak, ygalblum]`
 - Template parameter `title`/`description` fields within ComputeInstanceTemplate, BareMetalInstanceTemplate, and ClusterTemplate — only resource-level fields are affected `[Clarify: R1.Q3]`
 
 ## User Stories
@@ -45,7 +43,6 @@ OSAC resources use `metadata.name` as the primary human-visible identifier, but 
 ### Tenant User
 
 - As a Tenant User, I want to give my resources a friendly `display_name` (up to 63 characters) and `description` when creating them so that I can identify and organize them more easily than relying on the constrained `metadata.name` field. `[Clarify: R2.Q1]`
-- As a Tenant User, I want list views to show `display_name` when set and fall back to `metadata.name` when it is not, so that I always see the most useful identifier regardless of whether a display name was provided.
 
 ## Dependencies
 
@@ -55,7 +52,9 @@ OSAC resources use `metadata.name` as the primary human-visible identifier, but 
 
 ## Provenance
 
-Authored: respond @ prd 0.5.0 - 7b6dfe0, workspace main @ 280ee0f
-Phases: draft, revise, respond
+Authored: draft @ prd 0.5.0 - 92734a2, workspace main @ aac0f8e
+Final: respond @ prd 0.6.0 - 7b6dfe0, workspace main @ 280ee0f
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.5.0","ai_workflows":"7b6dfe0","source_repo":"280ee0f","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise","respond"],"authoring_modes":["skill"],"context_changed":false} -->
+> Context changed between draft and respond.
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.0","ai_workflows":"7b6dfe0","source_repo":"280ee0f","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise","respond"],"authoring_modes":["skill"],"context_changed":true} -->


### PR DESCRIPTION
## PRD: Add standardized display_name and description fields to resource Metadata

**Jira:** https://redhat.atlassian.net/browse/OSAC-2921

### Summary

This PRD proposes adding `display_name` (max 63 chars) and `description` (max 256 chars) as optional fields on the shared Metadata struct, giving every OSAC resource type a consistent, user-friendly naming mechanism. Existing per-resource `title`/`description` fields are removed from all 12 resource types that currently have them (including flat-shape platform-defined resources such as templates, catalog items, NetworkClass, and HostType) in favor of the shared Metadata fields.

### Requesting Review On

- Reconciliation strategy: removing resource-level `title`/`description` from all affected resource types
- Scope boundaries: identity stays on `metadata.name`; display behavior deferred to UX/design
- User stories completeness across Cloud Provider Admin, Cloud Infrastructure Admin, Tenant Admin, and Tenant User personas
- Validation constraints: 63-char `display_name` and 256-char `description` limits

### How to Review

- Comment inline on specific sections
- Approve when the PRD accurately reflects the agreed requirements
