### PR TITLE
OSAC-3153: fix detect_skills matching ui-design.md as design.md

### DIFF
--- a/.github/scripts/ep_review.py
+++ b/.github/scripts/ep_review.py
@@ -43,10 +43,10 @@ def get_changed_files(pr_number):
 
 def detect_skills(files):
     skills = []
-    has_prd = any(f.lower().endswith("prd.md") for f in files)
-    has_design = any(
-        f.lower().endswith("design.md") or
-        (f.lower().endswith("readme.md") and "enhancements/" in f.lower())
+    basenames = [os.path.basename(f).lower() for f in files]
+    has_prd = "prd.md" in basenames
+    has_design = "design.md" in basenames or any(
+        os.path.basename(f).lower() == "readme.md" and "enhancements/" in f.lower()
         for f in files
     )
 


### PR DESCRIPTION
## Summary

- `detect_skills()` used `endswith("design.md")` which incorrectly matched `ui-design.md` and `ux-design.md`
- Switch to `os.path.basename()` exact match so only files named exactly `design.md` or `prd.md` trigger reviews

## Root cause

`"ui-design.md".endswith("design.md")` is `True` in Python — the suffix check is too broad.

Observed on PR #123 (Organizations & Authentication UI design).

## Test plan

- [x] Verified locally: `detect_skills(["enhancements/organizations/ui-design.md"])` returns `[]`
- [x] Verified locally: `detect_skills(["enhancements/organizations/design.md"])` returns `["design-review"]`
- [x] All edge cases pass (ux-design, prd, readme, both files, unrelated)
- [ ] CI passes

Fixes: [OSAC-3153](https://redhat.atlassian.net/browse/OSAC-3153)