### PR TITLE
OSAC-2917: update design test plan for GPU validation

### DIFF
--- a/enhancements/OSAC-2917-gpu-instance-types/design.md
+++ b/enhancements/OSAC-2917-gpu-instance-types/design.md
@@ -274,10 +274,10 @@ Extend `InstanceTypeSpec` (field 6, after `deprecation = 5`):
 ```protobuf
 message InstanceTypeSpec {
   // Number of virtual CPU cores.
-  int32 cores = 1 [(buf.validate.field).int32.gte = 1];
+  int32 cores = 1;
 
   // Memory in gibibytes.
-  int32 memory_gib = 2 [(buf.validate.field).int32.gte = 1];
+  int32 memory_gib = 2;
 
   // Human-readable description of the instance type.
   string description = 3;
@@ -596,8 +596,6 @@ provisioning.
 
 **fulfillment-service (Ginkgo):**
 
-- `GpuSpec` validation: Create rejects `gpu.count = 0`, `gpu.count = -1`,
-  `gpu.pci_device_selector = ""`, and `gpu.resource_name = ""` when `gpu` is present.
 - Create accepts InstanceType with `gpu` omitted (non-GPU instance type).
 - Create accepts InstanceType with valid `gpu` (pci_device_selector = "10DE:20B0",
   resource_name = "nvidia.com/A100", count = 1).
@@ -622,6 +620,11 @@ provisioning.
 
 **fulfillment-service (kind cluster):**
 
+- `GpuSpec` validation via protovalidate interceptor: Create rejects
+  `gpu.pci_device_selector = ""`, `gpu.resource_name = ""`, `gpu.count = 0`, and
+  `gpu.count = 17` when `gpu` is present. These are tested as integration tests
+  (not unit tests) because GPU field constraints are enforced by `buf.validate` proto
+  annotations via the protovalidate gRPC interceptor, which unit tests bypass.
 - Create a GPU-enabled InstanceType (count=2), create a ComputeInstance referencing it,
   verify the reconciler stamps the `gpu` struct with `count=2` on the K8s
   ComputeInstance CR.


### PR DESCRIPTION
## Summary

- Move GPU field validation tests from unit tests to integration tests in the test plan section. GPU constraints are enforced by `buf.validate` proto annotations via the protovalidate interceptor, which unit tests bypass.
- Remove incorrect `buf.validate` annotations from `cores` and `memory_gib` in the proto snippet — these fields use server-side Go validation.

## Context

Discovered during [OSAC-3159](https://redhat.atlassian.net/browse/OSAC-3159) implementation (fulfillment-service#984).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the instance type design documentation to reflect revised validation requirements for CPU cores and memory.
  * Updated the test plan to cover GPU specification validation through integration testing, including required fields and valid count ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->