### PR TITLE
NO-ISSUE: skip EP review for forgeSmith-bot PRs

### DIFF
--- a/.github/workflows/ep-review.yml
+++ b/.github/workflows/ep-review.yml
@@ -16,7 +16,8 @@ on:
 jobs:
   resolve-pr:
     if: >-
-      github.event_name == 'pull_request_target'
+      (github.event_name == 'pull_request_target'
+       && github.event.pull_request.user.login != 'forgeSmith-bot')
       || (github.event_name == 'issue_comment'
           && github.event.issue.pull_request
           && contains(github.event.comment.body, '/review-ep')


### PR DESCRIPTION
## Summary
- Skip automatic EP review when PR author is `forgeSmith-bot`
- Forge pushes commits in response to review feedback, re-triggering the workflow via `synchronize` events, creating an infinite loop (see PR #169)
- Manual `/review-ep` comments still work on Forge PRs

## Test plan
- [ ] Verify existing Forge PRs no longer trigger ep-review on push
- [ ] Verify `/review-ep` comment on a Forge PR still triggers review
- [ ] Verify non-Forge PRs still get automatic review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the automated pull request review workflow from running for pull requests created by the forgeSmith-bot account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->