### PR TITLE
OSAC-3145: PRD: Metering for Networking Resources

### DIFF
--- a/enhancements/OSAC-3145-metering-networking/prd.md
+++ b/enhancements/OSAC-3145-metering-networking/prd.md
@@ -90,7 +90,7 @@ ExternalIP resources support all three services and can be attached to ComputeIn
 
 This section defines the metering units and measurement approach for networking resources, extending the usage measurement model from [Part 1](/enhancements/metering-and-usage-tracking/prd.md). Downstream systems (cost management, billing) consume this usage data and apply their own pricing — rate schedules are outside the scope of metering.
 
-Each networking resource type has a flat allocation meter. Usage is queryable by resource type, region, tenant, and project; VirtualNetworks additionally use network class, ExternalIPs use IP family and attachment status (see CAP-2 and CAP-3).
+Each networking resource type has a flat allocation meter. Usage is queryable by resource type, region, tenant, and project; VirtualNetworks additionally use network class; ExternalIPs additionally use IP family and attachment status (see CAP-2 and CAP-3).
 
 | Resource | Meter | Unit | Example (30 days) |
 |----------|-------|------|-------------------|
@@ -104,7 +104,7 @@ Each networking resource type has a flat allocation meter. Usage is queryable by
 
 - [ ] Each tenant-facing networking resource (VirtualNetwork, Subnet, SecurityGroup, ExternalIP, NATGateway) generates allocation usage data from READY/ALLOCATED state to deletion
 - [ ] An allocated-but-unattached ExternalIP generates usage data
-- [ ] Networking usage can be broken down by resource type, network class, IP family, region, tenant, and project
+- [ ] Networking usage can be broken down by resource type, region, tenant, and project; VirtualNetworks additionally expose network class; IP resources expose IP family; ExternalIPs expose attachment status
 - [ ] Networking resources attached to a parent resource (ExternalIPs to ComputeInstances/Clusters/BareMetalInstances, Subnets via network attachments) can be attributed to the parent in a unified usage view
 - [ ] Networking usage data is available after deploying the metering update without provisioning additional infrastructure
 - [ ] Networking usage data maintains per-second granularity, deduplication, and retention consistent with Part 1 metering
@@ -145,11 +145,8 @@ This PRD is part of the Metering Part 2 family:
 
 ## Provenance
 
-Authored: respond @ prd 0.6.3 - 6ec8c11, workspace main @ 78853cd
-Final: respond @ prd 0.7.1 - b8b3f86, workspace main @ 3c46f33
+Committed: commit @ prd 0.7.1 - b8b3f86, workspace prd/OSAC-3145 @ 2c5bc7d (50 behind origin/main, dirty)
 
-> Context changed between respond and respond.
+> Authoring phases not recorded this session (commit-time snapshot only).
 
-> This document's phase history does not include an initial /draft — structure was not verified against the template from origin.
-
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"3c46f33","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["respond","respond"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"2c5bc7d (dirty)","source_repo_branch":"prd/OSAC-3145","commits_behind_main":50,"commits_ahead_main":8,"main_ref":"main","phases":["commit","commit","commit","commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-3145-metering-networking/prd.md
+++ b/enhancements/OSAC-3145-metering-networking/prd.md
@@ -1,0 +1,128 @@
+# Metering and Usage Tracking — Part 2c: Networking
+
+| Field       | Value                |
+|-------------|----------------------|
+| Author(s)   | masayag@redhat.com   |
+| Jira        | [OSAC-3145](https://redhat.atlassian.net/browse/OSAC-3145) |
+| Date        | 2026-07-26           |
+
+## Glossary
+
+Terms defined in the [Part 1 PRD](/enhancements/metering-and-usage-tracking/prd.md) apply here. Additional terms:
+
+| Term | Definition |
+|------|-----------|
+| **Allocation metering** | Metering that runs for the duration a resource exists (creation to deletion), regardless of whether the resource is actively in use. Reflects the provider's physical capacity cost. |
+| **Network class** | A provider-defined network backend configuration that determines VirtualNetwork behavior and pricing. |
+
+## 1. Problem Statement
+
+OSAC provisions networking resources — virtual networks, subnets, security groups, public IPs, external IPs, NAT gateways — but has no mechanism to track their consumption over time. These resources consume provider capacity from the moment they are provisioned until deletion, regardless of whether they are actively carrying traffic. A public IP consumes address pool space whether it is attached to a resource or not — the provider's pool is finite and each allocation reduces availability. A VirtualNetwork consumes backend network configuration and VLAN allocation from creation.
+
+Without metering for these resources, Cloud Provider Admins have no usage data to account for the networking infrastructure tenants hold, and Tenant Admins have no visibility into their networking footprint across projects.
+
+## 2. In Scope
+
+- Networking resource allocation metering — metering for VirtualNetworks, Subnets, SecurityGroups, PublicIPs, ExternalIPs, NATGateways, and their attachments from READY/ALLOCATED state to deletion
+- Unattached IP metering — PublicIPs and ExternalIPs generate usage data regardless of attachment status
+- Parent-child attribution — extending [Part 1](/enhancements/metering-and-usage-tracking/prd.md) CAP-11 and CAP-12 so that PublicIPs and Subnets attached to VMs can be attributed to the parent resource in a unified usage view
+
+## 3. Out of Scope
+
+- BMaaS metering — tracked separately ([OSAC-2506](https://redhat.atlassian.net/browse/OSAC-2506))
+- Storage metering — tracked separately ([OSAC-3141](https://redhat.atlassian.net/browse/OSAC-3141))
+- Network bandwidth metering (ingress/egress traffic) — tracked separately ([OSAC-3149](https://redhat.atlassian.net/browse/OSAC-3149))
+- Costing, billing, quota enforcement, and budget alerts — deferred to a separate PRD
+- Workload-level metering inside tenant environments
+
+## 4. User Stories
+
+### Cloud Provider Admin
+
+- As a Cloud Provider Admin, I want to view networking resource usage across all tenants broken down by resource type (VirtualNetwork, PublicIP, NATGateway), so that I can track the network infrastructure each tenant consumes.
+
+### Cloud Infrastructure Admin
+
+- As a Cloud Infrastructure Admin, I want VirtualNetwork usage to be automatically grouped by the network classes I have configured in OSAC, so that different network backends (e.g., high-performance DPDK, standard OVN) can carry different rates — without requiring a separate registration step in the metering system.
+- As a Cloud Infrastructure Admin, I want to add meters for new networking resource types (e.g., LoadBalancer, VPN Gateway) via configuration without redeployment, extending Part 1 CAP-6 to networking resources.
+
+### Tenant Admin
+
+- As a Tenant Admin, I want to view my organization's networking resource usage broken down by project, including the count and duration of VirtualNetworks, PublicIPs, and NATGateways, so that I can attribute networking costs to the teams that provisioned them.
+
+### Tenant User
+
+- As a Tenant User, I want to view networking resource usage for the projects I belong to, including PublicIP allocation duration and NATGateway uptime, so that I can understand the networking costs of my deployments.
+
+## 5. Capabilities
+
+### 5.1 Networking Resource Allocation Metering
+
+- **CAP-1:** Tenant-facing networking resources (VirtualNetwork, Subnet, SecurityGroup, PublicIP, ExternalIP, NATGateway, and their attachments) are metered on an allocation basis. Usage accrues from the point the resource reaches READY or ALLOCATED state until deletion.
+- **CAP-2:** Networking usage is queryable by resource type, network class (for VirtualNetworks), IP family (IPv4/IPv6 for IP resources), region, tenant, and project.
+
+### 5.2 Unattached IP Metering
+
+- **CAP-3:** PublicIPs and ExternalIPs are metered regardless of whether they are attached to a resource. An allocated-but-unattached IP consumes address pool space that other tenants cannot use — the provider's pool is finite and each allocation reduces availability. Metering unattached IPs incentivizes tenants to release addresses they are not using, similar to how AWS charges for Elastic IPs that are not associated with a running instance. The `attached` status is included as a queryable dimension so providers can apply differential rates if desired (e.g., charge more for unattached IPs to encourage release).
+
+### 5.3 Cross-cutting
+
+- **CAP-4:** Networking meters are additive to the Part 1 metering deployment and require no separate infrastructure. All networking meters use the same per-second granularity, deduplication, and retention requirements as Part 1 (CAP-4, CAP-15, CAP-16).
+
+## 6. Charge Calculation Model
+
+OSAC provides usage data. The provider applies their own price schedule to generate charges. This section defines the metering units and formulas for networking resources, extending the charge calculation model from [Part 1](/enhancements/metering-and-usage-tracking/prd.md).
+
+Each networking resource type has a flat allocation meter. Resource type and network class (for VirtualNetworks) are the pricing dimensions.
+
+| Resource | Meter | Formula | Example (30 days) |
+|----------|-------|---------|-------------------|
+| VirtualNetwork | resource-seconds | duration × rate/s | 2592000 × $0.000005 = $12.96 |
+| Subnet | resource-seconds | duration × rate/s | 2592000 × $0.000001 = $2.59 |
+| PublicIP (IPv4) | resource-seconds | duration × rate/s | 2592000 × $0.000001 = $2.59 |
+| ExternalIP (IPv4) | resource-seconds | duration × rate/s | 2592000 × $0.000001 = $2.59 |
+| PublicIPAttachment | resource-seconds | duration × rate/s | 2592000 × $0.0000005 = $1.30 |
+| ExternalIPAttachment | resource-seconds | duration × rate/s | 2592000 × $0.0000005 = $1.30 |
+| NATGateway | resource-seconds | duration × rate/s | 2592000 × $0.00001 = $25.92 |
+| SecurityGroup | resource-seconds | duration × rate/s | 2592000 × $0.0000001 = $0.26 |
+
+## 7. Acceptance Criteria
+
+- [ ] Each tenant-facing networking resource (VirtualNetwork, Subnet, SecurityGroup, PublicIP, ExternalIP, NATGateway) generates allocation usage data from READY/ALLOCATED state to deletion
+- [ ] An allocated-but-unattached PublicIP generates usage data
+- [ ] Networking usage can be broken down by resource type, network class, IP family, region, tenant, and project
+- [ ] PublicIPs and Subnets attached to a VM can be attributed to the parent resource in a unified usage view
+- [ ] Networking meters are additive to the Part 1 metering deployment and require no separate infrastructure
+- [ ] All Part 1 cross-cutting acceptance criteria (per-second granularity, deduplication, retention, independent deployment) apply to networking meters
+
+## 8. Assumptions
+
+- Part 1 metering infrastructure is deployed and operational.
+- Allocation-based metering is supported by the Part 1 metering infrastructure without architectural changes — allocation meters use different start/stop state semantics.
+
+## 9. Dependencies
+
+- **Part 1 metering infrastructure:** The metering infrastructure established by [Part 1](/enhancements/metering-and-usage-tracking/prd.md) is a prerequisite. Part 2c extends but does not replace it.
+
+## 10. Risks
+
+### 10.1 Part 1 metering infrastructure not yet built
+
+- **Owner:** OSAC platform team
+- **Mitigation:** All Part 2c meters depend on the metering infrastructure (event pipeline, provider adapters) established by Part 1 (OSAC-985). Part 2c implementation cannot begin until Part 1 infrastructure is deployed.
+
+## 11. Open Questions
+
+### 11.1 Should VirtualNetwork metering start at PENDING or READY?
+
+- **Owner:** OSAC platform team
+- **Impact:** CAP-1. The current model starts metering at READY/ALLOCATED because that is when the resource is usable by the tenant. However, PENDING resources may already consume backend infrastructure (network configuration, VLAN allocation). Starting at PENDING aligns with the BMaaS allocation model (metering from provisioning start). Starting at READY aligns with what the tenant can observe and use. This applies to all networking resources with a PENDING-to-READY transition.
+
+## Related PRDs
+
+This PRD is part of the Metering Part 2 family:
+
+- **Part 2a: BMaaS** — [OSAC-2506](https://redhat.atlassian.net/browse/OSAC-2506)
+- **Part 2b: Storage** — [OSAC-3141](https://redhat.atlassian.net/browse/OSAC-3141)
+- **Part 2c: Networking** — this document (OSAC-3145)
+- **Part 2d: Network Bandwidth** — [OSAC-3149](https://redhat.atlassian.net/browse/OSAC-3149)

--- a/enhancements/OSAC-3145-metering-networking/prd.md
+++ b/enhancements/OSAC-3145-metering-networking/prd.md
@@ -146,3 +146,13 @@ This PRD is part of the Metering Part 2 family:
 - **Part 2b: Storage** — [OSAC-3141](https://redhat.atlassian.net/browse/OSAC-3141)
 - **Part 2c: Networking** — this document (OSAC-3145)
 - **Part 2d: Network Bandwidth** — [OSAC-3149](https://redhat.atlassian.net/browse/OSAC-3149)
+
+---
+
+## Provenance
+
+Committed: commit @ prd 0.6.0 - 139e6c1, workspace prd/OSAC-3145 @ 6d766ff (dirty)
+
+> Authoring phases not recorded this session (commit-time snapshot only).
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.6.0","ai_workflows":"139e6c1","source_repo":"6d766ff (dirty)","source_repo_branch":"prd/OSAC-3145","commits_behind_main":0,"commits_ahead_main":2,"main_ref":"main","phases":["commit","commit"],"authoring_modes":["skill"],"context_changed":true} -->

--- a/enhancements/OSAC-3145-metering-networking/prd.md
+++ b/enhancements/OSAC-3145-metering-networking/prd.md
@@ -34,15 +34,14 @@ Networking resources are service-agnostic — a VirtualNetwork or Subnet is mete
 | SecurityGroup | Yes | Yes | Yes |
 | NATGateway | Yes | Yes | Yes |
 | ExternalIP | Yes | Yes | Yes |
-| ExternalIPAttachment | Yes (ComputeInstance) | Yes (Cluster) | Yes (BareMetalInstance) |
 
-ExternalIP resources support all three services — `ExternalIPAttachment` targets ComputeInstance, Cluster, and BareMetalInstance.
+ExternalIP resources support all three services and can be attached to ComputeInstances, Clusters, and BareMetalInstances. Attachment status is tracked as a queryable dimension on the ExternalIP meter, not as a separately metered resource.
 
 ### 2.2 Capabilities
 
-- Networking resource allocation metering — metering for VirtualNetworks, Subnets, SecurityGroups, ExternalIPs, NATGateways, and their attachments from READY/ALLOCATED state to deletion
-- Unattached IP metering — ExternalIPs generate usage data regardless of attachment status
-- Parent-child attribution — extending [Part 1](/enhancements/metering-and-usage-tracking/prd.md) CAP-11 and CAP-12 so that networking resources attached to a parent resource can be attributed to it in a unified usage view: ExternalIPAttachments to ComputeInstances, Clusters, and BareMetalInstances, and Subnets to any resource connected via network attachments
+- Networking resource allocation metering — metering for VirtualNetworks, Subnets, SecurityGroups, ExternalIPs, and NATGateways from READY/ALLOCATED state to deletion
+- Unattached IP metering — ExternalIPs generate usage data regardless of attachment status, with attachment status as a queryable dimension
+- Parent-child attribution — extending [Part 1](/enhancements/metering-and-usage-tracking/prd.md) CAP-11 and CAP-12 so that networking resources attached to a parent resource can be attributed to it in a unified usage view: ExternalIPs to ComputeInstances, Clusters, and BareMetalInstances, and Subnets to any resource connected via network attachments
 
 ## 3. Out of Scope
 
@@ -76,7 +75,7 @@ ExternalIP resources support all three services — `ExternalIPAttachment` targe
 
 ### 5.1 Networking Resource Allocation Metering
 
-- **CAP-1:** Tenant-facing networking resources (VirtualNetwork, Subnet, SecurityGroup, ExternalIP, NATGateway) are metered on an allocation basis. Usage accrues from the point the resource reaches READY or ALLOCATED state until deletion. Attachment resources (ExternalIPAttachment) are metered for their own lifecycle — from attachment creation to attachment deletion.
+- **CAP-1:** Tenant-facing networking resources (VirtualNetwork, Subnet, SecurityGroup, ExternalIP, NATGateway) are metered on an allocation basis. Usage accrues from the point the resource reaches READY or ALLOCATED state until deletion.
 - **CAP-2:** Networking usage is queryable by resource type, network class (for VirtualNetworks), IP family (IPv4/IPv6 for IP resources), region, tenant, and project.
 
 ### 5.2 Unattached IP Metering
@@ -91,14 +90,13 @@ ExternalIP resources support all three services — `ExternalIPAttachment` targe
 
 This section defines the metering units and measurement approach for networking resources, extending the usage measurement model from [Part 1](/enhancements/metering-and-usage-tracking/prd.md). Downstream systems (cost management, billing) consume this usage data and apply their own pricing — rate schedules are outside the scope of metering.
 
-Each networking resource type has a flat allocation meter. Usage is queryable by resource type, region, tenant, and project; VirtualNetworks additionally use network class, IP resources use IP family, and IP attachment status is exposed where applicable (see CAP-2 and CAP-3).
+Each networking resource type has a flat allocation meter. Usage is queryable by resource type, region, tenant, and project; VirtualNetworks additionally use network class, ExternalIPs use IP family and attachment status (see CAP-2 and CAP-3).
 
 | Resource | Meter | Unit | Example (30 days) |
 |----------|-------|------|-------------------|
 | VirtualNetwork | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
 | Subnet | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
 | ExternalIP (IPv4) | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
-| ExternalIPAttachment | resource-seconds | seconds of attachment | 2,592,000 resource-seconds |
 | NATGateway | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
 | SecurityGroup | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
 
@@ -107,8 +105,7 @@ Each networking resource type has a flat allocation meter. Usage is queryable by
 - [ ] Each tenant-facing networking resource (VirtualNetwork, Subnet, SecurityGroup, ExternalIP, NATGateway) generates allocation usage data from READY/ALLOCATED state to deletion
 - [ ] An allocated-but-unattached ExternalIP generates usage data
 - [ ] Networking usage can be broken down by resource type, network class, IP family, region, tenant, and project
-- [ ] Networking resources attached to a parent resource (ExternalIPAttachments to ComputeInstances/Clusters/BareMetalInstances, Subnets via network attachments) can be attributed to the parent in a unified usage view
-- [ ] An ExternalIPAttachment generates usage data (resource-seconds) from attachment creation to attachment deletion
+- [ ] Networking resources attached to a parent resource (ExternalIPs to ComputeInstances/Clusters/BareMetalInstances, Subnets via network attachments) can be attributed to the parent in a unified usage view
 - [ ] Networking usage data is available after deploying the metering update without provisioning additional infrastructure
 - [ ] Networking usage data maintains per-second granularity, deduplication, and retention consistent with Part 1 metering
 
@@ -149,5 +146,10 @@ This PRD is part of the Metering Part 2 family:
 ## Provenance
 
 Authored: respond @ prd 0.6.3 - 6ec8c11, workspace main @ 78853cd
+Final: respond @ prd 0.7.1 - b8b3f86, workspace main @ 3c46f33
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"6ec8c11","source_repo":"78853cd","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["respond"],"authoring_modes":["skill"],"context_changed":false} -->
+> Context changed between respond and respond.
+
+> This document's phase history does not include an initial /draft — structure was not verified against the template from origin.
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"3c46f33","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["respond","respond"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":true} -->

--- a/enhancements/OSAC-3145-metering-networking/prd.md
+++ b/enhancements/OSAC-3145-metering-networking/prd.md
@@ -12,7 +12,7 @@ Terms defined in the [Part 1 PRD](/enhancements/metering-and-usage-tracking/prd.
 
 | Term | Definition |
 |------|-----------|
-| **Allocation metering** | Metering that runs for the duration a resource exists (creation to deletion), regardless of whether the resource is actively in use. Reflects the provider's physical capacity reservation. |
+| **Allocation metering** | Metering that runs from the point a resource is allocated until deletion, regardless of whether the resource is actively in use. Reflects the provider's physical capacity reservation. |
 | **Network class** | A provider-defined network backend configuration that determines VirtualNetwork behavior and metering classification. |
 
 ## 1. Problem Statement
@@ -78,7 +78,7 @@ PublicIP resources are VMaaS-only — the `PublicIPAttachment` target is limited
 
 ### 5.1 Networking Resource Allocation Metering
 
-- **CAP-1:** Tenant-facing networking resources (VirtualNetwork, Subnet, SecurityGroup, PublicIP, ExternalIP, NATGateway, and their attachments) are metered on an allocation basis. Usage accrues from the point the resource reaches READY or ALLOCATED state until deletion.
+- **CAP-1:** Tenant-facing networking resources (VirtualNetwork, Subnet, SecurityGroup, PublicIP, ExternalIP, NATGateway) are metered on an allocation basis. Usage accrues from the point the resource reaches READY or ALLOCATED state until deletion. Attachment resources (PublicIPAttachment, ExternalIPAttachment) are metered for their own lifecycle — from attachment creation to attachment deletion.
 - **CAP-2:** Networking usage is queryable by resource type, network class (for VirtualNetworks), IP family (IPv4/IPv6 for IP resources), region, tenant, and project.
 
 ### 5.2 Unattached IP Metering
@@ -112,6 +112,7 @@ Each networking resource type has a flat allocation meter. Usage is queryable by
 - [ ] An allocated-but-unattached PublicIP or ExternalIP generates usage data
 - [ ] Networking usage can be broken down by resource type, network class, IP family, region, tenant, and project
 - [ ] Networking resources attached to a parent resource (PublicIPAttachments to ComputeInstances, ExternalIPAttachments to ComputeInstances/Clusters/BareMetalInstances, Subnets via network attachments) can be attributed to the parent in a unified usage view
+- [ ] A PublicIPAttachment or ExternalIPAttachment generates usage data (resource-seconds) from attachment creation to attachment deletion
 - [ ] Networking usage data is available after deploying the metering update without provisioning additional infrastructure
 - [ ] Networking usage data maintains per-second granularity, deduplication, and retention consistent with Part 1 metering
 
@@ -151,8 +152,8 @@ This PRD is part of the Metering Part 2 family:
 
 ## Provenance
 
-Committed: commit @ prd 0.6.0 - 139e6c1, workspace prd/OSAC-3145 @ 60a4729
+Committed: commit @ prd 0.6.0 - 139e6c1, workspace prd/OSAC-3145 @ 314c274
 
 > Authoring phases not recorded this session (commit-time snapshot only).
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.6.0","ai_workflows":"139e6c1","source_repo":"60a4729","source_repo_branch":"prd/OSAC-3145","commits_behind_main":0,"commits_ahead_main":5,"main_ref":"main","phases":["commit","commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.6.0","ai_workflows":"139e6c1","source_repo":"314c274","source_repo_branch":"prd/OSAC-3145","commits_behind_main":0,"commits_ahead_main":6,"main_ref":"main","phases":["commit","commit","commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true} -->

--- a/enhancements/OSAC-3145-metering-networking/prd.md
+++ b/enhancements/OSAC-3145-metering-networking/prd.md
@@ -93,7 +93,7 @@ PublicIP resources are VMaaS-only — the `PublicIPAttachment` target is limited
 
 This section defines the metering units and measurement approach for networking resources, extending the usage measurement model from [Part 1](/enhancements/metering-and-usage-tracking/prd.md). Downstream systems (cost management, billing) consume this usage data and apply their own pricing — rate schedules are outside the scope of metering.
 
-Each networking resource type has a flat allocation meter. Resource type and network class (for VirtualNetworks) are the metering dimensions.
+Each networking resource type has a flat allocation meter. Usage is queryable by resource type, region, tenant, and project; VirtualNetworks additionally use network class, IP resources use IP family, and IP attachment status is exposed where applicable (see CAP-2 and CAP-3).
 
 | Resource | Meter | Unit | Example (30 days) |
 |----------|-------|------|-------------------|
@@ -151,8 +151,8 @@ This PRD is part of the Metering Part 2 family:
 
 ## Provenance
 
-Committed: commit @ prd 0.6.0 - 139e6c1, workspace prd/OSAC-3145 @ 16c8909
+Committed: commit @ prd 0.6.0 - 139e6c1, workspace prd/OSAC-3145 @ 60a4729
 
 > Authoring phases not recorded this session (commit-time snapshot only).
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.6.0","ai_workflows":"139e6c1","source_repo":"16c8909","source_repo_branch":"prd/OSAC-3145","commits_behind_main":0,"commits_ahead_main":4,"main_ref":"main","phases":["commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.6.0","ai_workflows":"139e6c1","source_repo":"60a4729","source_repo_branch":"prd/OSAC-3145","commits_behind_main":0,"commits_ahead_main":5,"main_ref":"main","phases":["commit","commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true} -->

--- a/enhancements/OSAC-3145-metering-networking/prd.md
+++ b/enhancements/OSAC-3145-metering-networking/prd.md
@@ -112,8 +112,8 @@ Each networking resource type has a flat allocation meter. Resource type and net
 - [ ] An allocated-but-unattached PublicIP or ExternalIP generates usage data
 - [ ] Networking usage can be broken down by resource type, network class, IP family, region, tenant, and project
 - [ ] Networking resources attached to a parent resource (PublicIPAttachments to ComputeInstances, ExternalIPAttachments to ComputeInstances/Clusters/BareMetalInstances, Subnets via network attachments) can be attributed to the parent in a unified usage view
-- [ ] Networking meters are additive to the Part 1 metering deployment and require no separate infrastructure
-- [ ] All Part 1 cross-cutting acceptance criteria (per-second granularity, deduplication, retention, independent deployment) apply to networking meters
+- [ ] Networking usage data is available after deploying the metering update without provisioning additional infrastructure
+- [ ] Networking usage data maintains per-second granularity, deduplication, and retention consistent with Part 1 metering
 
 ## 8. Assumptions
 
@@ -151,8 +151,8 @@ This PRD is part of the Metering Part 2 family:
 
 ## Provenance
 
-Committed: commit @ prd 0.6.0 - 139e6c1, workspace prd/OSAC-3145 @ 6d766ff (dirty)
+Committed: commit @ prd 0.6.0 - 139e6c1, workspace prd/OSAC-3145 @ 16c8909
 
 > Authoring phases not recorded this session (commit-time snapshot only).
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.6.0","ai_workflows":"139e6c1","source_repo":"6d766ff (dirty)","source_repo_branch":"prd/OSAC-3145","commits_behind_main":0,"commits_ahead_main":2,"main_ref":"main","phases":["commit","commit"],"authoring_modes":["skill"],"context_changed":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.6.0","ai_workflows":"139e6c1","source_repo":"16c8909","source_repo_branch":"prd/OSAC-3145","commits_behind_main":0,"commits_ahead_main":4,"main_ref":"main","phases":["commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true} -->

--- a/enhancements/OSAC-3145-metering-networking/prd.md
+++ b/enhancements/OSAC-3145-metering-networking/prd.md
@@ -12,8 +12,8 @@ Terms defined in the [Part 1 PRD](/enhancements/metering-and-usage-tracking/prd.
 
 | Term | Definition |
 |------|-----------|
-| **Allocation metering** | Metering that runs for the duration a resource exists (creation to deletion), regardless of whether the resource is actively in use. Reflects the provider's physical capacity cost. |
-| **Network class** | A provider-defined network backend configuration that determines VirtualNetwork behavior and pricing. |
+| **Allocation metering** | Metering that runs for the duration a resource exists (creation to deletion), regardless of whether the resource is actively in use. Reflects the provider's physical capacity reservation. |
+| **Network class** | A provider-defined network backend configuration that determines VirtualNetwork behavior and metering classification. |
 
 ## 1. Problem Statement
 
@@ -23,36 +23,56 @@ Without metering for these resources, Cloud Provider Admins have no usage data t
 
 ## 2. In Scope
 
+### 2.1 Services
+
+Networking resources are service-agnostic — a VirtualNetwork or Subnet is metered regardless of which service consumes it. Attachment resources vary by target type.
+
+| Resource | VMaaS | CaaS | BMaaS |
+|----------|-------|------|-------|
+| VirtualNetwork | Yes | Yes | Yes |
+| Subnet | Yes | Yes | Yes |
+| SecurityGroup | Yes | Yes | Yes |
+| NATGateway | Yes | Yes | Yes |
+| PublicIP | Yes | — | — |
+| PublicIPAttachment | Yes (ComputeInstance) | — | — |
+| ExternalIP | Yes | Yes | Yes |
+| ExternalIPAttachment | Yes (ComputeInstance) | Yes (Cluster) | Yes (BareMetalInstance) |
+
+PublicIP resources are VMaaS-only — the `PublicIPAttachment` target is limited to ComputeInstance. ExternalIP resources support all three services — `ExternalIPAttachment` targets ComputeInstance, Cluster, and BareMetalInstance.
+
+### 2.2 Capabilities
+
 - Networking resource allocation metering — metering for VirtualNetworks, Subnets, SecurityGroups, PublicIPs, ExternalIPs, NATGateways, and their attachments from READY/ALLOCATED state to deletion
 - Unattached IP metering — PublicIPs and ExternalIPs generate usage data regardless of attachment status
-- Parent-child attribution — extending [Part 1](/enhancements/metering-and-usage-tracking/prd.md) CAP-11 and CAP-12 so that PublicIPs and Subnets attached to VMs can be attributed to the parent resource in a unified usage view
+- Parent-child attribution — extending [Part 1](/enhancements/metering-and-usage-tracking/prd.md) CAP-11 and CAP-12 so that networking resources attached to a parent resource can be attributed to it in a unified usage view: PublicIPAttachments to ComputeInstances, ExternalIPAttachments to ComputeInstances, Clusters, and BareMetalInstances, and Subnets to any resource connected via network attachments
 
 ## 3. Out of Scope
 
-- BMaaS metering — tracked separately ([OSAC-2506](https://redhat.atlassian.net/browse/OSAC-2506))
+- BMaaS compute metering — tracked separately ([OSAC-2506](https://redhat.atlassian.net/browse/OSAC-2506)); networking resources consumed by BMaaS (VirtualNetworks, Subnets, ExternalIPs, etc.) are in scope here
 - Storage metering — tracked separately ([OSAC-3141](https://redhat.atlassian.net/browse/OSAC-3141))
 - Network bandwidth metering (ingress/egress traffic) — tracked separately ([OSAC-3149](https://redhat.atlassian.net/browse/OSAC-3149))
 - Costing, billing, quota enforcement, and budget alerts — deferred to a separate PRD
+- UI for viewing networking usage — metering data is consumed by the billing system, which provides the user-facing usage views
 - Workload-level metering inside tenant environments
 
 ## 4. User Stories
 
 ### Cloud Provider Admin
 
-- As a Cloud Provider Admin, I want to view networking resource usage across all tenants broken down by resource type (VirtualNetwork, PublicIP, NATGateway), so that I can track the network infrastructure each tenant consumes.
+- As a Cloud Provider Admin, I want networking resource usage data across all tenants to be available broken down by resource type (VirtualNetwork, PublicIP, NATGateway), so that downstream systems can track the network infrastructure each tenant consumes.
 
 ### Cloud Infrastructure Admin
 
-- As a Cloud Infrastructure Admin, I want VirtualNetwork usage to be automatically grouped by the network classes I have configured in OSAC, so that different network backends (e.g., high-performance DPDK, standard OVN) can carry different rates — without requiring a separate registration step in the metering system.
+- As a Cloud Infrastructure Admin, I want VirtualNetwork usage to be automatically grouped by the network classes I have configured in OSAC, so that different network backends (e.g., high-performance DPDK, standard OVN) are tracked as distinct metering categories — without requiring a separate registration step in the metering system.
 - As a Cloud Infrastructure Admin, I want to add meters for new networking resource types (e.g., LoadBalancer, VPN Gateway) via configuration without redeployment, extending Part 1 CAP-6 to networking resources.
 
 ### Tenant Admin
 
-- As a Tenant Admin, I want to view my organization's networking resource usage broken down by project, including the count and duration of VirtualNetworks, PublicIPs, and NATGateways, so that I can attribute networking costs to the teams that provisioned them.
+- As a Tenant Admin, I want my organization's networking resource usage data to be available broken down by project, including the count and duration of VirtualNetworks, PublicIPs, and NATGateways, so that downstream systems can attribute networking consumption to the teams that provisioned them.
 
 ### Tenant User
 
-- As a Tenant User, I want to view networking resource usage for the projects I belong to, including PublicIP allocation duration and NATGateway uptime, so that I can understand the networking costs of my deployments.
+- As a Tenant User, I want networking resource usage data for the projects I belong to — including PublicIP allocation duration and NATGateway uptime — to be available so that downstream systems can report the networking resource consumption of my deployments.
 
 ## 5. Capabilities
 
@@ -63,35 +83,35 @@ Without metering for these resources, Cloud Provider Admins have no usage data t
 
 ### 5.2 Unattached IP Metering
 
-- **CAP-3:** PublicIPs and ExternalIPs are metered regardless of whether they are attached to a resource. An allocated-but-unattached IP consumes address pool space that other tenants cannot use — the provider's pool is finite and each allocation reduces availability. Metering unattached IPs incentivizes tenants to release addresses they are not using, similar to how AWS charges for Elastic IPs that are not associated with a running instance. The `attached` status is included as a queryable dimension so providers can apply differential rates if desired (e.g., charge more for unattached IPs to encourage release).
+- **CAP-3:** PublicIPs and ExternalIPs are metered regardless of whether they are attached to a resource. An allocated-but-unattached IP consumes address pool space that other tenants cannot use — the provider's pool is finite and each allocation reduces availability. Metering unattached IPs provides visibility into idle address consumption, enabling providers to identify underutilized allocations. The `attached` status is included as a queryable dimension so that downstream systems (e.g., cost management, quota enforcement) can distinguish between active and idle IP usage.
 
 ### 5.3 Cross-cutting
 
 - **CAP-4:** Networking meters are additive to the Part 1 metering deployment and require no separate infrastructure. All networking meters use the same per-second granularity, deduplication, and retention requirements as Part 1 (CAP-4, CAP-15, CAP-16).
 
-## 6. Charge Calculation Model
+## 6. Usage Measurement Model
 
-OSAC provides usage data. The provider applies their own price schedule to generate charges. This section defines the metering units and formulas for networking resources, extending the charge calculation model from [Part 1](/enhancements/metering-and-usage-tracking/prd.md).
+This section defines the metering units and measurement approach for networking resources, extending the usage measurement model from [Part 1](/enhancements/metering-and-usage-tracking/prd.md). Downstream systems (cost management, billing) consume this usage data and apply their own pricing — rate schedules are outside the scope of metering.
 
-Each networking resource type has a flat allocation meter. Resource type and network class (for VirtualNetworks) are the pricing dimensions.
+Each networking resource type has a flat allocation meter. Resource type and network class (for VirtualNetworks) are the metering dimensions.
 
-| Resource | Meter | Formula | Example (30 days) |
-|----------|-------|---------|-------------------|
-| VirtualNetwork | resource-seconds | duration × rate/s | 2592000 × $0.000005 = $12.96 |
-| Subnet | resource-seconds | duration × rate/s | 2592000 × $0.000001 = $2.59 |
-| PublicIP (IPv4) | resource-seconds | duration × rate/s | 2592000 × $0.000001 = $2.59 |
-| ExternalIP (IPv4) | resource-seconds | duration × rate/s | 2592000 × $0.000001 = $2.59 |
-| PublicIPAttachment | resource-seconds | duration × rate/s | 2592000 × $0.0000005 = $1.30 |
-| ExternalIPAttachment | resource-seconds | duration × rate/s | 2592000 × $0.0000005 = $1.30 |
-| NATGateway | resource-seconds | duration × rate/s | 2592000 × $0.00001 = $25.92 |
-| SecurityGroup | resource-seconds | duration × rate/s | 2592000 × $0.0000001 = $0.26 |
+| Resource | Meter | Unit | Example (30 days) |
+|----------|-------|------|-------------------|
+| VirtualNetwork | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
+| Subnet | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
+| PublicIP (IPv4) | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
+| ExternalIP (IPv4) | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
+| PublicIPAttachment | resource-seconds | seconds of attachment | 2,592,000 resource-seconds |
+| ExternalIPAttachment | resource-seconds | seconds of attachment | 2,592,000 resource-seconds |
+| NATGateway | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
+| SecurityGroup | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
 
 ## 7. Acceptance Criteria
 
 - [ ] Each tenant-facing networking resource (VirtualNetwork, Subnet, SecurityGroup, PublicIP, ExternalIP, NATGateway) generates allocation usage data from READY/ALLOCATED state to deletion
-- [ ] An allocated-but-unattached PublicIP generates usage data
+- [ ] An allocated-but-unattached PublicIP or ExternalIP generates usage data
 - [ ] Networking usage can be broken down by resource type, network class, IP family, region, tenant, and project
-- [ ] PublicIPs and Subnets attached to a VM can be attributed to the parent resource in a unified usage view
+- [ ] Networking resources attached to a parent resource (PublicIPAttachments to ComputeInstances, ExternalIPAttachments to ComputeInstances/Clusters/BareMetalInstances, Subnets via network attachments) can be attributed to the parent in a unified usage view
 - [ ] Networking meters are additive to the Part 1 metering deployment and require no separate infrastructure
 - [ ] All Part 1 cross-cutting acceptance criteria (per-second granularity, deduplication, retention, independent deployment) apply to networking meters
 

--- a/enhancements/OSAC-3145-metering-networking/prd.md
+++ b/enhancements/OSAC-3145-metering-networking/prd.md
@@ -17,7 +17,7 @@ Terms defined in the [Part 1 PRD](/enhancements/metering-and-usage-tracking/prd.
 
 ## 1. Problem Statement
 
-OSAC provisions networking resources — virtual networks, subnets, security groups, public IPs, external IPs, NAT gateways — but has no mechanism to track their consumption over time. These resources consume provider capacity from the moment they are provisioned until deletion, regardless of whether they are actively carrying traffic. A public IP consumes address pool space whether it is attached to a resource or not — the provider's pool is finite and each allocation reduces availability. A VirtualNetwork consumes backend network configuration and VLAN allocation from creation.
+OSAC provisions networking resources — virtual networks, subnets, security groups, external IPs, NAT gateways — but has no mechanism to track their consumption over time. These resources consume provider capacity from the moment they are provisioned until deletion, regardless of whether they are actively carrying traffic. An external IP consumes address pool space whether it is attached to a resource or not — the provider's pool is finite and each allocation reduces availability. A VirtualNetwork consumes backend network configuration and VLAN allocation from creation.
 
 Without metering for these resources, Cloud Provider Admins have no usage data to account for the networking infrastructure tenants hold, and Tenant Admins have no visibility into their networking footprint across projects.
 
@@ -33,18 +33,16 @@ Networking resources are service-agnostic — a VirtualNetwork or Subnet is mete
 | Subnet | Yes | Yes | Yes |
 | SecurityGroup | Yes | Yes | Yes |
 | NATGateway | Yes | Yes | Yes |
-| PublicIP | Yes | — | — |
-| PublicIPAttachment | Yes (ComputeInstance) | — | — |
 | ExternalIP | Yes | Yes | Yes |
 | ExternalIPAttachment | Yes (ComputeInstance) | Yes (Cluster) | Yes (BareMetalInstance) |
 
-PublicIP resources are VMaaS-only — the `PublicIPAttachment` target is limited to ComputeInstance. ExternalIP resources support all three services — `ExternalIPAttachment` targets ComputeInstance, Cluster, and BareMetalInstance.
+ExternalIP resources support all three services — `ExternalIPAttachment` targets ComputeInstance, Cluster, and BareMetalInstance.
 
 ### 2.2 Capabilities
 
-- Networking resource allocation metering — metering for VirtualNetworks, Subnets, SecurityGroups, PublicIPs, ExternalIPs, NATGateways, and their attachments from READY/ALLOCATED state to deletion
-- Unattached IP metering — PublicIPs and ExternalIPs generate usage data regardless of attachment status
-- Parent-child attribution — extending [Part 1](/enhancements/metering-and-usage-tracking/prd.md) CAP-11 and CAP-12 so that networking resources attached to a parent resource can be attributed to it in a unified usage view: PublicIPAttachments to ComputeInstances, ExternalIPAttachments to ComputeInstances, Clusters, and BareMetalInstances, and Subnets to any resource connected via network attachments
+- Networking resource allocation metering — metering for VirtualNetworks, Subnets, SecurityGroups, ExternalIPs, NATGateways, and their attachments from READY/ALLOCATED state to deletion
+- Unattached IP metering — ExternalIPs generate usage data regardless of attachment status
+- Parent-child attribution — extending [Part 1](/enhancements/metering-and-usage-tracking/prd.md) CAP-11 and CAP-12 so that networking resources attached to a parent resource can be attributed to it in a unified usage view: ExternalIPAttachments to ComputeInstances, Clusters, and BareMetalInstances, and Subnets to any resource connected via network attachments
 
 ## 3. Out of Scope
 
@@ -59,7 +57,7 @@ PublicIP resources are VMaaS-only — the `PublicIPAttachment` target is limited
 
 ### Cloud Provider Admin
 
-- As a Cloud Provider Admin, I want networking resource usage data across all tenants to be available broken down by resource type (VirtualNetwork, PublicIP, NATGateway), so that downstream systems can track the network infrastructure each tenant consumes.
+- As a Cloud Provider Admin, I want networking resource usage data across all tenants to be available broken down by resource type (VirtualNetwork, ExternalIP, NATGateway), so that downstream systems can track the network infrastructure each tenant consumes.
 
 ### Cloud Infrastructure Admin
 
@@ -68,22 +66,22 @@ PublicIP resources are VMaaS-only — the `PublicIPAttachment` target is limited
 
 ### Tenant Admin
 
-- As a Tenant Admin, I want my organization's networking resource usage data to be available broken down by project, including the count and duration of VirtualNetworks, PublicIPs, and NATGateways, so that downstream systems can attribute networking consumption to the teams that provisioned them.
+- As a Tenant Admin, I want my organization's networking resource usage data to be available broken down by project, including the count and duration of VirtualNetworks, ExternalIPs, and NATGateways, so that downstream systems can attribute networking consumption to the teams that provisioned them.
 
 ### Tenant User
 
-- As a Tenant User, I want networking resource usage data for the projects I belong to — including PublicIP allocation duration and NATGateway uptime — to be available so that downstream systems can report the networking resource consumption of my deployments.
+- As a Tenant User, I want networking resource usage data for the projects I belong to — including ExternalIP allocation duration and NATGateway uptime — to be available so that downstream systems can report the networking resource consumption of my deployments.
 
 ## 5. Capabilities
 
 ### 5.1 Networking Resource Allocation Metering
 
-- **CAP-1:** Tenant-facing networking resources (VirtualNetwork, Subnet, SecurityGroup, PublicIP, ExternalIP, NATGateway) are metered on an allocation basis. Usage accrues from the point the resource reaches READY or ALLOCATED state until deletion. Attachment resources (PublicIPAttachment, ExternalIPAttachment) are metered for their own lifecycle — from attachment creation to attachment deletion.
+- **CAP-1:** Tenant-facing networking resources (VirtualNetwork, Subnet, SecurityGroup, ExternalIP, NATGateway) are metered on an allocation basis. Usage accrues from the point the resource reaches READY or ALLOCATED state until deletion. Attachment resources (ExternalIPAttachment) are metered for their own lifecycle — from attachment creation to attachment deletion.
 - **CAP-2:** Networking usage is queryable by resource type, network class (for VirtualNetworks), IP family (IPv4/IPv6 for IP resources), region, tenant, and project.
 
 ### 5.2 Unattached IP Metering
 
-- **CAP-3:** PublicIPs and ExternalIPs are metered regardless of whether they are attached to a resource. An allocated-but-unattached IP consumes address pool space that other tenants cannot use — the provider's pool is finite and each allocation reduces availability. Metering unattached IPs provides visibility into idle address consumption, enabling providers to identify underutilized allocations. The `attached` status is included as a queryable dimension so that downstream systems (e.g., cost management, quota enforcement) can distinguish between active and idle IP usage.
+- **CAP-3:** ExternalIPs are metered regardless of whether they are attached to a resource. An allocated-but-unattached IP consumes address pool space that other tenants cannot use — the provider's pool is finite and each allocation reduces availability. Metering unattached IPs provides visibility into idle address consumption, enabling providers to identify underutilized allocations. The `attached` status is included as a queryable dimension so that downstream systems (e.g., cost management, quota enforcement) can distinguish between active and idle IP usage.
 
 ### 5.3 Cross-cutting
 
@@ -99,20 +97,18 @@ Each networking resource type has a flat allocation meter. Usage is queryable by
 |----------|-------|------|-------------------|
 | VirtualNetwork | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
 | Subnet | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
-| PublicIP (IPv4) | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
 | ExternalIP (IPv4) | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
-| PublicIPAttachment | resource-seconds | seconds of attachment | 2,592,000 resource-seconds |
 | ExternalIPAttachment | resource-seconds | seconds of attachment | 2,592,000 resource-seconds |
 | NATGateway | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
 | SecurityGroup | resource-seconds | seconds of allocation | 2,592,000 resource-seconds |
 
 ## 7. Acceptance Criteria
 
-- [ ] Each tenant-facing networking resource (VirtualNetwork, Subnet, SecurityGroup, PublicIP, ExternalIP, NATGateway) generates allocation usage data from READY/ALLOCATED state to deletion
-- [ ] An allocated-but-unattached PublicIP or ExternalIP generates usage data
+- [ ] Each tenant-facing networking resource (VirtualNetwork, Subnet, SecurityGroup, ExternalIP, NATGateway) generates allocation usage data from READY/ALLOCATED state to deletion
+- [ ] An allocated-but-unattached ExternalIP generates usage data
 - [ ] Networking usage can be broken down by resource type, network class, IP family, region, tenant, and project
-- [ ] Networking resources attached to a parent resource (PublicIPAttachments to ComputeInstances, ExternalIPAttachments to ComputeInstances/Clusters/BareMetalInstances, Subnets via network attachments) can be attributed to the parent in a unified usage view
-- [ ] A PublicIPAttachment or ExternalIPAttachment generates usage data (resource-seconds) from attachment creation to attachment deletion
+- [ ] Networking resources attached to a parent resource (ExternalIPAttachments to ComputeInstances/Clusters/BareMetalInstances, Subnets via network attachments) can be attributed to the parent in a unified usage view
+- [ ] An ExternalIPAttachment generates usage data (resource-seconds) from attachment creation to attachment deletion
 - [ ] Networking usage data is available after deploying the metering update without provisioning additional infrastructure
 - [ ] Networking usage data maintains per-second granularity, deduplication, and retention consistent with Part 1 metering
 
@@ -152,8 +148,6 @@ This PRD is part of the Metering Part 2 family:
 
 ## Provenance
 
-Committed: commit @ prd 0.6.0 - 139e6c1, workspace prd/OSAC-3145 @ 314c274
+Authored: respond @ prd 0.6.3 - 6ec8c11, workspace main @ 78853cd
 
-> Authoring phases not recorded this session (commit-time snapshot only).
-
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.6.0","ai_workflows":"139e6c1","source_repo":"314c274","source_repo_branch":"prd/OSAC-3145","commits_behind_main":0,"commits_ahead_main":6,"main_ref":"main","phases":["commit","commit","commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"6ec8c11","source_repo":"78853cd","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["respond"],"authoring_modes":["skill"],"context_changed":false} -->


### PR DESCRIPTION
## Summary

- Add PRD for networking resource metering (Part 2c of the Metering Part 2 family)
- Covers VirtualNetworks, Subnets, SecurityGroups, PublicIPs, ExternalIPs, NATGateways
- Allocation-based metering from READY/ALLOCATED state to deletion, including unattached IP metering

## Jira

- Feature: [OSAC-3145](https://redhat.atlassian.net/browse/OSAC-3145)
- PRD gate task: [OSAC-3147](https://redhat.atlassian.net/browse/OSAC-3147)

## Related PRDs

- Part 2a: BMaaS — [OSAC-2506](https://redhat.atlassian.net/browse/OSAC-2506) (#118)
- Part 2b: Storage — [OSAC-3141](https://redhat.atlassian.net/browse/OSAC-3141) (#158)
- Part 2d: Network Bandwidth — [OSAC-3149](https://redhat.atlassian.net/browse/OSAC-3149)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a product requirements document for networking metering.
  * Defined allocation-based metering for VirtualNetworks, Subnets, SecurityGroups, ExternalIPs, NATGateways, and ExternalIPAttachments.
  * Documented unattached IP tracking, parent-child attribution, resource-second measurement, query dimensions, and acceptance criteria.
  * Included Part 1 dependencies, assumptions, risks, document provenance, and an open question regarding VirtualNetwork PENDING versus READY states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->