### PR TITLE
OSAC-3573: Sharpen persona-consolidation and internal-service guidance

### DIFF
--- a/guidelines/prd_guide.md
+++ b/guidelines/prd_guide.md
@@ -220,8 +220,8 @@ consumes the new capability:
 
 **Fix:** Describe the service's need in Dependencies: "[Service] depends
 on this metadata being present and reliable in [resource] status to
-[correlate/verify/consume] X." Reserve User Stories for the four personas
-in the table above.
+[correlate/verify/consume] X." Reserve User Stories for the personas
+listed in the table above.
 
 ## Workflow
 

--- a/guidelines/prd_guide.md
+++ b/guidelines/prd_guide.md
@@ -86,6 +86,11 @@ personas are affected.
 | **Tenant Admin** | Works for the tenant organization. Manages their org's config, users, IDP, quotas, and org-specific catalogs. Can only see their own organization. | Create networking objects, manage tenant resources, onboard users |
 | **Tenant User** | Works for the tenant organization. Self-service provisions cloud resources, manages full lifecycle. Prefers click-ops but wants API/CLI for automation. | Order machines/clusters/VMs, manage instance lifecycle, view quota |
 
+Internal OSAC services (BMaaS, CaaS, VMaaS, MaaS, Enclave) are not
+personas, even when a requirement is driven by one service consuming
+another's capability. Describe that need in Dependencies instead — see
+"Inventing a persona for an internal service" below.
+
 ## Writing Good User Stories
 
 Use the standard formula:
@@ -183,6 +188,35 @@ can run stateful workloads without waiting for manual configuration."
 Only combine when the capability is truly identical — if personas
 experience it differently (different constraints, different visibility
 scope), keep separate stories.
+
+**The swap test:** if two persona-specific stories differ only in the
+persona name and cosmetic wording — not in a constraint, scope, or
+outcome actually stated in the source material — that's duplication, not
+a genuine difference. Do not invent a differentiating detail (a
+motivation, a downstream consumer, a constraint) that the Jira ticket or
+clarification answers never mentioned, just to make two stories look
+distinct enough to justify separate headings. Apply this with particular
+care to Cloud Provider Admin and Cloud Infrastructure Admin — their table
+descriptions already overlap (both work for the cloud provider, both see
+across all tenants) — default to combining their stories for
+shared-visibility capabilities unless the source material states a
+concrete difference in what each persona can actually do.
+
+### Inventing a persona for an internal service
+
+Giving an internal OSAC service its own "persona" story just because it
+consumes the new capability:
+
+- "### CaaS (Internal Service Consumer) — As the CaaS system, I want to
+  read a provisioned instance's new status field so that I can correlate
+  it with a registering agent." (CaaS is a service from the vocabulary
+  table, not one of the four personas above — this belongs in
+  Dependencies, not User Stories.)
+
+**Fix:** Describe the service's need in Dependencies: "[Service] depends
+on this metadata being present and reliable in [resource] status to
+[correlate/verify/consume] X." Reserve User Stories for the four personas
+in the table above.
 
 ## Workflow
 

--- a/guidelines/prd_guide.md
+++ b/guidelines/prd_guide.md
@@ -196,11 +196,16 @@ a genuine difference. Do not invent a differentiating detail (a
 motivation, a downstream consumer, a constraint) that the Jira ticket or
 clarification answers never mentioned, just to make two stories look
 distinct enough to justify separate headings. Apply this with particular
-care to Cloud Provider Admin and Cloud Infrastructure Admin — their table
-descriptions already overlap (both work for the cloud provider, both see
-across all tenants) — default to combining their stories for
-shared-visibility capabilities unless the source material states a
-concrete difference in what each persona can actually do.
+care to Cloud Provider Admin and Cloud Infrastructure Admin — both work
+for the cloud provider, which makes it tempting to invent a difference
+just to keep them separate. Neither direction is automatically correct:
+the persona table states cross-tenant visibility explicitly for Cloud
+Provider Admin, not for Cloud Infrastructure Admin, so don't assume
+identical visibility scope for both. Combine their stories only when the
+source material (or the table itself) establishes a genuinely identical
+capability and outcome for both; keep them separate when the source
+material describes a real difference in what each can do — don't invent
+a difference either way.
 
 ### Inventing a persona for an internal service
 


### PR DESCRIPTION
**Jira:** https://redhat.atlassian.net/browse/OSAC-3573
**Related PRs:** [osac-project/osac-workspace#186](https://github.com/osac-project/osac-workspace/pull/186) (companion change, same commit), [osac-project/enhancement-proposals#178](https://github.com/osac-project/enhancement-proposals/pull/178) (merged predecessor — added the "Duplicated persona stories" entry this PR extends)

### Summary

An initial blind subagent test of `/prd` for [OSAC-3254](https://redhat.atlassian.net/browse/OSAC-3254) (isolated worktree, no session context) invented a dedicated "CaaS (Internal Service Consumer)" persona story and split Cloud Provider Admin / Cloud Infrastructure Admin with invented differentiating details. Root cause turned out to be that its `enhancement-proposals` clone defaulted to `main`, which at the time was missing `#178`'s persona-consolidation guidance entirely (merged since) — not a gap in `#178` itself.

**Re-tested after `#178` merged**, with two follow-up blind subagent runs:
- Against `main` alone (`#178`, no `#184`): correctly avoided inventing a CaaS persona (by following a linked issue's own precedent) and correctly kept Cloud Provider Admin / Cloud Infrastructure Admin separate (their needs were genuinely different this time). Neither failure mode reproduced.
- Against this branch (`#178` + `#184`): also correct, via the same route (recognized a mislabeled internal-service story, not via the new swap-test rule specifically).

**Honest conclusion:** neither run proves the swap-test/admin-consolidation guidance in this PR is fixing an active bug — `#178` alone handled this specific ticket correctly. What this PR adds is an explicit backstop for tickets that *don't* have a convenient linked-issue precedent to fall back on: an explicit "internal services aren't personas" rule (previously only implicit), and swap-test guidance for the genuine case where two persona stories really are duplicates dressed up with invented differences. Keeping it as defense-in-depth, not as a demonstrated-bug fix.

### Changes

- **`guidelines/prd_guide.md`** — adds "**The swap test**" to the existing "Duplicated persona stories" entry, and a new "**Inventing a persona for an internal service**" entry (OSAC services are not personas; describe their needs in Dependencies).
- Companion changes in `osac-workspace#186`: `section-guidance.md` cross-references both rules; `skills/prd-review/SKILL.md`'s WHAT criterion checks for missed consolidation and invented personas; `calibration-examples.md` gets matching worked examples.

### Review feedback addressed

CodeRabbit correctly flagged that the original swap-test wording overclaimed cross-tenant visibility for Cloud Infrastructure Admin — the persona table only states it explicitly for Cloud Provider Admin. Fixed (`4c9d395`): removed the "default to combining" bias entirely; the guidance now grounds the merge/split decision in what the table and source material actually state for each persona, with no presumption either way.

### Testing

`make skillsaw SKILL=skills/prd-review/` (in `osac-workspace`) — 0 errors, 0 warnings, Grade A, after the companion rubric changes.

Two blind subagent runs (see `osac-workspace#186` for full results) — both correct, for the reasons noted above.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that internal services should be documented as dependencies rather than product personas.
  - Added guidance for identifying and avoiding duplicated persona stories.
  - Included examples for distinguishing Cloud Provider Admin and Cloud Infrastructure Admin personas.
  - Added instructions to avoid inventing personas for internal services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->