### PR TITLE
OSAC-985: narrow CAP-17 wording to traceability

### DIFF
--- a/enhancements/OSAC-985-metering-and-usage-tracking/prd.md
+++ b/enhancements/OSAC-985-metering-and-usage-tracking/prd.md
@@ -16,7 +16,7 @@
 | **Usage** | Measured consumption of a resource (e.g., instance-type-seconds consumed while a VM was running). |
 | **Allocation** | Reserved capacity of a resource, regardless of whether it is actively used. |
 | **Resource class** | A provider-defined category for differentiated pricing. Examples: host type for CaaS worker nodes (e.g., `gpu-h100`, `cpu-only`), template for VMaaS, machine class for BMaaS, storage tier for Storage-aaS. To the metering system, it is an opaque label used for grouping. |
-| **Service** | An offering that can be purchased from a service provider, and can include many types of usage or other charges (e.g., a cloud database service may include compute, storage, and networking charges). In OSAC, a catalog item (per the [catalog-items](/enhancements/catalog-items) EP) maps to a Service — it's what the tenant provisions from. A single Service may bundle multiple independently priceable components (e.g., compute, OS entitlement, boot storage for VMaaS; control plane, workers, cluster version for CaaS). The metering system provides the references needed for a billing system to decompose the Service into its priceable layers using the provider's rate schedule. |
+| **Service** | An offering that can be purchased from a service provider, and can include many types of usage or other charges (e.g., a cloud database service may include compute, storage, and networking charges). In OSAC, a catalog item (per the [catalog-items](/enhancements/catalog-items) EP) maps to a Service — it's what the tenant provisions from. A single Service may bundle multiple independently priceable components (e.g., compute, OS entitlement, boot storage for VMaaS; control plane, workers, cluster version for CaaS). The metering system carries catalog item and template references so that downstream systems can trace charges back to the originating Service. |
 | **Price List** | A comprehensive list of prices offered by a service provider. |
 | **Billing Period** | The time window that an organization receives an invoice for, inclusive of the start date and exclusive of the end date. |
 | **Budget** | A spending limit on a scope (tenant, project, resource type) for a configurable time period. |
@@ -88,7 +88,7 @@ Beyond raw metering, providers need a pricing layer to define rate schedules, ge
 - **CAP-14:** The metering system can be deployed independently without affecting existing OSAC provisioning. Providers who use their own metering solution can consume OSAC's lifecycle data without deploying the built-in metering stack.
 - **CAP-15:** Upgrading the metering system does not cause loss of collected metering data or gaps in measurement of ongoing workloads.
 - **CAP-16:** Duplicate events do not cause double-counting in any meter.
-- **CAP-17:** A billing system can determine the originating catalog offer and its bundled components for any metered resource, so that charges can be decomposed into independently priceable layers (e.g., compute, OS entitlement, boot storage) using the provider's rate schedule.
+- **CAP-17:** Metering data includes catalog item and template references for any metered resource, enabling downstream systems to trace charges back to the originating catalog offer.
 
 ## 4. Operational Expectations
 
@@ -134,7 +134,7 @@ Beyond raw metering, providers need a pricing layer to define rate schedules, ge
 - [ ] Raw events older than the configured retention period are purged
 - [ ] Aggregated data from 13 months ago is still queryable
 - [ ] A Cloud Infrastructure Admin can add a new meter via configuration update and query it after deployment
-- [ ] A billing system can identify the full set of independently priceable components bundled in a catalog offer for any metered resource
+- [ ] Metering data for any resource includes catalog item and template references traceable to the originating catalog offer
 - [ ] Upgrading the metering system does not cause data loss or measurement gaps
 
 ## 6. Assumptions

--- a/enhancements/OSAC-985-metering-and-usage-tracking/prd.md
+++ b/enhancements/OSAC-985-metering-and-usage-tracking/prd.md
@@ -16,7 +16,7 @@
 | **Usage** | Measured consumption of a resource (e.g., instance-type-seconds consumed while a VM was running). |
 | **Allocation** | Reserved capacity of a resource, regardless of whether it is actively used. |
 | **Resource class** | A provider-defined category for differentiated pricing. Examples: host type for CaaS worker nodes (e.g., `gpu-h100`, `cpu-only`), template for VMaaS, machine class for BMaaS, storage tier for Storage-aaS. To the metering system, it is an opaque label used for grouping. |
-| **Service** | An offering that can be purchased from a service provider, and can include many types of usage or other charges (e.g., a cloud database service may include compute, storage, and networking charges). In OSAC, a catalog item (per the [catalog-items](/enhancements/catalog-items) EP) maps to a Service — it's what the tenant provisions from. A single Service may bundle multiple independently priceable components (e.g., compute, OS entitlement, boot storage for VMaaS; control plane, workers, cluster version for CaaS). The metering system carries catalog item and template references so that downstream systems can trace charges back to the originating Service. |
+| **Service** | An offering that can be purchased from a service provider, and can include many types of usage or other charges (e.g., a cloud database service may include compute, storage, and networking charges). In OSAC, a catalog item (per the [catalog-items](/enhancements/catalog-items) EP) maps to a Service — it's what the tenant provisions from. A single Service may bundle multiple independently priceable components (e.g., compute, OS entitlement, boot storage for VMaaS; control plane, workers, cluster version for CaaS). Metering data includes catalog item and template references for any metered resource, enabling downstream systems to trace charges back to the originating catalog offer. |
 | **Price List** | A comprehensive list of prices offered by a service provider. |
 | **Billing Period** | The time window that an organization receives an invoice for, inclusive of the start date and exclusive of the end date. |
 | **Budget** | A spending limit on a scope (tenant, project, resource type) for a configurable time period. |
@@ -134,7 +134,7 @@ Beyond raw metering, providers need a pricing layer to define rate schedules, ge
 - [ ] Raw events older than the configured retention period are purged
 - [ ] Aggregated data from 13 months ago is still queryable
 - [ ] A Cloud Infrastructure Admin can add a new meter via configuration update and query it after deployment
-- [ ] Metering data for any resource includes catalog item and template references traceable to the originating catalog offer
+- [ ] Metering data includes catalog item and template references for any metered resource, enabling downstream systems to trace charges back to the originating catalog offer
 - [ ] Upgrading the metering system does not cause data loss or measurement gaps
 
 ## 6. Assumptions


### PR DESCRIPTION
## Summary

Narrows the [CAP-17](https://redhat.atlassian.net/browse/CAP-17) wording from billing-system-specific language to consumer-neutral traceability.

**Before:** "A billing system can determine the originating catalog offer and its bundled components... so that charges can be decomposed into independently priceable layers"

**After:** "Metering data includes catalog item and template references for any metered resource, enabling downstream systems to trace charges back to the originating catalog offer"

The metering system carries the references; who joins them with catalog data (billing system, Usage API, auditor) is downstream of metering.

Updates: [CAP-17](https://redhat.atlassian.net/browse/CAP-17) definition, glossary Service description, and acceptance criterion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated metering and usage-tracking requirements to include catalog item and template references.
  * Clarified that charges can be traced to the originating service and catalog offer through metering data.
  * Refined acceptance criteria for traceability of metered resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->