### PR TITLE
OSAC-3502: Document persona-consolidated user stories and illustrative-example allowance in prd_guide.md

### DIFF
--- a/guidelines/prd_guide.md
+++ b/guidelines/prd_guide.md
@@ -87,6 +87,12 @@ specific things users interact with.
 - "As a Tenant Admin, I want to store OIDC client secrets for IDP
   integration, so that my team's identity provider credentials are
   centrally managed."
+- "As a Tenant Admin or Tenant User, I want persistent storage to be
+  available on my CaaS cluster when it is ready, so that I can run
+  stateful workloads without waiting for manual configuration." (Two
+  personas, one story — see
+  [OSAC-1332-caas-cluster-storage](../enhancements/OSAC-1332-caas-cluster-storage/prd.md)
+  for the full pattern.)
 
 ### Bad examples
 
@@ -140,6 +146,26 @@ must use an OSAC persona name from the table above.
 A PRD that covers storage provisioning, networking policy enforcement,
 and cluster monitoring is three features, not one. Test independence:
 could each ship on its own and provide value? If yes, split them.
+
+### Duplicated persona stories
+
+Copying the same story under multiple persona headings just to change the
+persona name inflates the document without adding information:
+
+- "As a Tenant Admin, I want persistent storage to be available on my
+  CaaS cluster when it is ready..." followed by a near-identical "As a
+  Tenant User, I want persistent storage to be available on my CaaS
+  cluster when it is ready..." (Same capability, same outcome — the
+  duplication tells the reader nothing new.)
+
+**Fix:** When two or more personas want the genuinely identical
+capability, combine them under one heading and story: "### Tenant Admin /
+Tenant User" with "As a Tenant Admin or Tenant User, I want persistent
+storage to be available on my CaaS cluster when it is ready, so that I
+can run stateful workloads without waiting for manual configuration."
+Only combine when the capability is truly identical — if personas
+experience it differently (different constraints, different visibility
+scope), keep separate stories.
 
 ## Workflow
 

--- a/guidelines/prd_guide.md
+++ b/guidelines/prd_guide.md
@@ -109,8 +109,7 @@ specific things users interact with.
 - "As a Tenant Admin or Tenant User, I want persistent storage to be
   available on my CaaS cluster when it is ready, so that I can run
   stateful workloads without waiting for manual configuration." (Two
-  personas, one story — see `enhancements/OSAC-1332-caas-cluster-storage/prd.md`
-  for the full pattern.)
+  personas, one story — identical capability and outcome for both.)
 
 ### Bad examples
 

--- a/guidelines/prd_guide.md
+++ b/guidelines/prd_guide.md
@@ -55,6 +55,25 @@ Referencing OSAC platform terms by name is acceptable context in a PRD:
 Naming these is fine. Mandating which internal component solves a problem
 or describing controller logic is not.
 
+### A narrow exception: illustrative examples
+
+A single minimal example — a sample request/response shape, a short flow
+list, a format a user types — may accompany prose when it's the clearest
+way to convey a user-observable capability or constraint. This is not
+license to describe internal architecture: apply the same litmus test to
+the example as to any other statement.
+
+- Good: "Tenants specify port mappings in the format `8080:80`
+  (host:container) when creating a ComputeInstance." — a value the user
+  types; conveys the format without describing the implementation.
+- Bad: "The reconciler records the mapping as `conditions: [{type:
+  PortMappingApplied, hostPort: 8080, containerPort: 80}]`." — reads like
+  a design doc even though it's framed as an example; the condition type
+  and field names are only visible in code.
+
+Use sparingly — one example per capability, always followed by prose
+stating the user-facing implication.
+
 ## OSAC Personas
 
 Use these exact names in user stories. Every PRD should identify which

--- a/guidelines/prd_guide.md
+++ b/guidelines/prd_guide.md
@@ -109,8 +109,7 @@ specific things users interact with.
 - "As a Tenant Admin or Tenant User, I want persistent storage to be
   available on my CaaS cluster when it is ready, so that I can run
   stateful workloads without waiting for manual configuration." (Two
-  personas, one story — see
-  [OSAC-1332-caas-cluster-storage](../enhancements/OSAC-1332-caas-cluster-storage/prd.md)
+  personas, one story — see `enhancements/OSAC-1332-caas-cluster-storage/prd.md`
   for the full pattern.)
 
 ### Bad examples


### PR DESCRIPTION
## [OSAC-3502](https://redhat.atlassian.net/browse/OSAC-3502): Document persona-consolidated user stories and illustrative-example allowance in `prd_guide.md`

**Jira:** https://redhat.atlassian.net/browse/OSAC-3502
**Related PR:** osac-project/osac-workspace#180 (`/prd` and `prd-review` skill changes implementing the same rules)

### Summary

Companion to the `osac-workspace` PR above — documents two rules for human PRD authors that the `/prd` and `prd-review` skills now also apply: combining identical persona stories under one heading instead of duplicating them, and a narrow allowance for a single illustrative example (e.g., a value format a user types) without it counting as design leakage.

### Changes

- **`guidelines/prd_guide.md`**:
  - Added "A narrow exception: illustrative examples" under the design-leakage section, with a good/bad worked example (`8080:80` port-mapping format vs. a reconciler's internal condition payload).
  - Added a persona-consolidation example to "Writing Good User Stories."
  - Added a new "Duplicated persona stories" entry to "Common Mistakes," with the fix (combine under one heading: `### Tenant Admin / Tenant User`) and the boundary condition (only when the capability is genuinely identical).

### Testing

- No CI check applies to `guidelines/*.md` changes (`CONTRIBUTING.md`'s "Enforcement" only validates newly-added `enhancements/*` paths).
- Manually verified the new relative link to `enhancements/OSAC-1332-caas-cluster-storage/prd.md` resolves.
- Manually reviewed for broken relative links and consistency with the corresponding `osac-workspace` guidance these rules are calibrated against.

### Acceptance Criteria

- [x] AC-3: Persona consolidation is documented for human PRD authors, matching the AI-facing guidance in `osac-workspace`.
- [x] AC-4: The illustrative-example allowance is documented as the canonical source, cross-referenced from `osac-workspace`'s `section-guidance.md` and `prd-review` rubric rather than restated independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using minimal, user-focused examples in product requirement documents.
  * Clarified when to combine identical persona-based user stories.
  * Added an example describing persistent cluster storage capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->