### PR TITLE
OSAC-3057: Make enhancement-proposals the canonical home for PRD and EP templates/guides

### DIFF
--- a/.github/scripts/ep_review.py
+++ b/.github/scripts/ep_review.py
@@ -9,6 +9,7 @@ structured review comment on the PR.
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -55,6 +56,37 @@ def detect_skills(files):
     if has_design:
         skills.append(("design-review", "skills/design-review/SKILL.md"))
     return skills
+
+
+def pr_enhancement_slugs(files):
+    """Extract enhancements/<slug>/ directories touched by this PR."""
+    slugs = set()
+    for f in files:
+        m = re.match(r"enhancements/([^/]+)/", f)
+        if m:
+            slugs.add(m.group(1))
+    return slugs
+
+
+def exclude_own_slug_from_reference_library(work_dir, files):
+    """Remove this PR's own enhancement directory from the staged
+    enhancement-proposals/enhancements/ reference library.
+
+    design-review's "Comparison with Similar Designs" step treats
+    enhancements/ as a library of *merged* designs to calibrate against.
+    If this PR updates an existing enhancement, the pre-PR version of that
+    same document would otherwise sit in the reference library right
+    alongside .context/pr-diff.txt's new version, and could get cited as a
+    "similar past design" — a stale ghost of the very document under
+    review, not a real precedent.
+    """
+    ref_root = Path(work_dir) / "enhancement-proposals" / "enhancements"
+    if not ref_root.exists():
+        return
+    for slug in pr_enhancement_slugs(files):
+        slug_dir = ref_root / slug
+        if slug_dir.exists():
+            shutil.rmtree(slug_dir)
 
 
 def run_review(hooks, skill_name, skill_path, ticket_key, ticket, work_dir):
@@ -164,6 +196,7 @@ def main():
             shutil.rmtree(work_dir)
         shutil.copytree(SKILLS_PATH, work_dir,
                         ignore=shutil.ignore_patterns('.git'))
+        exclude_own_slug_from_reference_library(work_dir, files)
 
         print(f"\nRunning {skill_name}...")
         try:

--- a/.github/scripts/test_ep_review.py
+++ b/.github/scripts/test_ep_review.py
@@ -1,0 +1,115 @@
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import ep_review as er
+
+
+class PrEnhancementSlugsTests(unittest.TestCase):
+    def test_single_slug_multiple_files(self):
+        files = [
+            "enhancements/OSAC-2917-gpu-instance-types/design.md",
+            "enhancements/OSAC-2917-gpu-instance-types/prd.md",
+        ]
+        self.assertEqual(
+            er.pr_enhancement_slugs(files), {"OSAC-2917-gpu-instance-types"}
+        )
+
+    def test_multiple_slugs(self):
+        files = [
+            "enhancements/OSAC-1-a/design.md",
+            "enhancements/OSAC-2-b/prd.md",
+        ]
+        self.assertEqual(
+            er.pr_enhancement_slugs(files), {"OSAC-1-a", "OSAC-2-b"}
+        )
+
+    def test_unrelated_paths_ignored(self):
+        files = [
+            "guidelines/prd_template.md",
+            "README.md",
+            ".github/workflows/ep-review.yml",
+        ]
+        self.assertEqual(er.pr_enhancement_slugs(files), set())
+
+    def test_bare_file_in_enhancements_ignored(self):
+        # A file directly under enhancements/ (no slug subdirectory) is not
+        # itself a slug.
+        self.assertEqual(
+            er.pr_enhancement_slugs(["enhancements/stray-file.md"]), set()
+        )
+
+    def test_mixed_related_and_unrelated(self):
+        files = [
+            "enhancements/OSAC-42-foo/design.md",
+            "some/other/unrelated-file.go",
+        ]
+        self.assertEqual(er.pr_enhancement_slugs(files), {"OSAC-42-foo"})
+
+
+class ExcludeOwnSlugFromReferenceLibraryTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.work_dir = Path(self.tmp) / "workdir-design-review"
+        self.ref_root = self.work_dir / "enhancement-proposals" / "enhancements"
+
+    def _make_slug_dir(self, slug, content="content"):
+        d = self.ref_root / slug
+        d.mkdir(parents=True)
+        (d / "design.md").write_text(content)
+        return d
+
+    def test_own_slug_removed_unrelated_slug_survives(self):
+        self._make_slug_dir(
+            "OSAC-2917-gpu-instance-types", "stale pre-PR version"
+        )
+        self._make_slug_dir("networking", "unrelated reference design")
+        files = ["enhancements/OSAC-2917-gpu-instance-types/design.md"]
+
+        er.exclude_own_slug_from_reference_library(self.work_dir, files)
+
+        self.assertFalse(
+            (self.ref_root / "OSAC-2917-gpu-instance-types").exists()
+        )
+        self.assertTrue((self.ref_root / "networking").exists())
+
+    def test_multiple_own_slugs_removed(self):
+        self._make_slug_dir("OSAC-1-a")
+        self._make_slug_dir("OSAC-2-b")
+        self._make_slug_dir("unrelated")
+        files = [
+            "enhancements/OSAC-1-a/design.md",
+            "enhancements/OSAC-2-b/prd.md",
+        ]
+
+        er.exclude_own_slug_from_reference_library(self.work_dir, files)
+
+        self.assertFalse((self.ref_root / "OSAC-1-a").exists())
+        self.assertFalse((self.ref_root / "OSAC-2-b").exists())
+        self.assertTrue((self.ref_root / "unrelated").exists())
+
+    def test_missing_reference_root_is_a_noop(self):
+        # enhancement-proposals/enhancements/ doesn't exist at all (e.g. a
+        # prd-review work_dir, which never needs the reference library).
+        self.work_dir.mkdir(parents=True)
+        files = ["enhancements/OSAC-2917-gpu-instance-types/design.md"]
+
+        er.exclude_own_slug_from_reference_library(self.work_dir, files)
+
+        self.assertFalse(self.ref_root.exists())
+
+    def test_absent_slug_directory_is_a_noop(self):
+        # The PR's own slug isn't present in the reference library at all
+        # (e.g. a brand-new enhancement with no prior merged version).
+        self._make_slug_dir("unrelated")
+        files = ["enhancements/OSAC-brand-new/design.md"]
+
+        er.exclude_own_slug_from_reference_library(self.work_dir, files)
+
+        self.assertTrue((self.ref_root / "unrelated").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ep-review.yml
+++ b/.github/workflows/ep-review.yml
@@ -100,6 +100,21 @@ jobs:
       - name: Clone workspace
         run: git clone --depth 1 https://github.com/osac-project/osac-workspace /opt/skills
 
+      - name: Stage enhancement-proposals content for skill lookups
+        # Reuses the repo already checked out by the first step above (at
+        # base_ref) instead of a second, independent clone of a mutable ref.
+        # guidelines/ is the canonical PRD/design template + guide source
+        # skills/prd-review and skills/design-review resolve against.
+        # enhancements/ is design-review's calibration reference library
+        # (see review-patterns.md's "EP Reference Library"). ep_review.py
+        # excludes the current PR's own enhancement directory from this
+        # copy before running the skill, so a design/PRD update never sees
+        # its own stale pre-PR version staged as a "reference" example.
+        run: |
+          mkdir -p /opt/skills/enhancement-proposals
+          cp -r guidelines /opt/skills/enhancement-proposals/
+          cp -r enhancements /opt/skills/enhancement-proposals/
+
       - name: Set up GCP credentials
         run: echo "$GCP_SA_KEY" | base64 -d > /tmp/gcp-sa-key.json
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 *.pyc
+
+# Workflow artifacts (bugfix, implement)
+.artifacts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,14 @@ This repository contains design documents (enhancement proposals) for the OSAC p
 
 **Do not create PRDs or design documents directly in this repo.** Use the osac-workspace AI workflows instead:
 
-- **PRD workflow**: `/prd:ingest` → `/prd:draft` → `/prd:publish`
+- **PRD workflow**: `/prd:ingest` → `/prd:clarify` → `/prd:draft` → `/prd:publish`
 - **Design workflow**: `/design:ingest` → `/design:draft` → `/design:publish`
 
 These workflows handle template selection, feature dimensions context, section guidance, and publishing. See `osac-workspace/AGENTS.md` for full instructions.
 
 ## Enhancement Proposals
 
-See `README.md` for qualification heuristics, review/approval process, and enhancement lifecycle.
+See `README.md` for qualification heuristics, review/approval process, and enhancement lifecycle. `guidelines/prd_guide.md` and `guidelines/design_guide.md` hold the per-section authoring guidance, PRD vs design EP boundary, and OSAC personas that the `/prd` and `/design` skills above draft against — use them to review an existing `prd.md`/`design.md` or to support a human author on the manual workflow, not as a way to author these documents yourself.
 
 ## Validation
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,40 @@ It is unlikely to require an enhancement if it:
 
 If you are not sure if the proposed work requires an enhancement, file an issue and ask!
 
+## How do I create a PRD?
+
+A PRD (Product Requirements Document) defines **what** a feature delivers and
+**why**, from the user's perspective. PRDs are merged before design work begins.
+For detailed guidance on writing PRDs, the PRD vs design EP boundary, personas,
+and good/bad examples, see [guidelines/prd_guide.md](guidelines/prd_guide.md).
+
+The recommended way to create a PRD is using the `/prd` skill in an AI-assisted
+development tool (Claude Code, Cursor, or similar):
+
+1. Run `/prd:ingest` with your Jira ticket to gather requirements.
+2. Run `/prd:clarify` to resolve ambiguities through guided Q&A.
+3. Run `/prd:draft` to generate the PRD from the project template.
+4. Run `/prd:publish` to create a PR on this repository.
+
+The skill produces a PRD that follows [guidelines/prd_template.md](guidelines/prd_template.md),
+addresses OSAC feature dimensions, and can be validated with `/prd-review`
+before submission.
+
+If you prefer to write manually, copy the template and follow the instructions
+inside it:
+
+```sh
+mkdir enhancements/OSAC-1234-my-nifty-feature
+cp guidelines/prd_template.md enhancements/OSAC-1234-my-nifty-feature/prd.md
+```
+
+Use the `OSAC-NNNN-feature-slug` naming convention (see
+[CONTRIBUTING.md](CONTRIBUTING.md) and the example directory name above).
+Create a pull request against `main` when ready.
+
+After the PRD is merged, create the design EP (`design.md`) in the same
+directory. See "How do I create an enhancement proposal?" below.
+
 ## How do I create an enhancement proposal?
 
 OSAC uses a two-document flow: a **PRD** (Product Requirements Document) describes WHAT and WHY, and a **design document** describes HOW.
@@ -35,7 +69,7 @@ OSAC uses a two-document flow: a **PRD** (Product Requirements Document) describ
 
 The [osac-workspace](https://github.com/osac-project/osac-workspace) provides AI-assisted workflows that guide you through the process:
 
-1. **PRD**: Run `/prd:ingest` to start a PRD, then `/prd:draft` and `/prd:publish` to create it in this repo as `enhancements/OSAC-NNNN-feature-slug/prd.md`.
+1. **PRD**: Run `/prd:ingest` to start a PRD, then `/prd:clarify`, `/prd:draft`, and `/prd:publish` to create it in this repo as `enhancements/OSAC-NNNN-feature-slug/prd.md`.
 2. **Design**: Run `/design:ingest` to start the design, then `/design:draft` and `/design:publish` to create it as `enhancements/OSAC-NNNN-feature-slug/design.md`.
 
 See the osac-workspace [AGENTS.md](https://github.com/osac-project/osac-workspace/blob/main/AGENTS.md) for full workflow details.
@@ -48,7 +82,7 @@ See the osac-workspace [AGENTS.md](https://github.com/osac-project/osac-workspac
     mkdir enhancements/OSAC-1234-my-nifty-feature
     ```
 
-2. Create your PRD (`prd.md`) and design document (`design.md`) in that directory. Use `guidelines/enhancement_template.md` as a starting point for the design if needed (note: this template predates the two-document split and includes sections like User Stories that now belong in the PRD).
+2. Create your PRD (`prd.md`) and design document (`design.md`) in that directory. Use [guidelines/prd_template.md](guidelines/prd_template.md) as a starting point for the PRD and [guidelines/design_template.md](guidelines/design_template.md) for the design — see [guidelines/prd_guide.md](guidelines/prd_guide.md) and [guidelines/design_guide.md](guidelines/design_guide.md) for authoring guidance on each.
 
 3. If your proposal requires additional assets -- images, sample configuration files, etc -- include them in the same directory.
 

--- a/guidelines/design_guide.md
+++ b/guidelines/design_guide.md
@@ -276,10 +276,10 @@ The skill produces a design EP that follows
 
 ## Review
 
-Design EPs are reviewed against four criteria: architecture (OSAC pattern
-compliance, tenant isolation, dependency clarity), feasibility
+Design EPs are reviewed against four criteria: architecture (pattern
+compliance, dependency clarity, terminology), feasibility
 (implementation depth, proto schemas, risk quality), scope (boundary
-clarity, PRD reference, dimension coverage), and testability (test
+clarity, persona coverage, dimension coverage), and testability (test
 strategy specificity, graduation criteria). Use the `design-review` skill
 for a detailed automated assessment before submitting your PR.
 

--- a/guidelines/design_guide.md
+++ b/guidelines/design_guide.md
@@ -1,0 +1,290 @@
+# Design EP Author Guide
+
+This guide explains how to write a design enhancement proposal (EP) for
+OSAC. It covers what a design EP is, how it differs from a PRD, per-section
+authoring guidance, and common mistakes to avoid.
+
+## What is a Design EP?
+
+A design EP describes **how** a feature will be implemented — architecture,
+API design, controller logic, provisioning workflows. It builds on a merged
+PRD (which describes **what** and **why**) and provides enough detail for
+engineering to estimate, plan, and implement.
+
+A design EP answers:
+- What components change, and how?
+- What are the new or modified APIs, CRDs, and data models?
+- How does the system behave on failure, and how does it recover?
+- What is the test strategy?
+
+## PRD vs Design EP
+
+OSAC uses a two-stage enhancement process. The PRD comes first and defines
+the requirements. The design EP follows and specifies the implementation.
+
+| | **PRD** (`prd.md`) | **Design EP** (`design.md`) |
+|---|---|---|
+| **Audience** | Product managers, reviewers, stakeholders | Engineers, architects |
+| **Focus** | User-facing capabilities and outcomes | Architecture, API fields, reconciliation logic |
+| **Content** | User stories, in/out of scope, success criteria | CRD schemas, controller design, playbook parameters |
+| **Lifecycle** | Merged before design work begins | Merged before implementation begins |
+
+**Litmus test:** Could this statement change if we swapped the
+implementation and kept the same user-facing behavior? If yes, it's design
+detail — it belongs here, not in the PRD.
+
+See [prd_guide.md](prd_guide.md) for the full "what belongs where" table,
+the platform-vocabulary allowlist, and the PRD's own litmus test. Don't
+duplicate PRD content here: a design EP's Summary and Motivation sections
+should bridge from the PRD, not restate its problem statement or user
+stories.
+
+## OSAC Personas
+
+Design EPs don't repeat persona definitions — see
+[prd_guide.md](prd_guide.md#osac-personas) for the canonical table
+(Cloud Provider Admin, Cloud Infrastructure Admin, Tenant Admin, Tenant
+User). In a design EP, personas show up as the actors in the **Workflow
+Description** section — name them explicitly when describing who triggers
+each step.
+
+## Per-Section Authoring Guidance
+
+These apply across all sections:
+
+- **Favor conciseness.** Long design documents don't get read. Every
+  sentence should earn its place.
+- **Be specific.** No vague language: name the data structure, the cache
+  strategy, the error taxonomy — not "an efficient data structure" or
+  "appropriate caching."
+- **Bridge from the PRD, don't repeat it.** Assume the reader may not have
+  read the PRD and needs enough context to understand the design
+  decisions, but direct them to `prd.md` for the full requirements.
+- **Keep all required headers.** If a section doesn't apply, explain why
+  but don't remove it.
+
+### YAML Frontmatter
+
+- `title`: lowercase slug with hyphens (e.g., `networking-api`)
+- `authors`: email addresses
+- `creation-date` / `last-updated`: ISO date format (`yyyy-mm-dd`)
+- `tracking-link`: full Jira URL
+- `prd`: relative path to the PRD document (typically `prd.md`)
+- `see-also` / `replaces` / `superseded-by`: usually `N/A` for new proposals
+
+### Summary
+
+1-2 sentences: what this design achieves and the technical approach. End
+with a PRD reference — "See [PRD](prd.md) for detailed requirements."
+
+### Motivation (Goals, Non-Goals)
+
+2-4 paragraphs restating the problem in implementation terms for technical
+reviewers. No user stories here — those are in the PRD. Goals are
+design-scoped constraints on the implementation approach ("reuse the
+existing controller reconciliation pattern"), not product outcomes
+("tenants can create VirtualNetworks" — that's a PRD goal). Non-goals
+prevent scope creep at the implementation level.
+
+### Proposal (Workflow Description, API Extensions)
+
+1-2 paragraphs introducing the key resources/APIs at a high level —
+typically the new CRDs, gRPC services, and controller changes. Workflow
+Description defines actors using OSAC personas, enumerates the steps a
+user takes starting from a defined state, and is explicit about which APIs
+are involved (gRPC, REST, kubectl). Use a
+[Mermaid](https://github.com/mermaid-js/mermaid#readme) sequence diagram
+for multi-step interactions. API Extensions names new gRPC services
+(fulfillment-service), new CRDs (osac-operator), webhooks, and finalizers,
+and calls out operational impact if the controller is down.
+
+### UX Alignment
+
+Required only when a matching `osac-ux/libs/ui-components/src/api/v1/<resource>.ts`
+file exists. Complete the field-mapping table and justify any deviation
+from the known anti-patterns (sub-resource actions, string-union storage
+classes, K8s-internal fields, one-time secrets, RHOAI operator fields).
+
+### Implementation Details/Notes/Constraints
+
+This is where technical depth lives. Include proto schema snippets
+following the standard object shape (`id`, `Metadata`, `<Type>Spec`,
+`<Type>Status`) and the conventions in
+[fulfillment-service's API.md](https://github.com/osac-project/fulfillment-service/blob/main/docs/API.md) —
+spec for desired state, status for observed state, conditions for
+lifecycle, declarative design with no imperative methods. Cover database
+schema considerations and controller reconciliation logic (state machine,
+finalizer flow), and describe integration with existing OSAC components.
+
+### Security Considerations
+
+Cover input validation, authentication/authorization changes, and data
+exposure risks. For multi-tenant features, describe how tenant isolation
+is enforced — OPA policies, namespace scoping, `osac.openshift.io/tenant`
+annotation filtering. If the feature inherits the existing security model
+unchanged, state that and explain why it's sufficient. Don't invent
+security concerns that don't apply.
+
+### Failure Handling and Recovery
+
+Enumerate concrete failure modes — not generic categories. For each: what
+happens, how the system recovers, what the user sees. Cover controller-side
+failures (reconciliation errors, stale caches), API-side failures
+(validation, database errors), and integration failures (AAP job timeouts,
+network provisioning failures). Note retry behavior, idempotency
+guarantees, and behavior when a controller restarts mid-reconciliation.
+
+### RBAC / Tenancy
+
+All new resources **must** include tenant isolation metadata:
+`osac.openshift.io/tenant` for tenant scoping, `osac.openshift.io/owner-reference`
+for resource hierarchy. Describe how OPA policies enforce isolation at
+runtime, and note visibility constraints (can a tenant see resources from
+other tenants? platform-defined resources like NetworkClass?). If no RBAC
+or tenancy changes are needed: "No RBAC or tenancy changes required." with
+brief justification.
+
+### Observability and Monitoring
+
+List new Prometheus metrics (name, type, labels, and what threshold
+indicates a problem), Kubernetes events (type, reason, when it fires), and
+structured log events. If none: "No new observability changes. Existing
+monitoring mechanisms apply."
+
+### Risks and Mitigations
+
+Technical risks only — product risks belong in the PRD. Each risk needs a
+concrete mitigation or an explicit "To be determined." Consider version
+skew, performance bottlenecks, security exposure, backwards compatibility,
+and cross-component coordination.
+
+### Drawbacks
+
+Steel-man the argument against the proposal. What trade-offs (maintenance
+burden, API complexity, user experience) must be made, and how do we
+justify them?
+
+### Alternatives (Not Implemented)
+
+At least one real alternative per non-trivial design decision, including
+"Do nothing" where applicable. For each: brief description, pros, cons,
+and the rejection reason. Be honest about trade-offs.
+
+### Open Questions
+
+Optional — omit entirely if none remain after drafting. Each question gets
+its own numbered subsection, framed as a clear, answerable question
+directed at reviewers. Design scope only — no process-level actions. This
+section is transient: when a question is resolved during review, fold the
+answer into the relevant section and remove the entry.
+
+### Test Plan
+
+*Not required until targeted at a release.* List concrete test scenarios
+under Unit, Integration, and E2E sub-sections — not general strategy. Each
+scenario should be specific enough that an implementer knows what to build
+(e.g., "validation rejects overlapping CIDRs," not "test validation").
+Reference OSAC test patterns: Ginkgo for unit/integration tests, pytest for
+e2e (via osac-test-infra). Call out tricky areas explicitly (CIDR parsing,
+dual-stack, concurrent reconciliation).
+
+### Graduation Criteria
+
+*Not required until targeted at a release.* If not yet targeting a
+release: "Graduation criteria will be defined when targeting a release.
+Expected stages: Dev Preview -> Tech Preview -> GA based on production
+deployment feedback." If targeting a release, define maturity levels and
+success signals.
+
+### Upgrade / Downgrade Strategy, Version Skew Strategy, Support Procedures
+
+For a new API with no upgrade impact: "This is a new API with no upgrade
+impact. Downgrade requires deleting all instances of the new resources
+before reverting." For changes to existing APIs, describe migration steps
+and version-skew handling between fulfillment-service and osac-operator.
+Support Procedures should describe failure-detection symptoms (events,
+metrics, alerts), how to disable the feature and the consequences, and
+recovery behavior.
+
+### Infrastructure Needed
+
+Usually "None." If needed, specify new test infrastructure, repos, or CI
+changes.
+
+## Common Mistakes
+
+### Vague implementation
+
+The design-EP equivalent of PRD design leakage. Symptoms: no proto
+schemas, hand-waving on hard parts ("handle edge cases appropriately," "the
+controller will handle provisioning"), and generic risks ("things might
+break"). **Fix:** name the data structures, error codes, and validation
+rules; state specific risks with concrete mitigations ("concurrent subnet
+allocation may cause CIDR overlap" with "use optimistic locking with
+resource version").
+
+### Missing PRD reference
+
+Every design EP needs a `prd:` frontmatter field or an explicit link to
+`prd.md`. A design EP with no PRD reference reads as ungrounded — reviewers
+can't tell whether the implementation matches agreed requirements.
+
+### Reintroducing user stories
+
+User stories belong in the PRD, not the design EP. If a design EP
+restates them, it's duplicating content that will drift out of sync with
+the PRD as requirements evolve.
+
+### Unbounded scope, no alternatives
+
+A design EP with no non-goals and "Alternatives: none considered" signals
+the author hasn't scoped the boundaries of the change. Every non-trivial
+design decision should have at least one real alternative and a stated
+rejection reason.
+
+### Thin test plans
+
+"Unit and integration tests will be added" gives an implementer nothing to
+build from. Specify what's tested (validation logic, state transitions,
+error paths) and how (kind cluster, mocked backends).
+
+## Workflow
+
+### Using the `/design` skill (recommended)
+
+If you are using an AI-assisted development tool (Claude Code, Cursor, or
+similar), the `/design` workflow automates design EP creation:
+
+1. **`/design:ingest`** with your Jira ticket (after the PRD is merged) to
+   gather design context
+2. **`/design:draft`** to generate the design document from the template
+3. **`/design:publish`** to create a PR on enhancement-proposals
+
+The skill produces a design EP that follows
+[design_template.md](design_template.md) and can be reviewed with the
+`design-review` skill.
+
+### Manual workflow
+
+1. Confirm the PRD is merged in the same `enhancements/OSAC-NNNN-feature-slug/`
+   directory (see [CONTRIBUTING.md](../CONTRIBUTING.md) for the naming
+   convention)
+2. Copy the template: `cp guidelines/design_template.md enhancements/OSAC-NNNN-feature-slug/design.md`
+3. Fill out all sections, referencing the per-section guidance above
+4. Self-review against the common mistakes above
+5. Create a pull request against `main`
+
+## Review
+
+Design EPs are reviewed against four criteria: architecture (OSAC pattern
+compliance, tenant isolation, dependency clarity), feasibility
+(implementation depth, proto schemas, risk quality), scope (boundary
+clarity, PRD reference, dimension coverage), and testability (test
+strategy specificity, graduation criteria). Use the `design-review` skill
+for a detailed automated assessment before submitting your PR.
+
+## External References
+
+- [OpenShift Enhancements](https://github.com/openshift/enhancements) —
+  this template's structure and section conventions descend from OpenShift's
+  own enhancement-proposal process

--- a/guidelines/design_template.md
+++ b/guidelines/design_template.md
@@ -118,8 +118,9 @@ failure recovery, or alternative outcomes.
 
 ### API Extensions
 
-API Extensions are CRDs, admission and conversion webhooks, aggregated API servers,
-and finalizers, i.e. those mechanisms that change the API surface and behaviour.
+API Extensions are new or modified gRPC services (fulfillment-service), CRDs,
+admission and conversion webhooks, aggregated API servers, and finalizers, i.e.
+those mechanisms that change the API surface and behaviour.
 
 - Name the API extensions this enhancement adds or modifies.
 - Does this enhancement modify the behaviour of existing resources, especially those owned

--- a/guidelines/design_template.md
+++ b/guidelines/design_template.md
@@ -4,8 +4,10 @@ authors:
   - TBD
 creation-date: yyyy-mm-dd
 last-updated: yyyy-mm-dd
-tracking-link: # link to the tracking ticket (for example: Github issue) that corresponds to this enhancement
+tracking-link: # link to the tracking ticket (for example: Jira issue) that corresponds to this enhancement
   - TBD
+prd: # relative path to the PRD document for this enhancement
+  - "prd.md"
 see-also:
   - "/enhancements/this-other-neat-thing"
 replaces:
@@ -14,35 +16,41 @@ superseded-by:
   - "/enhancements/our-past-effort"
 ---
 
-> **Note:** OSAC now uses a two-document flow: a PRD (`prd.md`) for WHAT/WHY and
-> a design document (`design.md`) for HOW. New enhancements should use the
-> AI-assisted workflows in [osac-workspace](https://github.com/osac-project/osac-workspace)
-> (`/prd:ingest` → `/design:ingest`). This template is retained for reference by
-> older enhancements. See the [README](../README.md) for details.
-
 To get started with this template:
-1. **Create a directory.** Create the directory for your enhancement proposal.
-1. **Make a copy of this template.** Copy this template into the directory for
-   the proposal as `README.md`.
+1. **Create a directory.** Create a directory inside `enhancements/` using
+   the naming convention `OSAC-NNNN-feature-slug` (see
+   [CONTRIBUTING.md](../CONTRIBUTING.md)) — the same directory your `prd.md`
+   already lives in, or will live in.
+1. **Make a copy of this template.** Copy this file into that directory
+   as `design.md`.
 1. **Fill out the metadata at the top.** The embedded YAML document is
-   checked by the linter.
-1. **Fill out the "overview" sections.** This includes the Summary and
-   Motivation sections. These should be easy and explain why the community
-   should desire this enhancement.
+   checked by the linter. The `prd` field should point to the PRD file
+   in the same directory (typically `prd.md`).
+1. **Fill out the "overview" sections.** The Summary and Motivation
+   sections should be brief — detailed requirements live in the PRD.
+   Focus on the technical approach and design rationale.
+1. **Consult the author guide.** See
+   [design_guide.md](design_guide.md) for per-section authoring guidance,
+   the PRD vs design EP boundary, OSAC personas, and examples.
 1. **Create a PR.** Assign it to folks with expertise in that domain to help
    sponsor the process.
 1. **Merge after reaching consensus.** Merge when there is consensus
    that the design is complete and all reviewer questions have been
-   answered so that work can begin.  Come back and update the document
+   answered so that work can begin. Come back and update the document
    if important details (API field names, workflow, etc.) change
    during code review.
 1. **Keep all required headers.** If a section does not apply to an
-   enhancement, explain why but do not remove the section. This part
-   of the process is enforced by the linter CI job.
+   enhancement, explain why but do not remove the section — reviewers
+   and the automated EP review check for this.
 
-See ../README.md for background behind these instructions.
+**Using the `/design` skill (recommended):** If you are using an AI-assisted
+development tool (Claude Code, Cursor, or similar), use the `/design`
+workflow instead of copying this template manually. Run `/design:ingest`
+with your Jira ticket (after the PRD is merged) to start the guided flow:
+ingest, draft, publish. The skill produces a design document that follows
+this template.
 
-Start by filling out the header with the metadata for this enhancement.
+See [README.md](../README.md) for background behind these instructions.
 
 # Neat Enhancement Idea
 
@@ -53,91 +61,30 @@ part of any review.
 The YAML `title` should be lowercased and spaces/punctuation should be
 replaced with `-`.
 
-The `Metadata` section above is intended to support the creation of tooling
-around the enhancement process.
-
 ## Summary
 
-The `Summary` section is important for producing high quality
-user-focused documentation such as release notes or a development roadmap. It
-should be possible to collect this information before implementation begins in
-order to avoid requiring implementors to split their attention between writing
-release notes and implementing the feature itself.
-
-Your summary should be one paragraph long. More detail
-should go into the following sections.
+One to two sentences describing the technical approach proposed by this
+enhancement. Reference the PRD for full requirements context:
+"See [PRD](prd.md) for detailed requirements."
 
 ## Motivation
 
-This section is for explicitly listing the motivation, goals and non-goals of
-this proposal. Describe why the change is important and the benefits to users.
-
-### User Stories
-
-Detail the things that people will be able to do if this is implemented and
-what goal that allows them to achieve. In each story, explain who the actor
-is based on their role, explain what they want to do with the system,
-and explain the underlying goal they have, what it is they are going to
-achieve with this new feature.
-
-Use the standard three part formula:
-
-> "As a _role_, I want to _take some action_ so that I can _accomplish a
-goal_."
-
-Make the change feel real for users, without getting bogged down in
-implementation details.
-
-Here are some example user stories to show what they might look like:
-
-* As an OpenShift engineer, I want to write an enhancement, so that I
-  can get feedback on my design and build consensus about the approach
-  to take before starting the implementation.
-* As an OpenShift engineer, I want to understand the rationale behind
-  a particular feature's design and alternatives considered, so I can
-  work on a new enhancement in that problem space knowing the history
-  of the current design better.
-* As a product manager, I want to review this enhancement proposal, so
-  that I can make sure the customer requirements are met by the
-  design.
-* As an administrator, I want a one-click OpenShift installer, so that
-  I can easily set up a new cluster without having to follow a long
-  set of operations.
-
-In each example, the persona's goal is clear, and the goal is clearly provided
-by the capability being described.
-The engineer wants feedback on their enhancement from their peers, and writing
-an enhancement allows for that feedback.
-The product manager wants to make sure that their customer requirements are fulfilled,
-reviewing the enhancement allows them to check that.
-The administrator wants to set up his OpenShift cluster as easily as possible, and
-reducing the install to a single click simplifies that process.
-
-Here are some real examples from previous enhancements:
-* [As a member of OpenShift concerned with the release process (TRT, dev, staff engineer, maybe even PM),
-I want to opt in to pre-release features so that I can run periodic testing in CI and obtain a signal of
-feature quality.](https://github.com/openshift/enhancements/blob/master/enhancements/installer/feature-sets.md#user-stories)
-* [As a cloud-provider affiliated engineer / platform integrator / RH partner
-I want to have a mechanism to signal OpenShift's built-in operators about additional
-cloud-provider specific components so that I can inject my own platform-specific controllers into OpenShift
-to improve the integration between OpenShift and my cloud provider.](https://github.com/openshift/enhancements/blob/master/enhancements/cloud-integration/infrastructure-external-platform-type.md#user-stories)
-* [As an OpenShift cluster administrator, I want to add worker nodes to my
-existing single control-plane node cluster, so that it'll be able to meet
-growing computation demands.](https://github.com/openshift/enhancements/blob/master/enhancements/single-node/single-node-openshift-with-workers.md#user-stories)
-
-Include a story on how this proposal will be operationalized:
-life-cycled, monitored and remediated at scale.
+Restate the problem in implementation terms for technical reviewers. Describe
+the current system's limitations and why this approach is proposed. Keep brief
+— the PRD contains the full problem statement, user stories, and acceptance
+criteria. This section bridges from the PRD for readers who need implementation
+context.
 
 ### Goals
 
-Summarize the specific goals of the proposal. How will we know that
-this has succeeded?  A good goal describes something a user wants from
-their perspective, and does not include the implementation details
-from the proposal.
+Design-scoped goals that constrain the implementation approach. These are
+not product outcomes (those are in the PRD) but implementation constraints:
+e.g., "Reuse the existing controller reconciliation pattern" or "Support
+both IPv4 and dual-stack from the initial implementation."
 
 ### Non-Goals
 
-What is out of scope for this proposal? Listing non-goals helps to
+What is out of scope for this design. Listing non-goals helps to
 focus discussion and make progress. Highlight anything that is being
 deferred to a later phase of implementation that may call for its own
 enhancement.
@@ -169,41 +116,36 @@ diagram.
 Use sub-sections to explain variations, such as for error handling,
 failure recovery, or alternative outcomes.
 
-For example:
-
-**cluster creator** is a human user responsible for deploying a
-cluster.
-
-**application administrator** is a human user responsible for
-deploying an application in a cluster.
-
-1. The cluster creator sits down at their keyboard...
-2. ...
-3. The cluster creator sees that their cluster is ready to receive
-   applications, and gives the application administrator their
-   credentials.
-
-See
-https://github.com/openshift/enhancements/blob/master/enhancements/workload-partitioning/management-workload-partitioning.md#high-level-end-to-end-workflow
-and https://github.com/openshift/enhancements/blob/master/enhancements/agent-installer/automated-workflow-for-agent-based-installer.md for more detailed examples.
-
 ### API Extensions
 
 API Extensions are CRDs, admission and conversion webhooks, aggregated API servers,
-and finalizers, i.e. those mechanisms that change the OCP API surface and behaviour.
+and finalizers, i.e. those mechanisms that change the API surface and behaviour.
 
 - Name the API extensions this enhancement adds or modifies.
 - Does this enhancement modify the behaviour of existing resources, especially those owned
   by other parties than the authoring team (including upstream resources), and, if yes, how?
   Please add those other parties as reviewers to the enhancement.
 
-  Examples:
-  - Adds a finalizer to namespaces. Namespace cannot be deleted without our controller running.
-  - Restricts the label format for objects to X.
-  - Defaults field Y on object kind Z.
+## UX Alignment
 
-Fill in the operational impact of these API Extensions in the "Operational Aspects
-of API Extensions" section.
+*Skip this section if `osac-ux/libs/ui-components/src/api/v1/<resource>.ts` does not exist.*
+
+If a matching `@temp-api` file exists — whether this EP covers a new resource or
+adds/changes fields on an existing one — complete the table below. This section is
+reviewed alongside the proto design to ensure the backend ships fields the UI can
+consume without a migration pass.
+
+| UI field (`@temp-api` TypeScript) | Proto field (this EP) | Notes / deviation |
+|---|---|---|
+| `spec.fieldName` | `spec.field_name` | Direct mapping |
+| `spec.storageClass` | `spec.storage_tier_id` | Deviation: UI uses string enum; proto references StorageTier resource |
+
+List any deviations from the known anti-patterns (sub-resource actions,
+string-union storage classes, K8s-internal fields, one-time secrets, RHOAI
+operator fields). Each deviation requires a justification.
+
+After the backend ships and `pnpm gen-types` is run in osac-ux, the UI
+migration diff should be limited to the deviations documented here.
 
 ### Implementation Details/Notes/Constraints
 
@@ -213,15 +155,52 @@ a good place to talk about core concepts and how they relate. While it is useful
 to go into the details of the code changes required, it is not necessary to show
 how the code will be rewritten in the enhancement.
 
+### Security Considerations
+
+Cover authentication and authorization changes, data exposure risks, and
+input validation requirements. If the feature inherits the existing security
+model without changes, state that and explain why it is sufficient.
+
+For multi-tenant features, describe how tenant isolation is enforced
+(e.g., OPA policies, namespace scoping, annotation-based filtering).
+
+### Failure Handling and Recovery
+
+Enumerate concrete failure modes for the proposed design. For each:
+what happens, how the system recovers, and what the user observes.
+
+Cover controller reconciliation failures, API-side errors, and
+integration failures (e.g., AAP job failures, network provisioning
+timeouts). Note retry behavior and idempotency guarantees.
+
+### RBAC / Tenancy
+
+Describe role-based access rules, tenant isolation boundaries, and
+visibility constraints introduced or modified by this enhancement.
+
+For new resources, specify the required tenant isolation metadata:
+`osac.openshift.io/tenant` and `osac.openshift.io/owner-reference`
+annotations, and how they are enforced.
+
+If no RBAC or tenancy changes are required, state so with brief
+justification.
+
+### Observability and Monitoring
+
+List new metrics, Kubernetes events, alerts, or structured log events
+introduced by this enhancement. Describe what each metric measures and
+what threshold would indicate a problem.
+
+If no new observability changes are needed, state: "No new observability
+changes. Existing monitoring mechanisms apply."
+
 ### Risks and Mitigations
 
 What are the risks of this proposal and how do we mitigate. Think broadly. For
-example, consider both security and how this will impact the larger OKD
+example, consider both security and how this will impact the larger
 ecosystem.
 
 How will security be reviewed and by whom?
-
-How will UX be reviewed and by whom?
 
 Consider including folks that also work outside your immediate sub-project.
 
@@ -236,7 +215,7 @@ we might not want to undertake this proposal, and how do we overcome them?
 
 Does this proposal implement a behavior that's new/unique/novel? Is it poorly
 aligned with existing user expectations?  Will it be a significant maintenance
-burden?  Is it likely to be superceded by something else in the near future?
+burden?  Is it likely to be superseded by something else in the near future?
 
 ## Alternatives (Not Implemented)
 
@@ -256,17 +235,29 @@ to implement the design.  For instance,
 
 **Note:** *Section not required until targeted at a release.*
 
-Consider the following in developing a test plan for this enhancement:
-- Will there be e2e and integration tests, in addition to unit tests?
-- How will it be tested in isolation vs with other components?
-- What additional testing is necessary to support managed OpenShift service-based offerings?
+List concrete test scenarios for each test type, with enough detail that an
+implementer knows what to build.
 
-No need to outline all of the test cases, just the general strategy. Anything
-that would count as tricky in the implementation and anything particularly
-challenging to test should be called out.
+### Unit Tests
 
-All code is expected to have adequate tests (eventually with coverage
-expectations).
+List specific behaviors to unit-test (e.g., "validation rejects overlapping
+CIDRs", "status condition transitions from Pending to Provisioned").
+
+### Integration Tests
+
+List scenarios that exercise the component with its real dependencies in a
+kind cluster (e.g., "creating a VirtualNetwork reconciles the namespace and
+network resources", "deleting a parent resource cascades to children").
+Integration tests are the primary test layer for controller and server logic.
+
+### E2E Tests
+
+List user-facing workflows that span multiple components (e.g., "tenant
+creates a ComputeInstance attached to a Subnet and reaches it via PublicIP").
+Reference osac-test-infra pytest patterns.
+
+Call out anything tricky to test: CIDR parsing, dual-stack, concurrent
+reconciliation, AAP job coordination, etc.
 
 ## Graduation Criteria
 
@@ -366,46 +357,14 @@ Describe how to
 - detect the failure modes in a support situation, describe possible symptoms (events, metrics,
   alerts, which log output in which component)
 
-  Examples:
-  - If the webhook is not running, kube-apiserver logs will show errors like "failed to call admission webhook xyz".
-  - Operator X will degrade with message "Failed to launch webhook server" and reason "WehhookServerFailed".
-  - The metric `webhook_admission_duration_seconds("openpolicyagent-admission", "mutating", "put", "false")`
-    will show >1s latency and alert `WebhookAdmissionLatencyHigh` will fire.
-
 - disable the API extension (e.g. remove MutatingWebhookConfiguration `xyz`, remove APIService `foo`)
 
   - What consequences does it have on the cluster health?
-
-    Examples:
-    - Garbage collection in kube-controller-manager will stop working.
-    - Quota will be wrongly computed.
-    - Disabling/removing the CRD is not possible without removing the CR instances. Customer will lose data.
-      Disabling the conversion webhook will break garbage collection.
-
   - What consequences does it have on existing, running workloads?
-
-    Examples:
-    - New namespaces won't get the finalizer "xyz" and hence might leak resource X
-      when deleted.
-    - SDN pod-to-pod routing will stop updating, potentially breaking pod-to-pod
-      communication after some minutes.
-
   - What consequences does it have for newly created workloads?
-
-    Examples:
-    - New pods in namespace with Istio support will not get sidecars injected, breaking
-      their networking.
 
 - Does functionality fail gracefully and will work resume when re-enabled without risking
   consistency?
-
-  Examples:
-  - The mutating admission webhook "xyz" has FailPolicy=Ignore and hence
-    will not block the creation or updates on objects when it fails. When the
-    webhook comes back online, there is a controller reconciling all objects, applying
-    labels that were not applied during admission webhook downtime.
-  - Namespaces deletion will not delete all objects in etcd, leading to zombie
-    objects when another namespace with the same name is created.
 
 ## Infrastructure Needed [optional]
 

--- a/guidelines/prd_guide.md
+++ b/guidelines/prd_guide.md
@@ -1,0 +1,182 @@
+# PRD Author Guide
+
+This guide explains how to write a Product Requirements Document (PRD) for
+OSAC. It covers what a PRD is, how it differs from a design enhancement
+proposal (EP), the personas to write for, and common mistakes to avoid.
+
+## What is a PRD?
+
+A PRD describes **what** the product must do and **why**, from the user's
+perspective. It defines user-facing capabilities, outcomes, and success
+criteria. It does not describe how the system implements those capabilities.
+
+A PRD answers:
+- Who is affected?
+- What pain exists today?
+- What can users do after this ships?
+- How will we know it works?
+
+## PRD vs Design EP
+
+OSAC uses a two-stage enhancement process. The PRD comes first and defines
+the requirements. The design EP follows and specifies the implementation.
+
+| | **PRD** (`prd.md`) | **Design EP** (`design.md`) |
+|---|---|---|
+| **Audience** | Product managers, reviewers, stakeholders | Engineers, architects |
+| **Focus** | User-facing capabilities and outcomes | Architecture, API fields, reconciliation logic |
+| **Content** | User stories, in/out of scope, success criteria | CRD schemas, controller design, playbook parameters |
+| **Lifecycle** | Merged before design work begins | Merged before implementation begins |
+
+**Litmus test:** Could a product manager verify this by using the product?
+If yes, it belongs in the PRD. If it requires reading source code, it
+belongs in the design EP.
+
+### What belongs where
+
+| PRD (user-observable) | Design EP (implementation) |
+|---|---|
+| "Tenants can create persistent volumes on CaaS clusters" | CRD fields, conditions, finalizers |
+| "Storage readiness is visible on the cluster status" | Controller reconcile logic |
+| "Clusters are reachable without manual networking setup" | Playbook names, API schemas |
+| "Admins can see storage readiness across all tenants" | Helm/installer changes |
+
+### Platform vocabulary is not design leakage
+
+Referencing OSAC platform terms by name is acceptable context in a PRD:
+
+- **Platform:** OpenShift, Kubernetes, Hosted Control Planes
+- **Services:** BMaaS, CaaS, VMaaS, MaaS, Enclave
+- **User-facing resources:** ClusterOrder, ComputeInstance, Tenant,
+  VirtualNetwork, Subnet, SecurityGroup, PublicIPPool, PublicIP,
+  StorageClass
+- **Tools:** kubectl, grpcurl, Helm
+
+Naming these is fine. Mandating which internal component solves a problem
+or describing controller logic is not.
+
+## OSAC Personas
+
+Use these exact names in user stories. Every PRD should identify which
+personas are affected.
+
+| Persona | Role | Examples |
+|---------|------|----------|
+| **Cloud Provider Admin** | Works for the cloud provider. Handles tenant onboarding, sets quotas, manages global catalogs. Super-user who can see all tenants. | Tenant onboarding, quota management, global template catalogs |
+| **Cloud Infrastructure Admin** | Works for the cloud provider. Manages core infrastructure: network, firewall, compute, storage. Integrates control plane with local infrastructure. | Network classes, IP pools, storage tiers, DNS, Netris/VAST/ESI integration |
+| **Tenant Admin** | Works for the tenant organization. Manages their org's config, users, IDP, quotas, and org-specific catalogs. Can only see their own organization. | Create networking objects, manage tenant resources, onboard users |
+| **Tenant User** | Works for the tenant organization. Self-service provisions cloud resources, manages full lifecycle. Prefers click-ops but wants API/CLI for automation. | Order machines/clusters/VMs, manage instance lifecycle, view quota |
+
+## Writing Good User Stories
+
+Use the standard formula:
+
+> As a **{persona}**, I want **{capability}** so that **{outcome}**.
+
+Ground each story in concrete artifacts, workflows, or scenarios. Name the
+specific things users interact with.
+
+### Good examples
+
+- "As a Tenant User, I want to retrieve cluster kubeconfig and admin
+  password via the secrets API, so that I can access my provisioned
+  cluster without asking an administrator."
+- "As a Cloud Infrastructure Admin, I want to configure a storage backend
+  once per deployment, so that tenants get persistent storage on new
+  clusters automatically."
+- "As a Tenant Admin, I want to store OIDC client secrets for IDP
+  integration, so that my team's identity provider credentials are
+  centrally managed."
+
+### Bad examples
+
+- "As a user, I want to create and manage secrets." (Too vague. Which
+  secrets? SSH keypairs? OIDC credentials? Kubeconfigs? "User" is not an
+  OSAC persona.)
+- "As a Tenant User, I want the controller to reconcile storage within
+  30 seconds." (Design leakage. Users do not observe controllers.)
+- "As an admin, I want storage support." (Vague persona, vague
+  capability. Which admin? What does "support" mean?)
+
+### Tips
+
+- One capability per story. If a story has "and", split it.
+- Name the artifacts: "SSH keypairs and OIDC client secrets" not "secrets."
+- State the outcome in terms of what the user can then do, not what the
+  system does internally.
+
+## Common Mistakes
+
+### Design leakage
+
+The most common PRD failure mode. Symptoms:
+
+- Naming controllers, reconcilers, or finalizers
+- Describing playbook parameters or AAP job templates
+- Specifying internal API conditions or environment variables
+- Mandating which component solves the problem
+
+**Fix:** Describe the user-observable outcome. "Storage is automatically
+available on new clusters" instead of "The storage controller invokes
+osac-create-tenant-cluster-storage with provisioning_target=hcp_data_plane."
+
+### Vague requirements
+
+- "Storage should be available" (which clusters? what does "available"
+  mean to the user?)
+- "Networking should work" (which networking objects? for which services?)
+
+**Fix:** Be specific about what users can do and see. "Tenants can create
+persistent volumes using StorageClasses on their CaaS cluster within
+5 minutes of the cluster becoming ready."
+
+### Missing personas
+
+A PRD that names no personas has an unclear audience. Every user story
+must use an OSAC persona name from the table above.
+
+### Bundling unrelated capabilities
+
+A PRD that covers storage provisioning, networking policy enforcement,
+and cluster monitoring is three features, not one. Test independence:
+could each ship on its own and provide value? If yes, split them.
+
+## Workflow
+
+### Using the `/prd` skill (recommended)
+
+If you are using an AI-assisted development tool (Claude Code, Cursor, or
+similar), the `/prd` workflow automates PRD creation:
+
+1. **`/prd:ingest`** with your Jira ticket to gather requirements
+2. **`/prd:clarify`** to resolve ambiguities through Q&A
+3. **`/prd:draft`** to generate the PRD from the template
+4. **`/prd:publish`** to create a PR on enhancement-proposals
+
+The skill produces a PRD that follows the
+[prd_template.md](prd_template.md) and can be reviewed with `/prd-review`.
+
+### Manual workflow
+
+1. Create a directory: `mkdir enhancements/OSAC-NNNN-feature-slug/` (see
+   [CONTRIBUTING.md](../CONTRIBUTING.md) for the naming convention)
+2. Copy the template: `cp guidelines/prd_template.md enhancements/OSAC-NNNN-feature-slug/prd.md`
+3. Fill out all sections
+4. Self-review using `/prd-review` if available, or check against the
+   common mistakes above
+5. Create a pull request against `main`
+6. After the PRD is merged, create the design EP (`design.md`) in the
+   same directory using [guidelines/design_template.md](design_template.md)
+   — see [design_guide.md](design_guide.md) for authoring guidance
+
+## Review
+
+PRDs are reviewed against five criteria: clear user-facing need, business
+justification, freedom from design leakage, focused scope, and testable
+requirements. Use `/prd-review` for a detailed automated assessment before
+submitting your PR.
+
+## External References
+
+- [Perforce: How to Write a PRD](https://www.perforce.com/blog/alm/how-write-product-requirements-document-prd)
+- [Atlassian: Agile Product Requirements](https://www.atlassian.com/agile/product-management/requirements)

--- a/guidelines/prd_guide.md
+++ b/guidelines/prd_guide.md
@@ -172,7 +172,7 @@ The skill produces a PRD that follows the
 ## Review
 
 PRDs are reviewed against five criteria: clear user-facing need, business
-justification, freedom from design leakage, focused scope, and testable
+justification, freedom from design leakage, focused scope, and verifiable
 requirements. Use `/prd-review` for a detailed automated assessment before
 submitting your PR.
 

--- a/guidelines/prd_template.md
+++ b/guidelines/prd_template.md
@@ -1,3 +1,5 @@
+# PRD Template
+
 To get started with this template:
 1. **Create a directory.** Create a directory inside `enhancements/` using
    the naming convention `OSAC-NNNN-feature-slug`, where `OSAC-NNNN` is the

--- a/guidelines/prd_template.md
+++ b/guidelines/prd_template.md
@@ -1,0 +1,66 @@
+To get started with this template:
+1. **Create a directory.** Create a directory inside `enhancements/` using
+   the naming convention `OSAC-NNNN-feature-slug`, where `OSAC-NNNN` is the
+   Jira **Feature**-level key exactly as it appears in Jira (no
+   zero-padding), followed by a kebab-case slug derived from the feature
+   summary. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full
+   convention and examples.
+1. **Make a copy of this template.** Copy this file into your directory
+   as `prd.md`.
+1. **Fill out the metadata** at the top (the table below).
+1. **Fill out each section.** If a section does not apply, mark it `N/A`
+   rather than removing it.
+1. **Create a pull request** against the main branch of this repository.
+1. After the PRD is merged, create the design EP (`design.md`) in the
+   same directory. See [design_template.md](design_template.md).
+
+**Using the `/prd` skill (recommended):** If you are using an AI-assisted
+development tool (Claude Code, Cursor, or similar), use the `/prd` workflow
+instead of copying this template manually. Run `/prd:ingest` with your Jira
+ticket to start the guided flow: ingest, clarify, draft, publish. The skill
+produces a PRD that follows this template and publishes it as a PR.
+
+For detailed authoring guidance, PRD vs design EP boundaries, personas,
+and good/bad examples, see [prd_guide.md](prd_guide.md).
+
+# {Title}
+
+| Field       | Value   |
+|-------------|---------|
+| Author(s)   |         |
+| Jira        |         |
+| Date        |         |
+
+## Problem Statement
+
+{Who is affected, what pain exists today, and what happens if this is not addressed?}
+
+## In Scope
+
+- {What this work delivers}
+
+## Out of Scope
+
+- {Explicitly excluded to prevent scope creep}
+
+## User Stories
+
+{Group by persona or workflow. Ground each story in explicit use cases — name
+the concrete artifacts, workflows, or scenarios, not generic capabilities.
+"I want to store SSH keypairs and OIDC client secrets" is actionable;
+"I want to create and manage secrets" is too vague to review. See
+[prd_guide.md](prd_guide.md) for OSAC personas and more good/bad examples.}
+
+### {Persona or workflow name}
+
+- As a {persona}, I want {capability} so that {outcome}.
+
+## Assumptions
+<!-- Optional: omit if no unverified assumptions underpin the requirements -->
+
+- {Statement believed to be true but not yet verified}
+
+## Dependencies
+<!-- Optional: omit if source material identifies no external dependencies -->
+
+- **{Dependency name}:** {What it provides and any ordering constraints}


### PR DESCRIPTION
## [OSAC-3057](https://redhat.atlassian.net/browse/OSAC-3057): Make enhancement-proposals the canonical home for PRD and EP templates/guides

**Jira:** https://redhat.atlassian.net/browse/OSAC-3057
**Story type:** Documentation + CI (sub-task; docs changes plus a small
follow-up CI fix — see below — so the automated EP review bot can
actually resolve the new canonical paths)

### Summary

Makes `guidelines/` in this repo the canonical, actively-synced home for
all four PRD/design-EP authoring artifacts, replacing a stale/deprecated
template and closing the gap left by closed-but-unmerged
osac-project/enhancement-proposals#125. Supersedes and ports content
from #125 — that PR is closed without merging; its prose is preserved
here rather than lost.

Also folds in a companion CI fix (originally opened as #157, now closed
in favor of landing it here — see "CI fix" below): once
`skills/prd-review/SKILL.md`/`skills/design-review/SKILL.md` in
`osac-workspace` ([OSAC-3059](https://redhat.atlassian.net/browse/OSAC-3059))
resolve templates/guides from `guidelines/` instead of local
`osac-workspace` copies, this repo's own `ep-review.yml` bot needs those
same paths available in its review sandbox — otherwise it silently
falls back to a stale vendored template with no hard CI failure to
signal the gap. Since that gap is *created by* this PR's file move,
fixing it here (rather than in a separately-merged PR) closes the
window entirely instead of requiring careful merge ordering.

### Changes

- **`guidelines/design_template.md`** — renamed from `enhancement_template.md`
  and rewritten to match `osac-workspace/.design/templates/design.md`'s
  structure exactly (verified byte-for-byte identical body content).
  Removes the old deprecation note and the stale `User Stories`
  requirement; adds `UX Alignment`, `Security Considerations`, and
  `RBAC / Tenancy` sections; restructures `Test Plan` into
  Unit/Integration/E2E.
- **`guidelines/prd_template.md`** (new) — current canonical PRD structure
  from `osac-workspace/.prd/templates/prd.md` (verified matching, save
  for one intentional cross-link), wrapped with getting-started
  instructions using this repo's `OSAC-NNNN-feature-slug` convention.
- **`guidelines/prd_guide.md`** (new) — PRD authoring guidance ported
  from #125 (PRD vs. design-EP boundary, OSAC personas, good/bad
  user-story examples), corrected to the current naming convention.
- **`guidelines/design_guide.md`** (new) — design-EP authoring guidance
  mirroring `prd_guide.md`'s structure, condensed from
  `osac-workspace/.design/templates/section-guidance.md`. #125 never
  added an EP-side guide; this closes that asymmetry.
- **`README.md`** — adds a "How do I create a PRD?" section and
  reconciles the enhancement-proposal section's template/guide
  cross-references and naming examples.
- **`AGENTS.md`** — points AI agents at the new guides for
  review/manual-fallback use, without contradicting the existing
  "use the osac-workspace AI workflows" directive.
- **`.gitignore`** — ignores `/implement` workflow artifacts (a
  pre-existing gap in this repo; every other OSAC component repo
  already has this rule).
- **`.github/workflows/ep-review.yml`** (CI fix) — stages `guidelines/`
  and `enhancements/` from the repo this job already checks out (at
  `base_ref`) into `/opt/skills/enhancement-proposals`, so
  `skills/prd-review`/`skills/design-review` can resolve the new
  canonical paths. Reuses the existing checkout rather than adding a
  second, independent clone of a mutable ref.
- **`.github/scripts/ep_review.py`** (CI fix) — excludes the PR's own
  enhancement directory from the staged `enhancements/` reference
  library before running each skill, so an update to an existing EP
  never sees its own stale pre-PR version cited by design-review's
  "Comparison with Similar Designs" calibration step as if it were a
  separate past precedent.

### Open items flagged for reviewer input (not pre-decided)

- **Filename rename** (`enhancement_template.md` → `design_template.md`):
  the ticket's stated default was to keep the old name to minimize diff
  to `design-review`/`ep_hooks.py`/older EPs. That rationale is now
  stale — none of those three actually reference the file anymore
  (confirmed via repo-wide grep; [OSAC-2946](https://redhat.atlassian.net/browse/OSAC-2946) already removed both live
  references). Renamed now for `prd_template.md`/`design_template.md`
  naming symmetry. Flagging explicitly in case anyone disagrees.
- **`ep_hooks.py` template-loading resumption** — the ticket calls this
  "nice-to-have, not blocking." Deliberately deferred; not attempted
  here, since it would touch the AI-review pipeline in a docs-only PR.

### Testing

- **Unit/Integration tests:** N/A for the `guidelines/`/`README.md`/
  `AGENTS.md`/`.gitignore` documentation changes — documentation-only
  repo, no test suite exists for those files.
- **CI fix testing:** `.github/scripts/ep_review.py`'s two new helper
  functions (`pr_enhancement_slugs`, `exclude_own_slug_from_reference_library`)
  were exercised with an inline script covering: (1) slug extraction from
  a realistic changed-files list, (2) the PR's own slug is removed from a
  staged reference library while an unrelated slug survives, (3) no
  exception when `enhancements/` isn't present. `python3 -m py_compile`
  passes. `pre-commit run --files .github/workflows/ep-review.yml
  .github/scripts/ep_review.py` passes (yamllint + standard hooks).
- **Coverage:** `pre-commit run --all-files` passes clean (trailing
  whitespace, `check-ep-naming`, yamllint, etc.). `design_template.md`'s
  body verified byte-for-byte identical to
  `osac-workspace/.design/templates/design.md`. `prd_template.md`
  verified matching `osac-workspace/.prd/templates/prd.md` save for one
  intentional cross-link. No dangling relative links across any of the
  6 changed/new documentation files. Full-branch diff reviewed by an
  independent pass (findings fixed: missing `Assisted-by:` trailers, a
  PRD-workflow step-count inconsistency between two sections of
  `README.md`, and a branch-naming convention fix).
- **Why no bot review comment will appear on *this* PR:** this repo's
  automated `ep-review.yml` AI-review bot only triggers on changes to
  `**/prd.md`/`**/design.md`/`enhancements/**/README.md` — it reviews
  EPs against these templates, not the templates themselves, and this
  PR touches neither. That's expected, not a gap in this PR's own
  validation. The CI fix above is precisely what makes that bot capable
  of finding these templates on *future* PRs that do touch a `prd.md`
  or `design.md`.

### Acceptance Criteria

- [x] AC-1: All four guideline files (`prd_template.md`, `prd_guide.md`,
      `design_template.md`, `design_guide.md`) live in this repo as
      canonical, actively-synced copies with no legacy/deprecated framing
- [x] AC-2: `design_template.md` matches `design.md`'s structure exactly
      — no drift, no stale `User Stories` requirement
- [x] AC-3: PR #125 closed; its prose ported here instead of lost
- [ ] AC-4: Paired `osac-workspace` sub-task ([OSAC-3059](https://redhat.atlassian.net/browse/OSAC-3059)) repoints the
      `/prd`/`/design` skills at these files — **out of scope for this
      PR**, tracked separately, blocked until this PR merges
- [x] (follow-up, not a formal AC) `ep-review.yml`'s review job can
      resolve `guidelines/`/`enhancements/` — closes what was tracked as
      #157, folded in here instead


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive PRD and Design Enhancement Proposal author guides.
  - Added a new PRD template with standardized metadata, user stories, scope, and workflow instructions.
  - Expanded README guidance for AI-assisted and manual PRD creation.
  - Updated contributor instructions to include a clarification step before drafting.
  - Refreshed the design template with improved UX, security, testing, observability, and support sections.

- **Workflow Improvements**
  - Enhanced design-review preparation and reference handling for more relevant review results.
  - Added staging for proposal guidelines and enhancement content during reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->