### PR TITLE
NO-ISSUE: Remove region references from networking designs

### DIFF
--- a/enhancements/OSAC-1433-unified-networking/design.md
+++ b/enhancements/OSAC-1433-unified-networking/design.md
@@ -81,8 +81,8 @@ OSAC networking is handled by two managers:
 - **K8s Manager** (optional) — handles everything needed to make VMs part of
   the fabric: creates the K8s overlay (e.g., CUDN with LocalNet) and bridges
   it to the fabric segment. Also creates MetalLB IPAddressPool CRs at subnet
-  creation time for CaaS VIP allocation. Needed for regions that host VMs or
-  CaaS clusters. Once VMs are on the fabric, the fabric manager handles them
+  creation time for CaaS VIP allocation. Needed for deployments that host
+  both VMs and BMs and require multi-tenancy across all. Once VMs are on the fabric, the fabric manager handles them
   identically to bare-metal servers.
 
 #### Why Two Managers?
@@ -112,7 +112,6 @@ kind: NetworkClass
 metadata:
   name: moc-region-1
 spec:
-  region: moc-region-1
   fabricManager: netris
   k8sManager: cudn_localnet
 status:
@@ -128,7 +127,6 @@ kind: NetworkClass
 metadata:
   name: bos-region-1
 spec:
-  region: bos-region-1
   fabricManager: neutron
   k8sManager: cudn_localnet
 status:
@@ -136,7 +134,7 @@ status:
     addressFamily: ipv4
 ```
 
-**BM-only region (no VMs):**
+**BM-only deployment (no VMs):**
 
 ```yaml
 apiVersion: osac.openshift.io/v1alpha1
@@ -144,7 +142,6 @@ kind: NetworkClass
 metadata:
   name: gpu-region-1
 spec:
-  region: gpu-region-1
   fabricManager: netris
 status:
   capabilities:
@@ -160,7 +157,7 @@ manager and k8sManager ConfigMaps and populates `status.capabilities`
 automatically.
 
 If the provider needs to restrict a capability that the managers support
-(e.g., disable IPv6 in a region even though the fabric manager supports
+(e.g., disable IPv6 in a deployment even though the fabric manager supports
 it), they can set `spec.disableCapabilities`:
 
 ```yaml
@@ -286,14 +283,14 @@ that subnet are reachable from the fabric at their subnet IP.
 
 VirtualNetwork and Subnet do not carry a scope or service field. Subnets are
 infrastructure-agnostic — the dispatcher provisions both the fabric segment
-and (if the region has a k8sManager) the K8s overlay for every subnet. Any
-resource type can be placed on any subnet.
+and (if the NetworkClass has a k8sManager) the K8s overlay for every subnet.
+Any resource type can be placed on any subnet.
 
 At subnet creation, the dispatcher runs:
 
 1. **Fabric manager** — creates fabric segment (e.g., VLAN, VPC)
 2. **K8s manager** (if present) — creates K8s overlay on each hosting
-   cluster in the region and bridges it to the fabric segment
+   cluster in the deployment and bridges it to the fabric segment
 
 VMs are placed in the K8s overlay (which is bridged to the fabric), BM
 servers and cluster nodes are placed directly on the fabric segment. The
@@ -303,7 +300,7 @@ resources, regardless of type, are on the fabric.
 ### Dispatcher (Operator Composition Logic)
 
 The osac-operator acts as a **dispatcher**: when reconciling any networking
-resource, it resolves the NetworkClass for the region and calls the
+resource, it resolves the NetworkClass and calls the
 appropriate managers. Each manager corresponds to an Ansible role — the
 dispatcher triggers the appropriate AAP playbook, passing the resource and
 context as the event payload.
@@ -368,13 +365,13 @@ K8s manager the provider has deployed. Annotations mark what is **new** or
 #### Provider Setup
 
 1. Provider deploys hosting cluster(s) and fabric controller
-2. Provider creates NetworkClass for the region (**new** — provider-only,
+2. Provider creates NetworkClass for the deployment (**new** — provider-only,
    tenants never see it)
 3. Provider creates ExternalIPPool (**renamed** from PublicIPPool):
 
 ```bash
 osac admin create externalippool \
-  --region moc-region-1 \
+  --network-class moc-region-1 \
   --cidrs 203.0.113.0/24 \
   --ip-family ipv4 \
   --name external-pool-1
@@ -391,7 +388,7 @@ servers.
 **Create VirtualNetwork:**
 
 ```bash
-osac create virtualnetwork --region moc-region-1 --cidr 10.0.0.0/16 \
+osac create virtualnetwork --network-class moc-region-1 --cidr 10.0.0.0/16 \
   --name my-net
 ```
 
@@ -405,7 +402,7 @@ osac create subnet --virtual-network my-net --cidr 10.0.1.0/24 \
 ```
 
 The fabric manager creates a fabric segment (e.g., VLAN) for the subnet.
-If the region has a K8s manager, it also creates a K8s overlay on each
+If the NetworkClass has a K8s manager, it also creates a K8s overlay on each
 hosting cluster and bridges it to the fabric segment. After this step, VMs placed in the
 overlay and BM servers with switch ports on the fabric segment are in the
 same L2 domain.
@@ -739,9 +736,9 @@ in the VN — VMs, BM servers, cluster nodes — since all are on the fabric.
 
 ```protobuf
 message VirtualNetworkSpec {
-  string region = 1;       // required, immutable
-  string ipv4_cidr = 2;    // optional, immutable
-  string ipv6_cidr = 3;    // optional, immutable
+  string network_class = 1; // required, immutable
+  string ipv4_cidr = 2;     // optional, immutable
+  string ipv6_cidr = 3;     // optional, immutable
 }
 ```
 
@@ -1101,9 +1098,9 @@ determines the target.
 is handled by the CaaS template (provider-configured). The `primary` field
 does not apply to `ClusterNetworkAttachment`.
 
-#### Multiple Hosting Clusters Per Region
+#### Multiple Hosting Clusters Per Deployment
 
-Multiple hosting clusters are supported per region. At subnet creation, the
+Multiple hosting clusters are supported per deployment. At subnet creation, the
 k8sManager creates a K8s overlay on each hosting cluster and bridges it to
 the fabric segment. VMs on different hosting clusters share the same subnet
 via the fabric.
@@ -1118,13 +1115,13 @@ separate enhancement.
 DNS is a service-integration concern, not part of the networking API. CaaS
 template roles create DNS records. A DNS API is a separate enhancement.
 
-#### BM-Only Regions
+#### BM-Only Deployments
 
-If a region's NetworkClass has no k8sManager, the region does not support
-VMs or CaaS clusters. ComputeInstance creation is rejected if the target
-region has no k8sManager — there is no K8s overlay to place the VM on.
-Cluster creation is also rejected — without a k8sManager, there is no
-MetalLB IPAddressPool for VIP allocation on the hosting cluster.
+If a NetworkClass has no k8sManager, the deployment does not support VMs or CaaS
+clusters. ComputeInstance creation is rejected if the target NetworkClass
+has no k8sManager — there is no K8s overlay to place the VM on. Cluster
+creation is also rejected — without a k8sManager, there is no MetalLB
+IPAddressPool for VIP allocation on the hosting cluster.
 
 #### CIDR Overlap
 

--- a/enhancements/OSAC-1435-vmaas-networking/design.md
+++ b/enhancements/OSAC-1435-vmaas-networking/design.md
@@ -50,7 +50,7 @@ ComputeInstance already participates in the networking API. Today's flow:
 - No per-resource-type attachment message (`ComputeNetworkAttachment`)
 - Single-NIC only — template creates one `l2bridge` interface
 - No dispatcher — uses `implementation_strategy` annotation
-- BM-only region validation (reject VM when no k8sManager)
+- BM-only deployment validation (reject VM when no k8sManager)
 - Auto ExternalIP allocation (tenant must manually create ExternalIP + ExternalIPAttachment)
 
 ### Goals
@@ -59,7 +59,7 @@ ComputeInstance already participates in the networking API. Today's flow:
 - Resource-specific attachment message (`ComputeNetworkAttachment`) with `primary` field
 - Optional `network_attachments` field — populate with tenant defaults when omitted
 - Auto ExternalIP attachment (`auto_external_ip_attachment`) for single-call inbound connectivity
-- BM-only region validation to reject VM provisioning when no k8s_manager is available
+- BM-only deployment validation to reject VM provisioning when no k8s_manager is available
 
 ### Non-Goals
 
@@ -75,7 +75,7 @@ ComputeInstance already participates in the networking API. Today's flow:
 
 1. **Tenant creates VirtualNetwork:**
    ```bash
-   osac create virtualnetwork --region moc-region-1 --cidr 10.0.0.0/16 --name my-net
+   osac create virtualnetwork --network-class moc-bm-virt --cidr 10.0.0.0/16 --name my-net
    ```
    - fulfillment-service → creates VirtualNetwork CR
    - osac-operator VirtualNetwork controller → dispatcher resolves NetworkClass → calls `osac.templates.{{ fabric_manager }}.create_virtual_network`
@@ -241,7 +241,7 @@ The feedback controller populates `ComputeNetworkAttachmentStatuses` by watching
 
 - During migration: accept both old field (14) and new field (18). If both set, reject. If old set, convert internally.
 - Primary validation: if multiple attachments, exactly one primary
-- BM-only region check: if region's NetworkClass has no k8sManager, reject ComputeInstance creation for that region
+- BM-only deployment check: if the NetworkClass has no k8sManager, reject ComputeInstance creation
 
 #### Template Changes (osac-aap)
 
@@ -327,7 +327,7 @@ New structured log events:
 
 New Kubernetes events on ComputeInstance:
 - `NetworkingResolved`: subnet → namespace resolution succeeded
-- `NetworkingResolutionFailed`: subnet resolution failed (not found, not Ready, BM-only region)
+- `NetworkingResolutionFailed`: subnet resolution failed (not found, not Ready, BM-only deployment)
 - `AutoExternalIPCreated`: ExternalIP and ExternalIPAttachment auto-provisioned
 
 No new metrics or alerts (existing provisioning duration and failure rate metrics apply).
@@ -392,7 +392,7 @@ Resolved: Return error, no resource persisted. Pool capacity checked synchronous
 
 - fulfillment-service: primary validation (reject >1 primary, accept single implicit primary, accept explicit primary)
 - fulfillment-service: dual-field validation (reject both old and new, convert old → new)
-- fulfillment-service: BM-only region validation (reject VM when no k8s_manager)
+- fulfillment-service: BM-only deployment validation (reject VM when no k8s_manager)
 - fulfillment-service: auto ExternalIP pool selection (pick READY pool with most capacity, respect IP family)
 - osac-operator ComputeInstance controller: `PrimarySubnetRef()` resolution (explicit primary, implicit single-attachment)
 
@@ -401,7 +401,7 @@ Resolved: Return error, no resource persisted. Pool capacity checked synchronous
 - E2E: create ComputeInstance with multiple attachments, verify multi-NIC KubeVirt VM provisioned
 - E2E: create ComputeInstance with `--external-ip-attachment`, verify auto ExternalIP + ExternalIPAttachment created, DNAT rule functional
 - E2E: delete ComputeInstance with auto-provisioned resources, verify ExternalIPAttachment and ExternalIP cleaned up
-- E2E: create ComputeInstance in BM-only region, verify error returned
+- E2E: create ComputeInstance in BM-only deployment, verify error returned
 - E2E: create ComputeInstance with old `network_attachments` field, verify backward compat (internal conversion)
 
 ### Tricky Test Cases
@@ -486,12 +486,12 @@ kubectl describe computeinstance <name> -n <namespace>
 # Check status.conditions for NetworkingResolutionFailed
 ```
 
-**Cause:** Subnet not found, not Ready, or BM-only region (no k8s_manager)
+**Cause:** Subnet not found, not Ready, or BM-only deployment (no k8s_manager)
 
 **Resolution:**
 1. Check Subnet status: `kubectl get subnet <subnet-name> -n <namespace>`
 2. If Subnet is not Ready, investigate Subnet provisioning failure (check AAP job logs)
-3. If BM-only region, tenant must create VM in a region with k8s_manager configured
+3. If BM-only deployment, tenant must create VM in a deployment with k8s_manager configured
 
 ### Symptom: Multi-NIC VM has no default gateway
 

--- a/enhancements/OSAC-1435-vmaas-networking/prd.md
+++ b/enhancements/OSAC-1435-vmaas-networking/prd.md
@@ -19,7 +19,7 @@ Tenants cannot create VMs with multiple network interfaces or designate which in
 - A tenant can create a VM with multiple network interfaces on different subnets, designating one as primary
 - A tenant can create a VM with `--external-ip-attachment` and have the system allocate an external IP and attach it automatically for inbound access
 - A tenant can create a VM without specifying networking details — the system uses the tenant's default subnet and security group
-- The platform prevents VM creation in regions that do not support virtualization
+- The platform prevents VM creation in deployments that do not support virtualization
 
 ### 2.2 Non-Goals
 
@@ -34,7 +34,7 @@ Tenants cannot create VMs with multiple network interfaces or designate which in
 - As a Tenant User, I want to designate one network interface as primary, so that it provides the VM's default gateway and DNS configuration
 - As a Tenant User, I want to create a VM with `--external-ip-attachment`, so that the VM is externally reachable without manually allocating an IP
 - As a Tenant User, I want to create a VM without specifying network details, so that the system uses my default subnet and security group and I can get started quickly
-- As a Tenant User, I want clear error messages when I try to create a VM in a region that only supports bare-metal servers, so that I understand the limitation and can choose a different region
+- As a Tenant User, I want clear error messages when I try to create a VM in a deployment that only supports bare-metal servers, so that I understand the limitation and can choose a different deployment
 
 ### Tenant Admin Stories
 
@@ -43,7 +43,7 @@ Tenants cannot create VMs with multiple network interfaces or designate which in
 
 ### Cloud Infrastructure Admin Stories
 
-- As a Cloud Infrastructure Admin, I want to configure which regions support VM provisioning, so that VM creation is rejected with a clear error in BM-only regions
+- As a Cloud Infrastructure Admin, I want to configure which deployments support VM provisioning, so that VM creation is rejected with a clear error in BM-only deployments
 
 ### Cloud Provider Admin Stories
 
@@ -70,9 +70,9 @@ Tenants cannot create VMs with multiple network interfaces or designate which in
 
 - **FR-5:** The allocated IP address for each network attachment is visible in the VM status after provisioning completes. When an external IP is attached to a VM, inbound traffic to the external IP is routed to the VM's primary attachment IP. [User]
 
-#### Region Validation
+#### Deployment Validation
 
-- **FR-6:** When a VM is created, the platform validates that the target region supports virtualization. If the region only supports bare-metal servers, the create request fails with a clear error message explaining the limitation. [User]
+- **FR-6:** When a VM is created, the platform validates that the target deployment supports virtualization. If the deployment only supports bare-metal servers, the create request fails with a clear error message explaining the limitation. [User]
 
 #### Backward Compatibility
 
@@ -86,7 +86,7 @@ Tenants cannot create VMs with multiple network interfaces or designate which in
 
 - [ ] A Tenant User can create a VM with multiple `--network-attachment` flags and designate one as `--primary`
 - [ ] A Tenant User can create a VM with `--external-ip-attachment` and no explicit network configuration — the VM is created on the default subnet with an auto-provisioned external IP for inbound access
-- [ ] Creating a VM in a bare-metal-only region returns an error with a clear message
+- [ ] Creating a VM in a bare-metal-only deployment returns an error with a clear message
 - [ ] A multi-interface VM is provisioned with all interfaces operational, with the primary interface providing the default gateway
 - [ ] VM status shows the allocated IP address for each network attachment after provisioning completes
 - [ ] External IP attachment with a VM target routes inbound traffic to the VM's primary attachment IP
@@ -98,7 +98,7 @@ Tenants cannot create VMs with multiple network interfaces or designate which in
 ## 6. Assumptions
 
 - The tenant has default networking resources (virtual network, subnet, security group) pre-created by the platform (see Default Networking PRD). If defaults are not configured, creating a VM without explicit network configuration fails with a clear error.
-- The target region supports virtualization. Bare-metal-only regions do not support VMs.
+- The target deployment supports virtualization. Bare-metal-only deployments do not support VMs.
 
 ## 7. Dependencies
 

--- a/enhancements/OSAC-1436-caas-networking/design.md
+++ b/enhancements/OSAC-1436-caas-networking/design.md
@@ -99,7 +99,7 @@ These steps are identical to VMaaS/BMaaS — the networking API is uniform.
 
 1. **Create VirtualNetwork:**
    ```bash
-   osac create virtualnetwork --region moc-region-1 --cidr 10.0.0.0/16 --name my-net
+   osac create virtualnetwork --network-class moc-bm-1 --cidr 10.0.0.0/16 --name my-net
    ```
    Dispatcher → `osac.templates.{{ fabric_manager }}.create_virtual_network`
 
@@ -107,7 +107,7 @@ These steps are identical to VMaaS/BMaaS — the networking API is uniform.
    ```bash
    osac create subnet --virtual-network my-net --cidr 10.0.1.0/24 --name my-subnet
    ```
-   Dispatcher → TWO jobs: fabric_manager creates VLAN/fabric segment + k8s_manager creates CUDN overlay (if region hosts VMs)
+   Dispatcher → TWO jobs: fabric_manager creates VLAN/fabric segment + k8s_manager creates CUDN overlay (if deployment hosts VMs)
 
 3. **Create SecurityGroup:**
    ```bash
@@ -656,12 +656,12 @@ kubectl describe cluster <name> -n <namespace>
 # Check status.conditions for NetworkingResolutionFailed
 ```
 
-**Cause:** Subnet not found, not Ready, or BM-only region (no k8s_manager)
+**Cause:** Subnet not found, not Ready, or BM-only deployment (no k8s_manager)
 
 **Resolution:**
 1. Check Subnet status: `kubectl get subnet <subnet-name> -n <namespace>`
 2. If Subnet is not Ready, investigate Subnet provisioning failure (check AAP job logs)
-3. If BM-only region, tenant must create Cluster in a region with k8s_manager configured
+3. If BM-only deployment, tenant must create Cluster in a deployment with k8s_manager configured
 
 ### Symptom: Auto-provisioned ExternalIP not cleaned up after Cluster deletion
 

--- a/enhancements/OSAC-1436-caas-networking/prd.md
+++ b/enhancements/OSAC-1436-caas-networking/prd.md
@@ -123,7 +123,7 @@ Cluster provisioning has no networking configuration. Tenants cannot choose whic
 ## 6. Assumptions
 
 - The tenant has default networking resources (virtual network, subnet, security group) pre-created. If defaults are not configured, creating a cluster without explicit network configuration fails with a clear error.
-- The target region's network infrastructure is configured to support virtual networks, subnets, security groups, external IPs, external IP attachments, NAT gateways, and network connectivity management.
+- The deployment's network infrastructure is configured to support virtual networks, subnets, security groups, external IPs, external IP attachments, NAT gateways, and network connectivity management.
 - Bare-metal host types have structured network interface configuration. The system uses this to determine which interface to configure for each subnet.
 
 ## 7. Dependencies

--- a/enhancements/OSAC-1437-bmaas-networking/design.md
+++ b/enhancements/OSAC-1437-bmaas-networking/design.md
@@ -159,7 +159,7 @@ Same as VMaaS/CaaS — the networking API is uniform.
 
 1. **Create VirtualNetwork:**
    ```bash
-   osac create virtualnetwork --region moc-region-1 --cidr 10.0.0.0/16 --name my-net
+   osac create virtualnetwork --network-class moc --cidr 10.0.0.0/16 --name my-net
    ```
    Dispatcher → `osac.templates.{{ fabric_manager }}.create_virtual_network`
 
@@ -167,7 +167,7 @@ Same as VMaaS/CaaS — the networking API is uniform.
    ```bash
    osac create subnet --virtual-network my-net --cidr 10.0.1.0/24 --name my-subnet
    ```
-   Dispatcher → fabric_manager creates VLAN/fabric segment. If the region has a k8s_manager: also creates CUDN overlay (but BM doesn't use it — the overlay exists for VMs that may share the same subnet).
+   Dispatcher → fabric_manager creates VLAN/fabric segment. If the NetworkClass has a k8s_manager: also creates CUDN overlay (but BM doesn't use it — the overlay exists for VMs that may share the same subnet).
 
 3. **Create SecurityGroup:**
    ```bash

--- a/enhancements/OSAC-1437-bmaas-networking/prd.md
+++ b/enhancements/OSAC-1437-bmaas-networking/prd.md
@@ -135,7 +135,7 @@ Provisioning bare-metal servers requires manual switch configuration outside the
 ## 6. Assumptions
 
 - The tenant has default networking resources (virtual network, subnet, security group) pre-created at onboarding (see Default Networking PRD). If defaults are not configured, creating a server without explicit network attachments fails with a clear error.
-- The target region's networking infrastructure has fabric manager configured (the system can resolve which network automation to use).
+- The NetworkClass has a fabric manager configured (the system can resolve which network automation to use).
 - The host type for the bare-metal template has a populated physical network interface list. If the list is empty, creating a server with explicit network attachments fails with a clear error.
 - Out-of-band provisioning interfaces (PXE boot, BMC) are reserved for system use and are NOT tenant-attachable (should not appear in network attachments).
 


### PR DESCRIPTION
## Summary

Removed all "region" references from the five networking design documents
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated networking guidance to use deployment-scoped NetworkClass references instead of regions.
  * Clarified virtual network and subnet provisioning behavior across Kubernetes, virtual machine, and bare-metal environments.
  * Documented bare-metal-only restrictions and validation based on NetworkClass capabilities.
  * Updated CLI examples, troubleshooting guidance, terminology, and networking assumptions to reflect the unified model.
  * Replaced the immutable `VirtualNetworkSpec.region` field with `network_class`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->