### PR TITLE
OSAC-3065: fix design review triggering on PRD-only PRs

### DIFF
--- a/.github/scripts/ep_review.py
+++ b/.github/scripts/ep_review.py
@@ -37,8 +37,8 @@ def gh(args):
 
 def get_changed_files(pr_number):
     raw = gh(["api", f"repos/{REPO}/pulls/{pr_number}/files",
-              "--paginate", "--jq", "[.[].filename]"])
-    return json.loads(raw) if raw.strip() else []
+              "--paginate", "--jq", ".[].filename"])
+    return [f for f in raw.splitlines() if f.strip()]
 
 
 def detect_skills(files):

--- a/.github/scripts/ep_review.py
+++ b/.github/scripts/ep_review.py
@@ -41,12 +41,6 @@ def get_changed_files(pr_number):
     return json.loads(raw) if raw.strip() else []
 
 
-def get_incremental_files(before_sha, head_sha):
-    raw = gh(["api", f"repos/{REPO}/compare/{before_sha}...{head_sha}",
-              "--jq", "[.files[].filename]"])
-    return json.loads(raw) if raw.strip() else []
-
-
 def detect_skills(files):
     skills = []
     has_prd = any(f.lower().endswith("prd.md") for f in files)
@@ -119,16 +113,7 @@ def main():
     if shadow:
         print("SHADOW MODE: review will run but no comment will be posted")
 
-    event_name = os.environ.get("EVENT_NAME", "")
-    event_action = os.environ.get("EVENT_ACTION", "")
-    before_sha = os.environ.get("EVENT_BEFORE_SHA", "")
-
-    # For synchronize events, only review files changed in the latest push
-    if event_action == "synchronize" and before_sha and head_sha:
-        files = get_incremental_files(before_sha, head_sha)
-        print(f"Synchronize: checking incremental diff ({before_sha[:8]}..{head_sha[:8]})")
-    else:
-        files = get_changed_files(pr_number)
+    files = get_changed_files(pr_number)
 
     if not files:
         print("No files changed")

--- a/.github/workflows/ep-review.yml
+++ b/.github/workflows/ep-review.yml
@@ -114,9 +114,6 @@ jobs:
           EP_REVIEW_SHADOW: ${{ vars.EP_REVIEW_SHADOW || 'true' }}
           PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
           PR_HEAD_SHA: ${{ needs.resolve-pr.outputs.head_sha }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_ACTION: ${{ github.event.action }}
-          EVENT_BEFORE_SHA: ${{ github.event.before }}
         run: python .github/scripts/ep_review.py
 
       - name: Upload OTEL metrics


### PR DESCRIPTION
## Summary

- Remove `get_incremental_files` which used the GitHub compare API (`compare/{before}...{head}`) for `synchronize` events. After a force-push/rebase the two SHAs have different ancestry, causing the compare to return every `.md` file in the repo — including `design.md` files from other enhancement directories — which made `detect_skills` schedule a spurious design review.
- Always use `get_changed_files` (the PR files endpoint) which reliably returns only the PR's actual diff regardless of rebase history.
- Remove unused `EVENT_NAME`, `EVENT_ACTION`, `EVENT_BEFORE_SHA` env vars from the workflow.

## Root cause

Confirmed via workflow logs:
- **Bad run** (run 29987941334): `synchronize` event → `get_incremental_files` returned 46 files across the entire repo → both `prd-review` and `design-review` triggered on a PRD-only PR
- **Good run** (run 30003381899): `get_changed_files` returned 1 file → only `prd-review` triggered

## Test plan

- [ ] Verify PRD-only PRs (e.g., PR #126) no longer receive "AI Design Review" comments
- [ ] Verify PRs with both `prd.md` and `design.md` still get both reviews
- [ ] Verify force-pushed PRs correctly detect only the files in the PR diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pull request reviews now consistently include the full set of changed files, including updates from subsequent pushes.
* **Chores / Workflow Updates**
  * Streamlined the review workflow configuration to improve reliability by simplifying how review scope parameters are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->