### PR TITLE
OSAC-2135: PRD - CaaS Bare-Metal Worker Node Provisioning

### DIFF
--- a/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/prd.md
+++ b/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/prd.md
@@ -14,11 +14,11 @@ CaaS requires bare-metal compute to back OpenShift cluster worker nodes. Today, 
 
 - On-demand provisioning of bare-metal worker nodes when a tenant orders a cluster specifying bare-metal resource classes.
 - Tenant-visible ClusterOrder status reflects provisioning progress and reports clear failure conditions when bare-metal hosts cannot be provisioned.
-- Tenant experience remains unchanged — no bare-metal infrastructure details (hosts, images, or installation agents) are visible to tenants.
-- CaaS-managed infrastructure resources are hidden from tenant-facing APIs, UIs, and catalogs.
+- Tenant experience remains unchanged — no CaaS-managed bare-metal infrastructure details (hosts, images, or installation agents) are visible to tenants. Tenant-owned BareMetalInstance workflows (BMaaS) are unaffected.
+- CaaS-managed worker instances and associated images are hidden from tenant-facing APIs, UIs, and catalogs.
 - Manual scale-up and scale-down of bare-metal worker nodes (tenant-initiated worker count changes).
 - Release of CaaS-managed BareMetalInstances when a cluster is decommissioned or scaled down.
-- No UI changes required — tenant console workflows are unaffected.
+- No CaaS-related UI changes required — tenant console workflows for cluster management and tenant-owned bare-metal instances are unaffected.
 
 ## Out of Scope
 
@@ -63,6 +63,7 @@ CaaS requires bare-metal compute to back OpenShift cluster worker nodes. Today, 
 
 ## Provenance
 
-Authored: revise @ prd 0.6.3 - c045d41, workspace feat/osac-taxonomy-presentation @ d22bfa1
+Authored: respond @ prd 0.6.3 - c045d41, workspace feat/osac-taxonomy-presentation @ d22bfa1
+Phases: revise, respond
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"c045d41","source_repo":"d22bfa1","source_repo_branch":"feat/osac-taxonomy-presentation","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["revise"],"authoring_modes":["skill"],"context_changed":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"c045d41","source_repo":"d22bfa1","source_repo_branch":"feat/osac-taxonomy-presentation","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["revise","respond"],"authoring_modes":["skill"],"context_changed":false} -->

--- a/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/prd.md
+++ b/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/prd.md
@@ -31,7 +31,7 @@ CaaS requires bare-metal compute to back OpenShift cluster worker nodes. Today, 
 
 ### Cloud Infrastructure Admin
 
-- As a Cloud Infrastructure Admin, I want CaaS to provision bare-metal worker nodes on demand through the BMaaS private API, so that I no longer need to maintain a static pool of pre-booted agents and can focus on managing BMaaS inventory.
+- As a Cloud Infrastructure Admin, I want bare-metal worker nodes to be provisioned automatically when CaaS clusters need them, so that I no longer need to maintain a static pool of pre-booted agents.
 
 ### Tenant User
 
@@ -45,11 +45,10 @@ CaaS requires bare-metal compute to back OpenShift cluster worker nodes. Today, 
 
 ## Assumptions
 
-- The BMaaS private API can accept and pass through discovery ignition payload as user data to the target physical host.
-- The standard boot image is pre-configured to process the ignition payload and start the installation agent without manual intervention.
+- BMaaS can provision bare-metal hosts with the required boot configuration without manual intervention.
+- A standard boot image exists that can initialize a host as a cluster worker node when given the appropriate configuration payload.
 
 ## Dependencies
 
-- **Host metadata in status `[Jira: OSAC-3254]`:** BMaaS must expose physical network interface identifiers in BareMetalInstance status so that CaaS can correlate provisioned hosts with registering agents.
 - **BareMetalInstanceType definitions `[Jira: OSAC-2675]`:** Resource class specifications must be finalized so that ClusterOrder can reference them.
-- **User data pass-through:** The BMaaS private API must support ingestion and pass-through of ignition configurations in BareMetalInstance specifications.
+- **Boot configuration pass-through:** BMaaS must support passing cluster-specific boot configuration to provisioned hosts.

--- a/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/prd.md
+++ b/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/prd.md
@@ -1,0 +1,55 @@
+# CaaS Bare-Metal Worker Node Provisioning
+
+| Field       | Value |
+|-------------|-------|
+| Author(s)   | Avishay Traeger |
+| Jira        | [OSAC-2135](https://redhat.atlassian.net/browse/OSAC-2135) |
+| Date        | 2026-08-04 |
+
+## Problem Statement
+
+CaaS requires bare-metal compute to back OpenShift cluster worker nodes. Today, a cron job maintains a static pool of pre-booted hosts running the Assisted Installer ISO. This approach wastes resources on idle hosts, is difficult to size correctly, and requires Cloud Infrastructure Admins to manage cluster-specific agent infrastructure alongside BMaaS. Without on-demand provisioning, OSAC incurs high operational costs from underutilized hardware and risks slow or failing cluster scale-up when the pool is exhausted.
+
+## In Scope
+
+- On-demand provisioning of bare-metal worker nodes when a tenant orders a cluster specifying bare-metal resource classes.
+- Tenant experience remains unchanged — no bare-metal infrastructure details (hosts, images, or installation agents) are visible to tenants.
+- CaaS-managed infrastructure resources are hidden from tenant-facing APIs, UIs, and catalogs.
+- Cleanup of CaaS-managed BareMetalInstances when a cluster is decommissioned or manually scaled down.
+
+## Out of Scope
+
+- **Day-2 autoscaling:** Automated workload-driven scaling based on resource utilization. Scaling down requires complex orchestration around cluster node draining and is deferred to a future phase.
+- **Virtual machine worker nodes:** Provisioning VM-based worker nodes using this pattern (deferred to future VMaaS integration).
+- **Admin tuning APIs:** Administrator-facing APIs for adjusting provisioning heuristics or retry thresholds.
+- **Boot-over-network optimization:** Network boot acceleration or advanced bare-metal caching strategies `[Jira: OSAC-2134]`.
+- **Custom networking configuration:** Direct management of tenant-specific VLANs or advanced network routing by CaaS.
+- **Host sanitization:** Physical host cleanup after deprovisioning (disk wipe, network reset) is BMaaS's responsibility.
+- **Billing and quota:** Cluster-level metering and quota tracking are covered by a separate CaaS metering feature.
+
+## User Stories
+
+### Cloud Infrastructure Admin
+
+- As a Cloud Infrastructure Admin, I want CaaS to provision bare-metal worker nodes on demand through the BMaaS private API, so that I no longer need to maintain a static pool of pre-booted agents and can focus on managing BMaaS inventory.
+
+### Tenant User
+
+- As a Tenant User, I want to create a ClusterOrder specifying bare-metal resource classes for my worker nodes, so that my cluster is backed by physical hardware without me managing infrastructure directly.
+
+- As a Tenant User, I want my cluster creation and management experience to remain unchanged, so that I am never exposed to underlying bare-metal instances, images, or installation internals.
+
+### Cloud Provider Admin
+
+- As a Cloud Provider Admin, I want CaaS-provisioned bare-metal instances and associated images hidden from tenant-facing views and catalogs, so that tenants cannot accidentally interact with underlying infrastructure nodes.
+
+## Assumptions
+
+- The BMaaS private API can accept and pass through discovery ignition payload as user data to the target physical host.
+- The standard boot image is pre-configured to process the ignition payload and start the installation agent without manual intervention.
+
+## Dependencies
+
+- **Host metadata in status `[Jira: OSAC-3254]`:** BMaaS must expose physical network interface identifiers in BareMetalInstance status so that CaaS can correlate provisioned hosts with registering agents.
+- **BareMetalInstanceType definitions `[Jira: OSAC-2675]`:** Resource class specifications must be finalized so that ClusterOrder can reference them.
+- **User data pass-through:** The BMaaS private API must support ingestion and pass-through of ignition configurations in BareMetalInstance specifications.

--- a/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/prd.md
+++ b/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/prd.md
@@ -38,15 +38,19 @@ CaaS requires bare-metal compute to back OpenShift cluster worker nodes. Today, 
 
 - As a Cloud Infrastructure Admin, I want CaaS to automatically handle provisioning retries and release of failed bare-metal resources, so that transient BMaaS failures do not leave orphaned infrastructure.
 
-### Tenant User
+### Tenant Admin / Tenant User
 
 - As a Tenant User, I want to create a ClusterOrder specifying bare-metal resource classes for my worker nodes, so that my cluster is backed by physical hardware without me managing infrastructure directly.
 
 - As a Tenant User, I want my cluster creation and management experience to remain unchanged, so that I am never exposed to underlying bare-metal instances, images, or installation internals.
 
+- As a Tenant User, I want to scale my cluster's bare-metal worker count up or down, so that I can adjust capacity to match my workload needs.
+
 ### Cloud Provider Admin
 
 - As a Cloud Provider Admin, I want CaaS-provisioned bare-metal instances and associated images hidden from tenant-facing views and catalogs, so that tenants cannot accidentally interact with underlying infrastructure nodes.
+
+- As a Cloud Provider Admin, I want to be able to access CaaS-managed BareMetalInstances for debugging (ssh, console, restart), so that I can troubleshoot worker node issues without disrupting the tenant experience.
 
 ## Assumptions
 
@@ -58,12 +62,13 @@ CaaS requires bare-metal compute to back OpenShift cluster worker nodes. Today, 
 - **BareMetalInstanceType definitions `[Jira: OSAC-2675]`:** Resource class specifications must be finalized so that ClusterOrder can reference them.
 - **BMaaS host lifecycle API:** BMaaS must support requesting, observing readiness of, and releasing bare-metal hosts so that CaaS can manage the full provisioning lifecycle.
 - **Cluster-specific host preparation:** BMaaS must support provisioning hosts preconfigured for a specific cluster, so that CaaS can request worker nodes without separate configuration steps.
+- **BMaaS networking for subnet attachment `[Jira: OSAC-1437]`:** BMaaS must support network attachments on BareMetalInstances so that CaaS-managed worker hosts are moved to the cluster's tenant subnet as part of the BMI lifecycle.
 
 ---
 
 ## Provenance
 
 Authored: respond @ prd 0.6.3 - c045d41, workspace feat/osac-taxonomy-presentation @ d22bfa1
-Phases: revise, respond
+Phases: revise, respond, respond
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"c045d41","source_repo":"d22bfa1","source_repo_branch":"feat/osac-taxonomy-presentation","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["revise","respond"],"authoring_modes":["skill"],"context_changed":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"c045d41","source_repo":"d22bfa1","source_repo_branch":"feat/osac-taxonomy-presentation","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["revise","respond","respond"],"authoring_modes":["skill"],"context_changed":false} -->

--- a/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/prd.md
+++ b/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/prd.md
@@ -13,18 +13,21 @@ CaaS requires bare-metal compute to back OpenShift cluster worker nodes. Today, 
 ## In Scope
 
 - On-demand provisioning of bare-metal worker nodes when a tenant orders a cluster specifying bare-metal resource classes.
+- Tenant-visible ClusterOrder status reflects provisioning progress and reports clear failure conditions when bare-metal hosts cannot be provisioned.
 - Tenant experience remains unchanged — no bare-metal infrastructure details (hosts, images, or installation agents) are visible to tenants.
 - CaaS-managed infrastructure resources are hidden from tenant-facing APIs, UIs, and catalogs.
-- Cleanup of CaaS-managed BareMetalInstances when a cluster is decommissioned or manually scaled down.
+- Manual scale-up and scale-down of bare-metal worker nodes (tenant-initiated worker count changes).
+- Release of CaaS-managed BareMetalInstances when a cluster is decommissioned or scaled down.
+- No UI changes required — tenant console workflows are unaffected.
 
 ## Out of Scope
 
-- **Day-2 autoscaling:** Automated workload-driven scaling based on resource utilization. Scaling down requires complex orchestration around cluster node draining and is deferred to a future phase.
+- **Day-2 autoscaling:** Automated workload-driven scaling based on resource utilization. CaaS does not currently support autoscaling; this is deferred to a future phase.
 - **Virtual machine worker nodes:** Provisioning VM-based worker nodes using this pattern (deferred to future VMaaS integration).
 - **Admin tuning APIs:** Administrator-facing APIs for adjusting provisioning heuristics or retry thresholds.
 - **Boot-over-network optimization:** Network boot acceleration or advanced bare-metal caching strategies `[Jira: OSAC-2134]`.
 - **Custom networking configuration:** Direct management of tenant-specific VLANs or advanced network routing by CaaS.
-- **Host sanitization:** Physical host cleanup after deprovisioning (disk wipe, network reset) is BMaaS's responsibility.
+- **Host sanitization:** Physical host cleanup after deprovisioning (disk wipe, network reset) is BMaaS's responsibility. BMaaS must complete sanitization before returning a host to the provisioning pool; a host that fails sanitization must not be made available for reuse.
 - **Billing and quota:** Cluster-level metering and quota tracking are covered by a separate CaaS metering feature.
 
 ## User Stories
@@ -32,6 +35,8 @@ CaaS requires bare-metal compute to back OpenShift cluster worker nodes. Today, 
 ### Cloud Infrastructure Admin
 
 - As a Cloud Infrastructure Admin, I want bare-metal worker nodes to be provisioned automatically when CaaS clusters need them, so that I no longer need to maintain a static pool of pre-booted agents.
+
+- As a Cloud Infrastructure Admin, I want CaaS to automatically handle provisioning retries and release of failed bare-metal resources, so that transient BMaaS failures do not leave orphaned infrastructure.
 
 ### Tenant User
 
@@ -45,10 +50,19 @@ CaaS requires bare-metal compute to back OpenShift cluster worker nodes. Today, 
 
 ## Assumptions
 
-- BMaaS can provision bare-metal hosts with the required boot configuration without manual intervention.
-- A standard boot image exists that can initialize a host as a cluster worker node when given the appropriate configuration payload.
+- BMaaS can provision bare-metal hosts that join a cluster as worker nodes without manual admin intervention.
+- BMaaS can prepare provisioned hosts with the boot configuration needed for a specific cluster.
 
 ## Dependencies
 
 - **BareMetalInstanceType definitions `[Jira: OSAC-2675]`:** Resource class specifications must be finalized so that ClusterOrder can reference them.
-- **Boot configuration pass-through:** BMaaS must support passing cluster-specific boot configuration to provisioned hosts.
+- **BMaaS host lifecycle API:** BMaaS must support requesting, observing readiness of, and releasing bare-metal hosts so that CaaS can manage the full provisioning lifecycle.
+- **Cluster-specific host preparation:** BMaaS must support provisioning hosts preconfigured for a specific cluster, so that CaaS can request worker nodes without separate configuration steps.
+
+---
+
+## Provenance
+
+Authored: revise @ prd 0.6.3 - c045d41, workspace feat/osac-taxonomy-presentation @ d22bfa1
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"c045d41","source_repo":"d22bfa1","source_repo_branch":"feat/osac-taxonomy-presentation","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["revise"],"authoring_modes":["skill"],"context_changed":false} -->


### PR DESCRIPTION
## PRD: CaaS Bare-Metal Worker Node Provisioning

**Jira:** [OSAC-2135](https://redhat.atlassian.net/browse/OSAC-2135)

Supersedes #181 (bot-generated PRD that had design leakage and incorrect persona assignments).

### Summary

This PRD defines on-demand bare-metal worker node provisioning for CaaS clusters. Tenants order clusters specifying bare-metal resource classes; CaaS provisions hosts through the BMaaS private API without exposing infrastructure details to tenants. Cloud Infrastructure Admins no longer maintain a static pre-booted agent pool.

### Requesting Review On

- Requirements completeness — are the user stories sufficient?
- Scope boundaries — are In Scope / Out of Scope clear?
- Persona coverage — correct assignment of Cloud Infrastructure Admin, Tenant User, Cloud Provider Admin stories
- Assumptions and Dependencies accuracy

### How to Review

- Comment inline on specific sections
- Approve when the PRD accurately reflects the agreed requirements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added product requirements for on-demand CaaS bare-metal worker provisioning.
  * Documented tenant-triggered provisioning, worker status reporting, failure handling, manual scaling, and resource release workflows.
  * Clarified infrastructure visibility, scope, exclusions, assumptions, and user stories.
  * Documented bare-metal lifecycle, networking dependencies, provider-admin troubleshooting access, and provisioning provenance metadata requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->