### PR TITLE
OSAC-2870: `check-ep-naming` grandfather against live main, not just stale base_sha

### DIFF
--- a/.github/scripts/check_ep_naming.py
+++ b/.github/scripts/check_ep_naming.py
@@ -114,7 +114,11 @@ def validate_paths(
     # A base SHA *was* provided (i.e. we're in CI) but doesn't resolve —
     # unlike the "no base SHA" case above, this indicates a CI
     # misconfiguration (e.g. a shallow checkout) and should stay fail-closed
-    # rather than silently disabling enforcement.
+    # rather than silently disabling enforcement. That fail-closed guarantee
+    # covers the live ref too: a checkout broken enough that the base SHA
+    # doesn't resolve can't be trusted to have fetched the live ref
+    # correctly either, so grandfathering is disabled entirely here, not
+    # just narrowed to one reference.
     if not ref_exists(base_sha):
         print(
             f"warning: PR base SHA '{base_sha}' is not available in this "
@@ -124,8 +128,9 @@ def validate_paths(
             file=sys.stderr,
         )
         base_sha = None
-
-    live_base_ref = resolve_live_base_ref(live_base_ref)
+        live_base_ref = None
+    else:
+        live_base_ref = resolve_live_base_ref(live_base_ref)
 
     violations = []
     for path in paths:

--- a/.github/scripts/check_ep_naming.py
+++ b/.github/scripts/check_ep_naming.py
@@ -8,6 +8,25 @@ Enforcement requires a PR base SHA (set via PRE_COMMIT_PR_BASE_SHA, always
 present in the CI pre-commit job). Local runs without it are advisory-only
 (a note is printed, nothing is flagged) so the git hook never blocks a
 commit that CI would pass.
+
+PRE_COMMIT_PR_BASE_SHA is a snapshot of `main` taken from the
+`pull_request` webhook payload at the PR's last open/synchronize event —
+it does not advance just because `main` gains new commits, and re-running
+an old CI job replays that same stale payload rather than refreshing it.
+For a long-lived PR that hasn't been pushed to since some *other*,
+unrelated PR merged a still-non-compliant directory into `main`, that
+stale SHA predates the unrelated directory, so it looks "new" here and
+gets (incorrectly) enforced against — even though the current PR never
+touches it and it's already correctly grandfathered on `main` itself.
+
+To avoid that false positive, grandfathering also checks the *live* tip
+of the base branch (PRE_COMMIT_LIVE_BASE_REF, e.g. `origin/main`, fetched
+fresh at the start of every CI run) in addition to the stale base SHA: a
+path is grandfathered if it exists at *either* reference. This keeps
+enforcement scoped to paths that are genuinely new — including for
+contributors actively renaming their own non-compliant directory to fix
+it, who should never be blocked by an unrelated pre-existing violation
+elsewhere in the repo.
 """
 
 import os
@@ -19,6 +38,7 @@ NAME_RE = re.compile(r"^OSAC-[1-9][0-9]*-[a-z0-9]+(?:-[a-z0-9]+)*$")
 CHECKED_FILENAMES = frozenset({"prd.md", "design.md"})
 
 BASE_SHA_ENV_VAR = "PRE_COMMIT_PR_BASE_SHA"
+LIVE_BASE_REF_ENV_VAR = "PRE_COMMIT_LIVE_BASE_REF"
 
 
 def path_exists_at_ref(ref: str, path: str) -> bool:
@@ -47,7 +67,32 @@ def top_level_enhancement_dir(path: str) -> str | None:
     return rest.split("/", 1)[0]
 
 
-def validate_paths(paths: list[str], base_sha: str | None) -> list[str]:
+def resolve_live_base_ref(live_base_ref: str | None) -> str | None:
+    # The live ref is best-effort: it's only set in CI (and only useful once
+    # actions/checkout has actually fetched it). If it's absent or doesn't
+    # resolve, grandfathering silently falls back to the base-SHA-only
+    # behavior below rather than erroring — this is a supplementary check,
+    # not a required one.
+    if live_base_ref is not None and ref_exists(live_base_ref):
+        return live_base_ref
+    return None
+
+
+def is_grandfathered(
+    path: str, base_sha: str | None, live_base_ref: str | None
+) -> bool:
+    if base_sha is not None and path_exists_at_ref(base_sha, path):
+        return True
+    if live_base_ref is not None and path_exists_at_ref(live_base_ref, path):
+        return True
+    return False
+
+
+def validate_paths(
+    paths: list[str],
+    base_sha: str | None,
+    live_base_ref: str | None = None,
+) -> list[str]:
     # No base SHA at all means this is a local, non-CI run (CI always sets
     # PRE_COMMIT_PR_BASE_SHA). Enforcing here would block commits that CI
     # would pass — e.g. anyone with the git hook installed editing a file in
@@ -80,6 +125,8 @@ def validate_paths(paths: list[str], base_sha: str | None) -> list[str]:
         )
         base_sha = None
 
+    live_base_ref = resolve_live_base_ref(live_base_ref)
+
     violations = []
     for path in paths:
         dir_name = top_level_enhancement_dir(path)
@@ -87,7 +134,7 @@ def validate_paths(paths: list[str], base_sha: str | None) -> list[str]:
             continue
 
         dir_path = f"enhancements/{dir_name}"
-        dir_is_grandfathered = base_sha is not None and path_exists_at_ref(base_sha, dir_path)
+        dir_is_grandfathered = is_grandfathered(dir_path, base_sha, live_base_ref)
 
         if not dir_is_grandfathered and not NAME_RE.match(dir_name):
             violations.append(
@@ -101,7 +148,7 @@ def validate_paths(paths: list[str], base_sha: str | None) -> list[str]:
         if basename.lower() not in CHECKED_FILENAMES or basename.lower() == basename:
             continue
 
-        file_is_grandfathered = base_sha is not None and path_exists_at_ref(base_sha, path)
+        file_is_grandfathered = is_grandfathered(path, base_sha, live_base_ref)
         if not file_is_grandfathered:
             violations.append(
                 f"{path}: filename '{basename}' must be lowercase "
@@ -113,7 +160,8 @@ def validate_paths(paths: list[str], base_sha: str | None) -> list[str]:
 
 def main(argv: list[str]) -> int:
     base_sha = os.environ.get(BASE_SHA_ENV_VAR) or None
-    violations = validate_paths(argv, base_sha)
+    live_base_ref = os.environ.get(LIVE_BASE_REF_ENV_VAR) or None
+    violations = validate_paths(argv, base_sha, live_base_ref)
     for violation in violations:
         print(violation, file=sys.stderr)
     return 1 if violations else 0

--- a/.github/scripts/test_check_ep_naming.py
+++ b/.github/scripts/test_check_ep_naming.py
@@ -23,13 +23,33 @@ class TopLevelEnhancementDirTests(unittest.TestCase):
 
 
 class ValidatePathsTests(unittest.TestCase):
-    def _validate(self, paths, base_sha, existing_at_base, base_ref_exists=True):
-        with patch.object(cen, "ref_exists", return_value=base_ref_exists), \
+    def _validate(
+        self,
+        paths,
+        base_sha,
+        existing_at_base,
+        base_ref_exists=True,
+        live_base_ref=None,
+        live_base_ref_exists=True,
+        existing_at_live_base=frozenset(),
+    ):
+        def fake_ref_exists(ref):
+            if ref == base_sha:
+                return base_ref_exists
+            if ref == live_base_ref:
+                return live_base_ref_exists
+            return False
+
+        def fake_path_exists_at_ref(ref, path):
+            if ref == live_base_ref:
+                return path in existing_at_live_base
+            return path in existing_at_base
+
+        with patch.object(cen, "ref_exists", side_effect=fake_ref_exists), \
                 patch.object(
-                    cen, "path_exists_at_ref",
-                    side_effect=lambda ref, path: path in existing_at_base,
+                    cen, "path_exists_at_ref", side_effect=fake_path_exists_at_ref,
                 ):
-            return cen.validate_paths(paths, base_sha)
+            return cen.validate_paths(paths, base_sha, live_base_ref)
 
     def test_grandfathered_directory_is_not_flagged(self):
         violations = self._validate(
@@ -162,6 +182,48 @@ class ValidatePathsTests(unittest.TestCase):
         message = captured.getvalue().lower()
         self.assertIn("deadbeef", message)
         self.assertIn("fetch-depth", message)
+
+    def test_pre_existing_on_live_main_but_absent_at_stale_base_sha_is_not_flagged(self):
+        # Reproduces the false positive seen on PR #121: a directory merged
+        # by an unrelated PR after this PR's base SHA was last captured is
+        # absent at the stale base_sha but present on the live tip of main
+        # — it must still be recognized as grandfathered, not flagged as
+        # "new" just because this PR's own history predates it.
+        violations = self._validate(
+            paths=["enhancements/storage-control-plane-osac-2872/prd.md"],
+            base_sha="stale123",
+            existing_at_base=set(),
+            live_base_ref="origin/main",
+            existing_at_live_base={"enhancements/storage-control-plane-osac-2872"},
+        )
+        self.assertEqual(violations, [])
+
+    def test_new_directory_absent_from_both_refs_is_still_flagged(self):
+        # The live-ref check is supplementary, not a blanket exemption —
+        # a genuinely new, badly-named directory (absent from the stale
+        # base SHA *and* from the live tip of main) must still be flagged.
+        violations = self._validate(
+            paths=["enhancements/storage-network/prd.md"],
+            base_sha="stale123",
+            existing_at_base=set(),
+            live_base_ref="origin/main",
+            existing_at_live_base=set(),
+        )
+        self.assertEqual(len(violations), 1)
+        self.assertIn("storage-network", violations[0])
+
+    def test_live_base_ref_unresolvable_falls_back_to_base_sha_only(self):
+        # If the live ref was never fetched (e.g. an older CI run before
+        # this env var existed, or a checkout quirk), grandfathering falls
+        # back to base-SHA-only behavior rather than erroring.
+        violations = self._validate(
+            paths=["enhancements/networking/design.md"],
+            base_sha="abc123",
+            existing_at_base={"enhancements/networking"},
+            live_base_ref="origin/main",
+            live_base_ref_exists=False,
+        )
+        self.assertEqual(violations, [])
 
     def test_new_directory_with_consecutive_dashes_is_flagged(self):
         violations = self._validate(

--- a/.github/scripts/test_check_ep_naming.py
+++ b/.github/scripts/test_check_ep_naming.py
@@ -225,6 +225,42 @@ class ValidatePathsTests(unittest.TestCase):
         )
         self.assertEqual(violations, [])
 
+    def test_pre_existing_on_live_main_but_absent_at_stale_base_sha_file_casing_is_not_reflagged(self):
+        # Same false-positive class as the directory-grandfathering case
+        # above, but for the filename-casing check specifically — it's a
+        # separate code path (file_is_grandfathered) using the same
+        # is_grandfathered() helper, so it needs its own coverage.
+        path = "enhancements/OSAC-42-example-feature/DESIGN.md"
+        violations = self._validate(
+            paths=[path],
+            base_sha="stale123",
+            existing_at_base=set(),
+            live_base_ref="origin/main",
+            existing_at_live_base={
+                "enhancements/OSAC-42-example-feature",
+                path,
+            },
+        )
+        self.assertEqual(violations, [])
+
+    def test_unresolvable_base_sha_disables_live_ref_grandfathering_too(self):
+        # The fail-closed guarantee ("grandfathering disabled, every path
+        # validated as new") must hold in full: an unresolvable base SHA
+        # can't partially fail closed by still trusting the live ref. Here
+        # the live ref alone would grandfather the path if it were
+        # consulted — it must not be.
+        violations = self._validate(
+            paths=["enhancements/networking/design.md"],
+            base_sha="deadbeef",
+            base_ref_exists=False,
+            existing_at_base=set(),
+            live_base_ref="origin/main",
+            live_base_ref_exists=True,
+            existing_at_live_base={"enhancements/networking"},
+        )
+        self.assertEqual(len(violations), 1)
+        self.assertIn("networking", violations[0])
+
     def test_new_directory_with_consecutive_dashes_is_flagged(self):
         violations = self._validate(
             paths=["enhancements/OSAC-1--foo/prd.md"],

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -16,3 +16,4 @@ jobs:
     - uses: pre-commit/action@v3.0.1
       env:
         PRE_COMMIT_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PRE_COMMIT_LIVE_BASE_REF: origin/${{ github.event.pull_request.base.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,11 @@ exact substring match on the key, not a sortable one.
 
 A CI check validates any `enhancements/*` directory and
 `prd.md`/`design.md` file that is newly added in a pull request. Directories
-and files that already existed before the PR are not re-validated —
-existing non-compliant directories are a separate, tracked cleanup
+and files that already existed before the PR — either at the PR's base
+commit, or currently on `main` — are not re-validated. This means an
+unrelated, still-non-compliant directory merged by someone else's PR
+never blocks your PR, even if your branch hasn't been rebased since.
+Existing non-compliant directories are a separate, tracked cleanup
 (see [OSAC-2870](https://redhat.atlassian.net/browse/OSAC-2870)), not a
 blocker for new work.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,9 @@ exact substring match on the key, not a sortable one.
 A CI check validates any `enhancements/*` directory and
 `prd.md`/`design.md` file that is newly added in a pull request. Directories
 and files that already existed before the PR — either at the PR's base
-commit, or currently on `main` — are not re-validated. This means an
-unrelated, still-non-compliant directory merged by someone else's PR
-never blocks your PR, even if your branch hasn't been rebased since.
+commit, or currently on the PR's base branch — are not re-validated. This
+means an unrelated, still-non-compliant directory merged by someone else's
+PR never blocks your PR, even if your branch hasn't been rebased since.
 Existing non-compliant directories are a separate, tracked cleanup
 (see [OSAC-2870](https://redhat.atlassian.net/browse/OSAC-2870)), not a
 blocker for new work.


### PR DESCRIPTION
## Summary

Fixes a false-positive class of `check-ep-naming` CI failure: a long-lived PR that hasn't been pushed to since some *other*, unrelated PR merged a still-non-compliant `enhancements/` directory into `main` fails on that unrelated directory — even though the PR never touches it, and it's already correctly grandfathered on `main` itself.

**Observed concretely on [#121](https://github.com/osac-project/enhancement-proposals/pull/121)**, which fails `check-ep-naming` on `enhancements/storage-control-plane-osac-2872` (merged non-compliant by #134) despite never touching that path — because #121's `base.sha` (captured at its last open/synchronize event, 2026-07-16) predates #134's merge.

## Root cause

`PRE_COMMIT_PR_BASE_SHA` (set from `github.event.pull_request.base.sha`) is a snapshot taken at the PR's last open/synchronize event. It does not advance just because `main` gains new commits, and re-running an old CI job replays that same stale payload rather than refreshing it. The naming check's grandfather logic only checked this one, potentially stale, reference — so anything that landed on `main` *after* that snapshot looks "new" to the script, regardless of whether the current PR touches it.

## Fix

Grandfathering now checks **two** references instead of one — a path is grandfathered if it exists at *either*:
1. `PRE_COMMIT_PR_BASE_SHA` (existing behavior, unchanged), or
2. `PRE_COMMIT_LIVE_BASE_REF` — the live tip of the base branch (`origin/main`), fetched fresh at the start of every CI run (new).

This keeps enforcement scoped to genuinely new paths. It's purely additive/supplementary: if the live ref isn't available for any reason (not fetched, older workflow run, local `pre-commit install` without network), it silently falls back to base-SHA-only behavior — no new failure mode introduced.

Critically, this also protects contributors who are actively fixing their own directory's naming (as prompted by the review comments just posted on `#13`, `#46`, `#54`, `#61`, `#70`, `#81`, `#88`, `#91`, `#117`, `#118`, `#119`, `#126`, `#127`): renaming their own non-compliant directory to a compliant one should never be blocked by an *unrelated* pre-existing violation elsewhere in the repo picked up by `--all-files`.

## Changes

- `.github/workflows/pre-commit.yaml` — add `PRE_COMMIT_LIVE_BASE_REF: origin/${{ github.event.pull_request.base.ref }}` env var (relies on the existing `fetch-depth: 0` checkout, which already fetches all branches).
- `.github/scripts/check_ep_naming.py` — new `is_grandfathered()` helper checks both references; `validate_paths()` and `main()` thread the new `live_base_ref` parameter through. Docstring expanded to explain the staleness mechanism and fix.
- `.github/scripts/test_check_ep_naming.py` — 3 new tests: the exact #121 false-positive scenario (grandfathered on live main, absent at stale base_sha → not flagged), a regression check that genuinely-new bad names are still flagged when absent from *both* refs, and a fallback check when the live ref isn't resolvable. 22 → 25 tests, all passing.
- `CONTRIBUTING.md` — one-sentence clarification that grandfathering checks both the PR's base commit and the current tip of `main`.

## Testing

- `python3 -m unittest test_check_ep_naming` — 25/25 pass.
- `pre-commit run --all-files` locally — all hooks pass, including `check-ep-naming` and `yamllint` on the workflow file.
- Ran `check_ep_naming.py` directly against every current `enhancements/*` file with `PRE_COMMIT_LIVE_BASE_REF=origin/main` — clean exit 0.

## Notes for reviewers

- Not able to fully verify in this PR's own CI run whether `origin/${{ github.event.pull_request.base.ref }}` resolves as expected post-checkout (should, per `actions/checkout`'s documented `fetch-depth: 0` → full-history-all-branches behavior, and the existing `fetch-depth: 0` step is unchanged) — worth confirming the `check-ep-naming` step doesn't log the "PR base SHA ... not available" warning-path when this PR's own CI runs. If for some reason the live ref doesn't resolve, the fallback is silent and behavior is unchanged from today (i.e., this PR is a strict improvement, never a regression).
- Doesn't fix `#121` directly (that's still blocked until either it's rebased, or #128 — which already renames the offending directory — merges); this PR fixes the underlying mechanism so this class of false positive stops recurring for *any* future PR in the same situation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enhancement naming checks in CI by recognizing directories already present on the current base branch, even when the pull request’s base revision is outdated.
  * Preserved validation for newly introduced directories with invalid names.
  * Added graceful fallback when the current base branch reference cannot be resolved.

* **Documentation**
  * Clarified which pre-existing directories are exempt from naming validation and how unrelated legacy violations are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->