### PR TITLE
OSAC-2921: Design - Add Standardized display_name and description Fields to Resource Metadata

### DIFF
--- a/enhancements/OSAC-2921-metadata-display-name/design.md
+++ b/enhancements/OSAC-2921-metadata-display-name/design.md
@@ -3,7 +3,7 @@ title: metadata-display-name
 authors:
   - ushkalim@redhat.com
 creation-date: 2026-08-02
-last-updated: 2026-08-02
+last-updated: 2026-08-04
 tracking-link:
   - https://redhat.atlassian.net/browse/OSAC-2921
 prd:
@@ -69,8 +69,12 @@ changes, not proto-only edits.
 - Changing TemplateParameter `title`/`description`, HostType interface
   `description`, or FieldDefinition `display_name`. [Locked: D3]
 - Aligning public/private Metadata field number divergence for existing
-  fields (`name` is 4 public / 6 private).
-- Encrypting or sanitizing description content beyond length validation.
+  fields (`name` is 4 public / 6 private). Tracked as a follow-up outside
+  this enhancement.
+- Server-side encryption or content sanitization of `description` beyond
+  length validation. Descriptions remain opaque stored strings; safe
+  rendering is a **client** responsibility (see Security Considerations).
+  UI/CLI hardening beyond the policy stated here is tracked as a follow-up.
 
 ## Proposal
 
@@ -277,8 +281,17 @@ Rules:
 - Prefer `title` / `spec.title` for `display_name` when present.
 - Copy description from the corresponding path; if longer than 256 Unicode
   code points, truncate to 256.
-- After copy, remove the old keys from `data` JSON so leftover fields do not
-  linger after proto reservation.
+- After copy, delete **only the explicit migrated path for that resource
+  type** (for example top-level `title`/`description` on flat-shape types,
+  or `spec.title`/`spec.description` on metadata-bearing types). Do **not**
+  perform a generic delete of every matching key name in the JSON document.
+  Nested fields that this enhancement excludes must remain intact, including
+  `TemplateParameter.title` / `description`, `FieldDefinition.display_name`,
+  and HostType interface `description`. [Locked: D3]
+- When any row's description is truncated, emit a migration-time **warning**
+  that includes the resource/table type and the count of truncated rows for
+  that type. Do **not** log description contents. Also call out truncation
+  in release notes.
 - Types without old fields leave columns as `''`.
 
 Pattern reference: `13_add_name.up.sql`, `16_add_labels.up.sql`,
@@ -316,6 +329,11 @@ This enhancement:
    `name`, `display_name` if that matches existing filter identifier
    style). Reject anything else with `InvalidArgument`.
 4. Defaults to `id asc` when `order` is empty (preserves current behavior).
+5. When the request specifies a non-`id` primary order (for example
+   `metadata.display_name asc`), append `id asc` as an implicit secondary
+   sort key unless `id` is already present in the order expression. This
+   keeps offset/limit pagination stable when `display_name` values are
+   duplicated.
 
 ### Server and test updates
 
@@ -355,8 +373,17 @@ NetworkClass, templates, and catalog items).
 No new authn/authz surfaces. Fields are ordinary Metadata readable/writable
 under existing object permissions and OPA tenancy. Descriptions are opaque
 user-controlled strings — same trust model as annotations and existing
-per-type descriptions. Validate length only; do not execute description
-content.
+per-type descriptions. The API validates length only and does not sanitize,
+transform, or execute description content.
+
+**Client safe rendering (required):** Treat `metadata.description` (and any
+future Markdown presentation of it) as untrusted user input. UI and CLI
+clients that render descriptions as Markdown or HTML **must** encode or
+sanitize before display (for example HTML-escape plain text, or run a
+Markdown renderer with a strict allowlist that strips scripts and unsafe
+URLs). Do not pass raw description strings into `innerHTML`, shell
+expansion, or other execution contexts. Broader UI hardening beyond this
+policy is tracked as a follow-up outside the server cutover.
 
 ### Failure Handling and Recovery
 
@@ -389,7 +416,10 @@ observed via normal migration runner logs.
 | Risk | Mitigation |
 |------|------------|
 | Breaking API for twelve types | One release with reserved fields; coordinate E2E and UI; changelog callout |
-| Truncation of Project descriptions > 256 | Document in release notes; truncate at migration |
+| Truncation of Project descriptions > 256 | Truncate at migration; emit per-type count warning (no content); document in release notes |
+| Accidental deletion of nested title/description | Path-specific JSON cleanup only; tests assert excluded nested fields remain |
+| Unstable List pages when display_name duplicates | Implicit secondary `id asc` on ordered lists |
+| XSS if clients render description as HTML/Markdown | Client encode/sanitize requirement in Security Considerations; UI follow-up |
 | Wide migration (many tables) | Follow established add-column migration pattern; test on representative tables in integration suite |
 | List `order` allowlist too narrow | Start with `id`, `name`, `display_name`; expand later without schema change |
 | Confusion with FieldDefinition.display_name | Document distinction in API.md and this design |
@@ -411,39 +441,39 @@ review explicitly rejected. [Locked: D1, D4, D6]
 
 ### Keep flat-shape title/description; only migrate spec-based types
 
-**Pros:** Smaller blast radius.  
+**Pros:** Smaller blast radius.
 **Cons:** Leaves inconsistent naming on platform types; rejected in PRD
-review. [Locked: D1, D4]  
+review. [Locked: D1, D4]
 **Rejection:** Locked decision.
 
 ### Store display_name/description only inside data JSON
 
-**Pros:** Avoids altering every table.  
+**Pros:** Avoids altering every table.
 **Cons:** Breaks Metadata column model; FilterTranslator Metadata path
-expects columns; inconsistent with `name`/`labels`.  
+expects columns; inconsistent with `name`/`labels`.
 **Rejection:** Violates GenericDAO Metadata persistence pattern
 [Codebase: fulfillment-service/internal/database/dao/generic_dao.go].
 
 ### Backend auto-populate display_name from metadata.name
 
-**Pros:** Clients always see a non-empty display_name.  
+**Pros:** Clients always see a non-empty display_name.
 **Cons:** Confuses users on edit (field appears set without user action);
-PRD deferred display behavior to clients. [Locked: D9]  
+PRD deferred display behavior to clients. [Locked: D9]
 **Rejection:** Clarification and PR review consensus against backend fill.
 
 ### Dual-write / deprecation window for title fields
 
-**Pros:** Softer client migration.  
+**Pros:** Softer client migration.
 **Cons:** Prolongs dual paths; PRD requires removal, not aliasing.
-[Locked: D1]  
+[Locked: D1]
 **Rejection:** Locked decision for one-shot removal.
 
 ### Fail migration if any description exceeds 256
 
-**Pros:** No silent data loss.  
-**Cons:** Blocks upgrade until operators manually shorten rows.  
+**Pros:** No silent data loss.
+**Cons:** Blocks upgrade until operators manually shorten rows.
 **Rejection:** Truncation chosen for operable upgrades; call out in release
-notes.
+notes and emit migration-time warnings with per-type truncated counts.
 
 ## Test Plan
 
@@ -455,17 +485,26 @@ notes.
   including clear-to-empty via update_mask.
 - FilterTranslator translates `this.metadata.display_name == 'x'`.
 - List order parses `metadata.display_name desc` and rejects unknown fields.
+- List order with `metadata.display_name` appends secondary `id asc` when
+  `id` is not already present.
 - Server tests for the twelve types create/update without title fields and
   assert Metadata values.
 - Migration unit/integration test: seed rows with flat and spec title/
   description (including >256 description), run migration, assert column
-  values and JSON keys removed.
+  values and **only** the migrated JSON paths removed.
+- Migration preserves excluded nested fields (`TemplateParameter.title`,
+  `FieldDefinition.display_name`, HostType interface `description`).
+- Migration emits a warning with resource type and truncated-row count when
+  descriptions exceed 256 (no description contents in logs).
+- Create/Update retry with the same payload remains idempotent.
 
 ### Integration (`ginkgo run it`)
 
 - Create Project / NetworkClass / ComputeInstanceCatalogItem with
   display_name; List with filter and order; Update clear; Get confirms
   empty string.
+- List with duplicate `display_name` values and `order=metadata.display_name`
+  returns stable pages across offset/limit (no duplicates/skips).
 
 ### E2E (osac-test-infra pytest)
 
@@ -476,12 +515,30 @@ notes.
 - Representative create/list/filter for a tenant resource (e.g.
   ComputeInstance) with display_name set.
 
+### Client / UI (follow-up)
+
+- UI and CLI unit tests covering encode/sanitize before Markdown/HTML
+  render of `metadata.description` land with the client hardening follow-up
+  (not required to unblock the server API cutover).
+
 ## Graduation Criteria
 
-Graduation criteria will be defined when targeting a release. Expected
-stages: Dev Preview → Tech Preview → GA based on production deployment
-feedback. Documentation of Metadata fields and migration notes must ship
-with the first user-facing release that includes the API break.
+Stages: Dev Preview → Tech Preview → GA.
+
+**Dev Preview (minimum for first user-facing release with this API break):**
+
+- Unit and integration suites above pass in CI, including migration backfill,
+  excluded nested JSON paths, truncation warnings, and stable ordered List
+  pagination with duplicate `display_name`.
+- E2E catalog-item and representative tenant create/list/filter paths pass
+  against a cluster running the migrated schema.
+- API.md / CLI help document `metadata.display_name` and `metadata.description`,
+  and release notes call out the breaking field removals and truncation
+  behavior.
+- Client safe-rendering policy is documented for UI/CLI consumers.
+
+**Tech Preview / GA:** Defined when targeting a release, based on production
+deployment feedback and completion of UI/CLI hardening follow-ups.
 
 ## Upgrade / Downgrade Strategy
 
@@ -541,6 +598,7 @@ None.
 
 ## Provenance
 
-Authored: draft @ design 0.4.2 - 75ae801, workspace main @ 3cb3621
+Authored: respond @ design 0.4.2 - 75ae801, workspace main @ 3cb3621
+Phases: draft, respond
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"design","workflow_version":"0.4.2","ai_workflows":"75ae801","source_repo":"3cb3621","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"design","workflow_version":"0.4.2","ai_workflows":"75ae801","source_repo":"3cb3621","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","respond"],"authoring_modes":["skill"],"context_changed":false} -->

--- a/enhancements/OSAC-2921-metadata-display-name/design.md
+++ b/enhancements/OSAC-2921-metadata-display-name/design.md
@@ -1,0 +1,546 @@
+---
+title: metadata-display-name
+authors:
+  - ushkalim@redhat.com
+creation-date: 2026-08-02
+last-updated: 2026-08-02
+tracking-link:
+  - https://redhat.atlassian.net/browse/OSAC-2921
+prd:
+  - "prd.md"
+see-also:
+  - "/enhancements/OSAC-1061-resource-names"
+replaces:
+  - N/A
+superseded-by:
+  - N/A
+---
+
+# Add Standardized display_name and description Fields to Resource Metadata
+
+## Summary
+
+This design adds optional `display_name` and `description` fields to the
+shared `Metadata` message in fulfillment-service, persists them as first-class
+database columns on every object table, implements List `order` support (today
+hardcoded to `id`), and removes per-resource `title`/`description` fields from
+the twelve object types that currently define them — with a one-shot data
+migration. See [PRD](prd.md) for detailed requirements.
+
+## Motivation
+
+OSAC objects already expose `metadata.name`, but that field is constrained to
+DNS-label format. Twelve object types worked around this with per-type
+`title` and/or `description` fields — some on `spec`, some as flat fields —
+while most types (ComputeInstance, VirtualNetwork, Subnet, PublicIP, and
+others) have no friendly label at all. Naming discussions recur for each new
+type, and clients must special-case which path holds the human-readable label.
+
+Two complementary naming features apply:
+
+- **OSAC-1061** makes `metadata.name` mandatory, unique, and immutable (DNS
+  identity).
+- **This enhancement** adds mutable, non-unique `metadata.display_name` and
+  `metadata.description` for natural-language labeling, and consolidates the
+  existing per-type fields onto Metadata. [Locked: D1, D2, D4]
+
+`metadata` fields are stored in dedicated SQL columns, not in the `data`
+JSONB document [Codebase: fulfillment-service/internal/database/dao/generic_dao.go].
+Adding Metadata fields therefore requires schema migration and GenericDAO
+changes, not proto-only edits.
+
+### Goals
+
+- Extend shared public and private `Metadata` with optional `display_name`
+  (max 63) and `description` (max 256), validated via buf.validate. [Locked: D5, D7, D8]
+- Persist both fields as columns on all object and archive tables and wire
+  them through GenericDAO create/update/list/makeMetadata and FilterTranslator.
+- Implement List `order` plumbing end-to-end so clients can sort by
+  `metadata.display_name` (and `metadata.name`, `id`). [Locked: D6]
+- Remove resource-level `title`/`description` from all twelve affected types
+  in one release, migrating existing values into Metadata. [Locked: D1, D4]
+- Update CLI table definitions, List docs, E2E helpers, and generated
+  osac-operator API bindings to the new fields. [Locked: D10]
+
+### Non-Goals
+
+- Mandating how UI/CLI present `display_name` versus `metadata.name` when
+  unset — display behavior remains a client decision. [Locked: D9]
+- Changing TemplateParameter `title`/`description`, HostType interface
+  `description`, or FieldDefinition `display_name`. [Locked: D3]
+- Aligning public/private Metadata field number divergence for existing
+  fields (`name` is 4 public / 6 private).
+- Encrypting or sanitizing description content beyond length validation.
+
+## Proposal
+
+Add two fields to `osac.public.v1.Metadata` and `osac.private.v1.Metadata`.
+Every object that embeds Metadata inherits them automatically. Persist the
+values in new `display_name` and `description` columns. Extend FilterTranslator
+so CEL filters can use `this.metadata.display_name`. Implement the documented
+but currently ignored List `order` parameter so sorting by
+`metadata.display_name` works.
+
+Remove `title`/`description` (or `description` alone for InstanceType) from
+the twelve types listed below, reserve the old proto field numbers and names,
+and migrate stored values from `data` JSON into the new columns in the same
+release.
+
+```mermaid
+flowchart LR
+  Client["API / CLI / UI"] --> FS["fulfillment-service"]
+  FS --> Proto["Metadata proto\ndisplay_name, description"]
+  FS --> DAO["GenericDAO"]
+  DAO --> Cols["SQL columns\ndisplay_name, description"]
+  DAO --> JSON["data jsonb\n(spec / flat fields)"]
+  Migrate["One-shot migration"] --> Cols
+  Migrate --> JSON
+```
+
+The diagram shows that Metadata fields live in columns, while remaining
+object payload stays in `data`. Migration copies old `title`/`description`
+out of `data` into the new columns, then the proto removal drops those
+JSON paths.
+
+**Identity model** (alongside OSAC-1061):
+
+| Field | Role |
+|-------|------|
+| `id` | System-assigned unique identifier |
+| `metadata.name` | DNS-label name (OSAC-1061: mandatory, unique, immutable) |
+| `metadata.display_name` | Optional mutable non-unique friendly label (max 63) |
+| `metadata.description` | Optional mutable opaque string (max 256) |
+
+### Workflow Description
+
+**Actors:** Tenant User, Tenant Admin, Cloud Provider Admin, Cloud
+Infrastructure Admin — any persona that creates or updates objects via
+gRPC, REST, or CLI (`osac`).
+
+#### Create with display_name
+
+Starting state: authenticated caller with create permission on a type
+(e.g. ComputeInstance).
+
+1. Caller submits Create with `metadata.name` (DNS-label) and optional
+   `metadata.display_name` / `metadata.description`.
+2. Protovalidate rejects values exceeding max length (`InvalidArgument`
+   with field violations).
+3. GenericDAO writes `display_name` and `description` columns (empty
+   string when omitted) and returns the created object.
+
+#### Update and clear
+
+1. Caller submits Update with `update_mask` including
+   `metadata.display_name` and/or `metadata.description`.
+2. Setting a field to `""` clears it (same convention as clearing other
+   plain Metadata strings).
+3. Omitting a field from `update_mask` leaves the stored value unchanged.
+
+#### List filter and sort
+
+1. Filter: `this.metadata.display_name == 'Dell PowerEdge XE9680'`
+   (case-sensitive CEL → SQL, same as other string filters).
+2. Order: `metadata.display_name asc` or `metadata.display_name desc`.
+   Empty values sort as empty strings (first under ASC).
+3. Unsupported order fields return `InvalidArgument`.
+
+#### Error paths
+
+- Length violation → `InvalidArgument` (protovalidate).
+- Unknown filter metadata field → filter translation error surfaced as
+  `InvalidArgument`.
+- Clients still sending removed `title`/`description` after upgrade →
+  unknown fields discarded on unmarshal where `DiscardUnknown` applies, or
+  rejected by clients generated against the new schema; servers no longer
+  persist those paths.
+
+### API Extensions
+
+No new gRPC services or CRDs. Changes are to shared Metadata and twelve
+existing object messages (public and private).
+
+**Modified shared type:**
+
+| Message | Change |
+|---------|--------|
+| `osac.public.v1.Metadata` | Add `display_name = 11`, `description = 12` |
+| `osac.private.v1.Metadata` | Add `display_name = 11`, `description = 12` |
+
+**Removed fields (reserve numbers and names):**
+
+| Object | Removed fields |
+|--------|----------------|
+| Project | `spec.title`, `spec.description` |
+| Role | `spec.title`, `spec.description` |
+| IdentityProvider | `spec.title`, `spec.description` |
+| InstanceType | `spec.description` |
+| NetworkClass | `title`, `description` |
+| HostType | `title`, `description` (not nested interface `description`) |
+| ClusterTemplate | `title`, `description` |
+| ComputeInstanceTemplate | `title`, `description` |
+| BareMetalInstanceTemplate | `title`, `description` |
+| ClusterCatalogItem | `title`, `description` |
+| ComputeInstanceCatalogItem | `title`, `description` |
+| BareMetalInstanceCatalogItem | `title`, `description` |
+
+**List behavior change:** `GenericServer.List` and `GenericDAO.List`
+honor the existing `order` request field (currently ignored).
+
+**Operational impact:** No new controllers or webhooks. API servers must
+roll out with the DB migration. Until migration completes, service startup
+fails on missing columns (standard migration gating).
+
+## UX Alignment
+
+Display behavior (whether to show `display_name`, `name`, or both) is not
+mandated by the PRD [Locked: D9]. This section maps @temp-api field
+locations to the new Metadata fields so UI work can proceed once the API
+ships.
+
+| UI / @temp-api location | Current field | Target field | Notes |
+|-------------------------|---------------|--------------|-------|
+| `project.ts` `CreateProjectBody.spec.title` | `spec.title` | `metadata.display_name` | Required in UI create body today → becomes optional Metadata |
+| `project.ts` `CreateProjectBody.spec.description` | `spec.description` | `metadata.description` | |
+| `networking.ts` NetworkClass `title` / `description` | top-level | `metadata.display_name` / `metadata.description` | |
+| `identity-provider.ts` `spec.title` | `spec.title` | `metadata.display_name` | |
+| `storage-tier.ts` `metadata.description` | already on metadata | `metadata.description` | Aligns with this design |
+| `storage-tier.ts` `spec.displayName` | `spec.displayName` | `metadata.display_name` | **Deviation:** UI placed friendly name on spec; backend standard is Metadata — UI should move to `metadata.display_name` |
+| Catalog / template pages (when bound to live API) | flat `title` | `metadata.display_name` | Same consolidation as NetworkClass |
+| FieldDefinition `display_name` | N/A | unchanged | Different concept (catalog field labels) |
+
+**Justification for StorageTier deviation:** Backend Metadata is the
+canonical home for friendly naming across all types. Moving StorageTier
+UI to `metadata.display_name` avoids a second naming convention.
+
+## Implementation Details/Notes/Constraints
+
+### Proto schema
+
+Public and private Metadata gain identical fields and docs
+[Codebase: fulfillment-service/docs/API.md]:
+
+```protobuf
+// Human-friendly display name. Optional, not unique, mutable.
+// Not constrained to DNS-label format.
+string display_name = 11 [(buf.validate.field).string = {
+  max_len: 63
+}];
+
+// Optional human-friendly description. Opaque string; clients may
+// treat content as Markdown. Not unique, mutable.
+string description = 12 [(buf.validate.field).string = {
+  max_len: 256
+}];
+```
+
+Empty string means unset. No pattern constraint. Length uses protovalidate
+Unicode code-point counting.
+
+For each removed field, follow existing reserved patterns:
+
+```protobuf
+reserved N;
+reserved "title";  // or "description"
+```
+
+Update `docs/API.md` Metadata table and List `order` examples that currently
+cite `title`.
+
+### Database migration
+
+For every object table and its archive table that uses the GenericDAO column
+layout:
+
+```sql
+alter table <table> add column display_name text not null default '';
+alter table <table> add column description text not null default '';
+```
+
+Optional index for filter/sort hot paths (same rationale as `*_by_name`):
+
+```sql
+create index <table>_by_display_name on <table> (display_name);
+```
+
+**Data backfill** (same migration, before clients rely on removal):
+
+| Source path in `data` | Destination column |
+|----------------------|--------------------|
+| `title` (flat) | `display_name` |
+| `spec.title` | `display_name` |
+| `description` (flat) | `description` |
+| `spec.description` | `description` |
+
+Rules:
+
+- Prefer `title` / `spec.title` for `display_name` when present.
+- Copy description from the corresponding path; if longer than 256 Unicode
+  code points, truncate to 256.
+- After copy, remove the old keys from `data` JSON so leftover fields do not
+  linger after proto reservation.
+- Types without old fields leave columns as `''`.
+
+Pattern reference: `13_add_name.up.sql`, `16_add_labels.up.sql`,
+`17_add_annotations.up.sql`.
+
+### GenericDAO
+
+Extend `metadataIface` with `GetDisplayName`/`SetDisplayName` and
+`GetDescription`/`SetDescription`. Update create, update, list scan,
+and `makeMetadata` to read/write the new columns. Extend the list SELECT
+column list accordingly
+[Codebase: fulfillment-service/internal/database/dao/generic_dao*.go].
+
+### FilterTranslator
+
+Add `display_name` (and `description` if ordered/filtered) to
+`translateSelectThisMdField` alongside `name`, mapping to the SQL column
+[Codebase: fulfillment-service/internal/database/dao/filter_translator.go].
+
+### List order implementation
+
+Today `GenericServer.List` only forwards filter/offset/limit, and
+`GenericDAO.List` hardcodes `order by id`
+[Codebase: fulfillment-service/internal/servers/generic_server.go,
+fulfillment-service/internal/database/dao/generic_dao_list.go].
+
+This enhancement:
+
+1. Adds `GetOrder()` to the List request interface in GenericServer and
+   `SetOrder` on `ListRequest`.
+2. Parses `order` as SQL-like tokens (`field [asc|desc]`, comma-separated),
+   matching API.md examples.
+3. Allows an explicit allowlist: `id`, `metadata.name` → `name`,
+   `metadata.display_name` → `display_name` (and the bare column forms
+   `name`, `display_name` if that matches existing filter identifier
+   style). Reject anything else with `InvalidArgument`.
+4. Defaults to `id asc` when `order` is empty (preserves current behavior).
+
+### Server and test updates
+
+- Update unit tests that set/assert `.Title` / `.Description` /
+  `spec.title` on the twelve types to use Metadata fields
+  [Codebase: fulfillment-service/internal/servers/*_test.go].
+- No per-type business logic is required beyond proto regeneration and
+  test/fixture updates; GenericDAO handles persistence.
+
+### CLI table rendering
+
+Update CEL column expressions in
+`fulfillment-service/internal/rendering/tables/` that reference
+`this.title`, `this.spec.title`, or `this.spec.description` to
+`this.metadata.display_name` / `this.metadata.description` (including
+public and private Role, Project, IdentityProvider, InstanceType,
+NetworkClass, templates, and catalog items).
+
+### Downstream components
+
+| Component | Change |
+|-----------|--------|
+| osac-operator | Regenerate / bump private API dependency; no controller logic changes expected for Title/Description |
+| osac-test-infra | Update `grpc_client.py` and catalog/BMaaS fixtures from `title=` to Metadata fields |
+| osac-ux / osac-ui | After API availability, move create/update bodies per UX Alignment |
+| osac-installer | No Helm changes beyond picking up new fulfillment-service image |
+
+### Dependency order
+
+1. fulfillment-service (proto, migration, DAO, servers, CLI tables, docs)
+2. osac-operator (generated API)
+3. osac-test-infra E2E
+4. UI clients
+
+### Security Considerations
+
+No new authn/authz surfaces. Fields are ordinary Metadata readable/writable
+under existing object permissions and OPA tenancy. Descriptions are opaque
+user-controlled strings — same trust model as annotations and existing
+per-type descriptions. Validate length only; do not execute description
+content.
+
+### Failure Handling and Recovery
+
+| Failure | Behavior | Recovery |
+|---------|----------|----------|
+| Migration fails mid-flight | Transaction rollback (standard goose/migration runner) | Fix SQL and re-run; columns not partially applied |
+| Create/Update with overlong display_name/description | `InvalidArgument` field violation | Client shortens value |
+| List with unsupported `order` field | `InvalidArgument` | Client uses allowlisted fields |
+| Filter on `metadata.display_name` before FilterTranslator update | Translation error | Deploy DAO change with proto |
+| Old client sends removed `title` | Field ignored or rejected by new stubs | Client upgrade |
+
+Create/Update/List remain idempotent under retry for the same payload.
+No controller reconciliation is involved.
+
+### RBAC / Tenancy
+
+No RBAC or tenancy changes required. `display_name` and `description`
+inherit the parent object's tenant/project visibility and existing OPA
+policies. Platform-defined objects (NetworkClass, HostType, catalog items,
+templates) remain visible under current platform rules.
+
+### Observability and Monitoring
+
+No new Prometheus metrics or Kubernetes events. Existing gRPC and DAO
+operation duration metrics cover Create/Update/List. Migration progress is
+observed via normal migration runner logs.
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking API for twelve types | One release with reserved fields; coordinate E2E and UI; changelog callout |
+| Truncation of Project descriptions > 256 | Document in release notes; truncate at migration |
+| Wide migration (many tables) | Follow established add-column migration pattern; test on representative tables in integration suite |
+| List `order` allowlist too narrow | Start with `id`, `name`, `display_name`; expand later without schema change |
+| Confusion with FieldDefinition.display_name | Document distinction in API.md and this design |
+
+### Drawbacks
+
+- Breaking change across many protos, tests, CLI tables, and clients in one
+  cut — higher coordination cost than additive-only Metadata fields.
+- Truncating long Project descriptions loses data that previously fit in
+  1024-character comments.
+- Implementing general List `order` expands scope beyond Metadata fields,
+  but is required because sort is documented yet not implemented today.
+
+These are justified by locked PRD decisions (full removal, filter/sort by
+display_name) and by avoiding a prolonged dual-field period that the PR
+review explicitly rejected. [Locked: D1, D4, D6]
+
+## Alternatives (Not Implemented)
+
+### Keep flat-shape title/description; only migrate spec-based types
+
+**Pros:** Smaller blast radius.  
+**Cons:** Leaves inconsistent naming on platform types; rejected in PRD
+review. [Locked: D1, D4]  
+**Rejection:** Locked decision.
+
+### Store display_name/description only inside data JSON
+
+**Pros:** Avoids altering every table.  
+**Cons:** Breaks Metadata column model; FilterTranslator Metadata path
+expects columns; inconsistent with `name`/`labels`.  
+**Rejection:** Violates GenericDAO Metadata persistence pattern
+[Codebase: fulfillment-service/internal/database/dao/generic_dao.go].
+
+### Backend auto-populate display_name from metadata.name
+
+**Pros:** Clients always see a non-empty display_name.  
+**Cons:** Confuses users on edit (field appears set without user action);
+PRD deferred display behavior to clients. [Locked: D9]  
+**Rejection:** Clarification and PR review consensus against backend fill.
+
+### Dual-write / deprecation window for title fields
+
+**Pros:** Softer client migration.  
+**Cons:** Prolongs dual paths; PRD requires removal, not aliasing.
+[Locked: D1]  
+**Rejection:** Locked decision for one-shot removal.
+
+### Fail migration if any description exceeds 256
+
+**Pros:** No silent data loss.  
+**Cons:** Blocks upgrade until operators manually shorten rows.  
+**Rejection:** Truncation chosen for operable upgrades; call out in release
+notes.
+
+## Test Plan
+
+### Unit (Ginkgo — `internal/`)
+
+- Protovalidate accepts display_name length 0–63 and description 0–256;
+  rejects longer values.
+- GenericDAO Create/Update/Get round-trips display_name and description,
+  including clear-to-empty via update_mask.
+- FilterTranslator translates `this.metadata.display_name == 'x'`.
+- List order parses `metadata.display_name desc` and rejects unknown fields.
+- Server tests for the twelve types create/update without title fields and
+  assert Metadata values.
+- Migration unit/integration test: seed rows with flat and spec title/
+  description (including >256 description), run migration, assert column
+  values and JSON keys removed.
+
+### Integration (`ginkgo run it`)
+
+- Create Project / NetworkClass / ComputeInstanceCatalogItem with
+  display_name; List with filter and order; Update clear; Get confirms
+  empty string.
+
+### E2E (osac-test-infra pytest)
+
+- Catalog item lifecycle tests use `metadata.display_name` instead of
+  `title`.
+- BMaaS template fixtures stop passing top-level `title` for resource-level
+  fields (TemplateParameter / FieldDefinition display_name unchanged).
+- Representative create/list/filter for a tenant resource (e.g.
+  ComputeInstance) with display_name set.
+
+## Graduation Criteria
+
+Graduation criteria will be defined when targeting a release. Expected
+stages: Dev Preview → Tech Preview → GA based on production deployment
+feedback. Documentation of Metadata fields and migration notes must ship
+with the first user-facing release that includes the API break.
+
+## Upgrade / Downgrade Strategy
+
+**Upgrade:**
+
+1. Apply DB migration (add columns, backfill, scrub old JSON keys).
+2. Deploy fulfillment-service build with new protos and DAO/order support.
+3. Deploy osac-operator with regenerated API.
+4. Update E2E and UI clients.
+
+**Downgrade:**
+
+- Not supported without restoring removed proto fields and reverse
+  migrating columns back into `data` JSON. Operators who must roll back
+  should restore the previous schema and binary together from backup.
+- Archive tables receive the same columns so archived rows remain readable
+  by the new binary.
+
+## Version Skew Strategy
+
+- **Old client → new server:** Create/Update without Metadata display
+  fields succeed (empty columns). Clients sending removed `title` fields
+  no longer persist them.
+- **New client → old server:** New Metadata field numbers are ignored if
+  the server predates the change; clients should not rely on display_name
+  until the server version includes this enhancement.
+- **osac-operator:** Must not deploy a regenerated API that assumes
+  removed Title fields against an old fulfillment-service; follow
+  dependency order above.
+
+## Support Procedures
+
+**Detection:**
+
+- Migration failures appear in fulfillment-service migration logs at
+  startup.
+- Clients using removed fields see missing data or schema errors after
+  upgrade.
+- Unsupported `order` expressions return `InvalidArgument`.
+
+**Disabling:**
+
+- Feature is core API shape; cannot be feature-flagged independently.
+  Rollback requires previous schema + binary.
+
+**Recovery:**
+
+- Re-run fixed migration; redeploy matching binary.
+- For truncated descriptions, restore longer text from pre-upgrade backup
+  if needed and store externally or shorten to 256.
+
+## Infrastructure Needed
+
+None.
+
+---
+
+## Provenance
+
+Authored: draft @ design 0.4.2 - 75ae801, workspace main @ 3cb3621
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"design","workflow_version":"0.4.2","ai_workflows":"75ae801","source_repo":"3cb3621","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false} -->


### PR DESCRIPTION
## Summary

Design for **[OSAC-2921](https://redhat.atlassian.net/browse/OSAC-2921)**: standardize human-readable naming via `metadata.display_name` and `metadata.description`, remove conflicting `title`/`description` fields from 12 resource types, and enable List filter/sort by `display_name`.

**Related PRD:** https://github.com/osac-project/enhancement-proposals/pull/141

## Scope

- Extend shared Metadata proto + GORM columns; wire Create/Update/Get/List; implement List `order` (currently hardcoded to `id`)
- Migrate Project, Role, IdentityProvider, InstanceType (metadata-bearing) and eight flat-shape types to Metadata
- CLI (`--display-name` / `--description`), API docs, UI @temp-api, operator CRD alignment, E2E + user docs

## Key decisions

| Topic | Choice |
|-------|--------|
| Storage | Dedicated DB columns (not jsonb) |
| Clear semantics | Empty string clears; omit = unchanged |
| List order | Implement API-documented `order` for metadata fields |
| Description overflow | Truncate >256 with warning (migration) |
| Breaking change | One-shot removal of title/description |

## Decomposition

5 epics / 17 stories (in local design artifacts; not in this PR).

## Review focus

1. Empty-string clear vs omit-unchanged semantics
2. List `order` implementation plan vs FilterTranslator allowlist
3. Flat-shape → Metadata migration (Host especially: `name` stays)
4. Operator CRD alignment timing relative to API cutover

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design proposal for standardized optional metadata display names and descriptions across public and private resources.
  * Documented consistent validation, filtering, list ordering, persistence, migration, and compatibility behavior.
  * Defined migration and backfill plans for existing resource titles and descriptions.
  * Specified updates needed across APIs, command-line tools, clients, testing, rollout, and recovery procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->