### PR TITLE
OSAC-1415: PRD for cluster upgrade (CaaS)

### DIFF
--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -40,6 +40,7 @@ flowchart TD
 - As a Tenant User, I want to be informed when my cluster's control plane and node pool versions have diverged and a node pool upgrade is needed, so that I can keep my cluster working and supported.
 - As a Tenant User, I want to view the upgrade history for my cluster, so that I can see which version transitions have occurred and their outcomes.
 - As a Tenant User, I want to know when the platform applies a z-stream upgrade to my cluster, so that I am aware of platform-managed changes to my cluster's version.
+- As a Tenant User, I want to see when my cluster has entered limited-support state due to a failed forced EOL upgrade, so that I understand the SLA change and know that support remains available.
 
 ### Tenant Admin / Tenant User
 
@@ -59,6 +60,7 @@ flowchart TD
 
 - As a Cloud Provider Admin, I want to select and publish a z-stream target version per minor version cohort for control plane upgrades, so that all clusters running that minor version are brought to a consistent patch level without requiring tenant action.
 - As a Cloud Provider Admin, I want to pause a z-stream rollout that is causing regressions, so that I can stop further clusters from being upgraded while I assess the impact.
+- As a Cloud Provider Admin, I want to resume a paused z-stream rollout once the regression is resolved, so that clusters not yet upgraded at the time of pause continue receiving the upgrade.
 - As a Cloud Provider Admin, I want to monitor control plane upgrade status across all clusters, so that I can detect stalled or failed upgrades and intervene.
 - As a Cloud Provider Admin, I want to force a control plane y-stream upgrade for a specific cluster approaching EOL, so that the platform can maintain supportability independently of tenant scheduling.
 
@@ -78,20 +80,21 @@ No active role in this feature; all platform-level upgrade operations are covere
 - If any node set fails to upgrade, the node pool tier upgrade is treated as failed; failure details identify which node set(s) did not complete the transition
 - A cancellation window of a few minutes exists after upgrade initiation
 - In-progress upgrades cannot be cancelled
-- Completed upgrades cannot be rolled back through OSAC
+- Completed upgrades cannot be rolled back through OSAC; HCP does not support control plane version downgrade, so remediation for regression-affected clusters requires intervention outside of OSAC
 - Tenants cannot select or initiate z-stream control plane upgrades; these are applied by the Cloud Provider Admin via progressive rollout
 - Z-stream upgrades are triggered on-demand; the regular cadence targets FedRAMP-aligned CVE remediation timelines (High CVEs: 30 days, Medium: 90 days)
+- A paused rollout is visible as a distinct state in the rollout status; pausing stops new clusters from being selected for the rollout; resuming targets clusters in the cohort that had not yet been upgraded at pause time
 - If the fleet-wide z-stream target version is not reachable from a cluster's available update graph, the cluster is flagged in the rollout status and no upgrade is initiated for that cluster
 - During a forced EOL upgrade, node pools remain at their current version and continue to serve workloads
-- If a forced EOL upgrade fails, the cluster enters a limited-support state (SLA no longer applies, but support remains available); the limited-support state is visible to tenants on the cluster
+- If a forced EOL upgrade fails, the cluster enters a limited-support state (SLA no longer applies, but support remains available)
 
 **User-facing API surfaces:**
 
 | Surface | Change |
 |---------|--------|
-| Fulfillment API | Upgrade initiation and cancellation per cluster component (control plane and node pool). Available upgrade versions query per cluster component. Upgrade status, progress, and history per cluster component. Org-wide upgrade visibility for Tenant Admins. Fleet-wide z-stream target management, rollout triggering and pausing, and per-cluster rollout status for Cloud Provider Admins. |
-| CLI | Upgrade lifecycle commands: list available versions, initiate upgrade, cancel pending upgrade, view upgrade status, view upgrade history. Cloud Provider Admin: set fleet-wide z-stream target, trigger and monitor rollout, pause rollout, force EOL upgrade on a specific cluster. |
-| UI | Upgrade lifecycle actions and history in the cluster detail view. Available versions and risk display before upgrade initiation. Cloud Provider Admin: fleet-wide z-stream target selection, rollout triggering, pause, and cross-cluster upgrade status monitoring. |
+| Fulfillment API | Upgrade initiation and cancellation per cluster component (control plane and node pool). Available upgrade versions query per cluster component. Upgrade status, progress, and history per cluster component. Org-wide upgrade visibility for Tenant Admins. Fleet-wide z-stream target management, rollout triggering, pausing, and resuming, and per-cluster rollout status for Cloud Provider Admins. |
+| CLI | Upgrade lifecycle commands: list available versions, initiate upgrade, cancel pending upgrade, view upgrade status, view upgrade history. Cloud Provider Admin: set fleet-wide z-stream target, trigger, pause, and resume rollout, force EOL upgrade on a specific cluster. |
+| UI | Upgrade lifecycle actions and history in the cluster detail view. Available versions and risk display before upgrade initiation. Cloud Provider Admin: fleet-wide z-stream target selection, rollout triggering, pause, resume, and cross-cluster upgrade status monitoring. |
 
 **E2E testing:** E2E coverage for upgrade initiation, status tracking, upgrade history, and pending upgrade cancellation in osac-test-infra.
 

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -30,6 +30,7 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 - Tenant-initiated z-stream control plane upgrades
 - Platform-initiated node pool upgrades
 - Cancellation of running upgrades
+- Switching upgrade channels — a cluster remains on the channel it was created with
 
 ## User Stories
 

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -8,49 +8,7 @@
 
 ## Problem Statement
 
-OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion — but provides no managed path for upgrading a cluster's OpenShift version. Clusters are provisioned via Hosted Control Planes (HCP), where the control plane and worker node pools are independent upgrade targets with distinct ownership and ordering constraints; today neither target has first-class support in the OSAC API. Tenants who need a newer version must interact directly with HCP infrastructure, bypassing OSAC entirely: upgrades leave no record in OSAC and are invisible to its monitoring. As clusters age, the gap compounds: EOL versions lose Red Hat support coverage and security patches, but OSAC has no mechanism to surface upgrade readiness, track version transitions, or apply platform-wide patches.
-
-## In Scope
-
-**Services:** CaaS — OpenShift clusters provisioned by OSAC via Hosted Control Planes.
-
-**Upgrade constraints:**
-- Available versions are directly reachable (one hop) in the cluster's update graph, filtered by the cluster's update channel
-- A reachable version is only available for upgrade if an enabled ClusterVersion (OSAC-1269) exists for it
-- Node pool versions are additionally capped at the current control plane version
-- Only one active upgrade per cluster component (control plane or node pool) is permitted; control plane and node pool upgrades are independent and may proceed concurrently
-- A cancellation window of a few minutes exists after upgrade initiation
-
-**Platform-managed z-stream upgrades:**
-- Tenants cannot select or initiate z-stream control plane upgrades; these are applied by the Cloud Provider Admin via progressive rollout
-- Available z-stream versions follow the same one-hop reachability constraint as tenant-visible versions
-- Z-stream upgrades are triggered on-demand; the regular cadence targets FedRAMP-aligned CVE remediation timelines (High CVEs: 30 days, Medium: 90 days)
-- If the fleet-wide z-stream target version is not reachable from a cluster's available update graph, the cluster is flagged in the rollout status and no upgrade is initiated for that cluster
-
-**Forced EOL y-stream upgrades (Cloud Provider Admin):**
-- Each forced upgrade is a single one-hop operation; if reaching the desired target requires multiple hops, the Cloud Provider Admin is responsible for executing them sequentially
-- Node pools remain at their current version during a forced upgrade and continue to serve workloads
-- If a forced upgrade fails, the cluster enters a limited-support state (SLA no longer applies, but support remains available); the limited-support state is visible to tenants on the cluster
-
-**User-facing API surfaces:**
-
-| Surface | Change |
-|---------|--------|
-| Fulfillment API | Upgrade initiation and cancellation per cluster component (control plane and node pool). Available upgrade versions query per cluster component. Upgrade status, progress, and history per cluster component. Org-wide upgrade visibility for Tenant Admins. Fleet-wide z-stream target management, rollout triggering and pausing, and per-cluster rollout status for Cloud Provider Admins. |
-| CLI | Upgrade lifecycle commands: list available versions, initiate upgrade, cancel pending upgrade, view upgrade status, view upgrade history. Cloud Provider Admin: set fleet-wide z-stream target, trigger and monitor rollout, pause rollout, force EOL upgrade on a specific cluster. |
-| UI | Upgrade lifecycle actions and history in the cluster detail view. Available versions and risk display before upgrade initiation. Cloud Provider Admin: fleet-wide z-stream target selection, rollout triggering, pause, and cross-cluster upgrade status monitoring. |
-
-**E2E testing:** E2E coverage for upgrade initiation, status tracking, upgrade history, and pending upgrade cancellation in osac-test-infra.
-
-**Documentation:** User guides for upgrade initiation and monitoring (Tenant User), z-stream upgrade visibility (Tenant Admin), and fleet-wide z-stream management (Cloud Provider Admin).
-
-**Interfaces:** Fulfillment API, CLI, and UI console.
-
-## Out of Scope
-
-- SNO and traditional (non-HCP) control plane node upgrades
-- Rollback of completed upgrades — HCP does not support control plane version downgrade; completed upgrades cannot be reversed through OSAC
-- Cancelling an upgrade once it is in progress; only pending upgrades within the cancellation window can be cancelled
+OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion — but provides no managed path for upgrading a cluster's OpenShift version. Clusters are provisioned via Hosted Control Planes (HCP), where the control plane and worker node pools are independent upgrade targets with distinct ownership and ordering constraints; today neither target has first-class support in the OSAC API. Tenants who need a newer version must interact directly with HCP infrastructure, bypassing OSAC entirely. As clusters age, the gap compounds: end-of-life (EOL) versions lose Red Hat support coverage and security patches, but OSAC has no mechanism to surface upgrade readiness, track version transitions, or apply platform-wide patches.
 
 ## User Stories
 
@@ -77,11 +35,11 @@ flowchart TD
 - As a Tenant User, I want to view the available upgrade versions for my cluster's control plane and node pools, including any known risks per version, so that I can make an informed upgrade decision.
 - As a Tenant User, I want to initiate a control plane y-stream upgrade for my cluster, acknowledging any identified risks, so that I can keep my cluster's OpenShift version current.
 - As a Tenant User, I want to initiate a node pool upgrade for my cluster — acknowledging any identified risks — so that my worker nodes run a supported OpenShift version.
-- As a Tenant User, I want to monitor the status of an upgrade — its current state (pending, running, succeeded, or failed), the source and target versions, and when each state transition happened.
+- As a Tenant User, I want to monitor the status of an upgrade — its current state (pending, running, succeeded, or failed), the source and target versions, and when each state transition happened, so that I can take an appropriate action in a timely manner.
 - As a Tenant User, I want to be warned when a node pool is approaching the N-2 minor version skew limit relative to the control plane, so that I can initiate a node pool upgrade before it falls out of the supported range.
-- As a Tenant User, I want to be informed when my cluster's control plane and node pool versions have diverged and a node pool upgrade is needed.
+- As a Tenant User, I want to be informed when my cluster's control plane and node pool versions have diverged and a node pool upgrade is needed, so that I can keep my cluster working and supported.
 - As a Tenant User, I want to view the upgrade history for my cluster, so that I can see which version transitions have occurred and their outcomes.
-- As a Tenant User, I want to be notified when the platform applies a z-stream upgrade to my cluster, so that I am aware of platform-managed changes to my cluster's version.
+- As a Tenant User, I want to know when the platform applies a z-stream upgrade to my cluster, so that I am aware of platform-managed changes to my cluster's version.
 
 ### Tenant Admin / Tenant User
 
@@ -92,28 +50,51 @@ flowchart TD
 - As a Tenant Admin, I want to view the available upgrade versions for each cluster's control plane and node pools within my organization, so that I can plan and coordinate upgrades across my teams.
 - As a Tenant Admin, I want to initiate a control plane y-stream upgrade for any cluster in my organization — acknowledging any identified risks — so that I can manage the OpenShift version lifecycle on behalf of my organization.
 - As a Tenant Admin, I want to initiate a node pool upgrade for any cluster in my organization — acknowledging any identified risks — so that worker nodes remain within a supported version range.
+- As a Tenant Admin, I want to monitor the status of an upgrade for any cluster in my organization — its current state (pending, running, succeeded, or failed), the source and target versions, and when each state transition happened.
+- As a Tenant Admin, I want to be informed when a cluster in my organization has its control plane and node pool versions diverged and a node pool upgrade is needed.
 - As a Tenant Admin, I want to view the upgrade history for any cluster in my organization, so that I can see which version transitions have occurred and their outcomes.
-- As a Tenant Admin, I want to be notified when the platform applies a z-stream upgrade to a cluster in my organization, so that I have visibility into platform-managed changes affecting my clusters.
+- As a Tenant Admin, I want to know when the platform applies a z-stream upgrade to a cluster in my organization, so that I have visibility into platform-managed changes affecting my clusters.
 
 ### Cloud Provider Admin
 
 - As a Cloud Provider Admin, I want to select and publish the fleet-wide z-stream target version for control plane upgrades, so that all managed clusters run a consistent, supported patch version without requiring tenant action.
 - As a Cloud Provider Admin, I want to pause a z-stream rollout that is causing regressions, so that I can stop further clusters from being upgraded while I assess the impact.
 - As a Cloud Provider Admin, I want to monitor control plane upgrade status across all clusters, so that I can detect stalled or failed upgrades and intervene.
-- As a Cloud Provider Admin, I want to force a control plane y-stream upgrade for a specific cluster approaching end-of-life, so that the platform can maintain supportability independently of tenant scheduling.
+- As a Cloud Provider Admin, I want to force a control plane y-stream upgrade for a specific cluster approaching EOL, so that the platform can maintain supportability independently of tenant scheduling.
 
 ### Cloud Infrastructure Admin
 
 No active role in this feature; all platform-level upgrade operations are covered by the Cloud Provider Admin stories above.
 
-## Dependencies
+## Constraints
 
-- **HCP (HostedCluster + NodePool)**: source of upgrade state, conditions, and history; the design will confirm the specific HyperShift API surface used.
+- Only CaaS-provisioned, HCP OpenShift clusters are covered: SNO and traditional (non-HCP) control plane node upgrades are not managed by OSAC
+- Available versions are directly reachable (one hop) in the cluster's update graph, filtered by the cluster's update channel
+- A reachable version is only available for upgrade if an enabled ClusterVersion (OSAC-1269) exists for it
+- Node pool versions are additionally capped at the current control plane version
+- Only one active upgrade per cluster component (control plane or node pool) is permitted; control plane and node pool upgrades are independent and may proceed concurrently
+- A cancellation window of a few minutes exists after upgrade initiation
+- In-progress upgrades cannot be cancelled
+- Completed upgrades cannot be rolled back through OSAC
+- Tenants cannot select or initiate z-stream control plane upgrades; these are applied by the Cloud Provider Admin via progressive rollout
+- Z-stream upgrades are triggered on-demand; the regular cadence targets FedRAMP-aligned CVE remediation timelines (High CVEs: 30 days, Medium: 90 days)
+- If the fleet-wide z-stream target version is not reachable from a cluster's available update graph, the cluster is flagged in the rollout status and no upgrade is initiated for that cluster
+- During a forced EOL upgrade, node pools remain at their current version and continue to serve workloads
+- If a forced EOL upgrade fails, the cluster enters a limited-support state (SLA no longer applies, but support remains available); the limited-support state is visible to tenants on the cluster
 
-## Risks
+**User-facing API surfaces:**
 
-- **Version discovery availability**: if the update service is unreachable (e.g., network partition or local OpenShift Update Service failure in a disconnected environment), the platform cannot surface available upgrade versions or per-version risk data; the design will specify error behavior and retry semantics.
-- **Upgrade duration variability**: cluster upgrades can take minutes to hours depending on cluster size, workload, and the number of node pools; the platform exposes upgrade progress but makes no completion time guarantee.
+| Surface | Change |
+|---------|--------|
+| Fulfillment API | Upgrade initiation and cancellation per cluster component (control plane and node pool). Available upgrade versions query per cluster component. Upgrade status, progress, and history per cluster component. Org-wide upgrade visibility for Tenant Admins. Fleet-wide z-stream target management, rollout triggering and pausing, and per-cluster rollout status for Cloud Provider Admins. |
+| CLI | Upgrade lifecycle commands: list available versions, initiate upgrade, cancel pending upgrade, view upgrade status, view upgrade history. Cloud Provider Admin: set fleet-wide z-stream target, trigger and monitor rollout, pause rollout, force EOL upgrade on a specific cluster. |
+| UI | Upgrade lifecycle actions and history in the cluster detail view. Available versions and risk display before upgrade initiation. Cloud Provider Admin: fleet-wide z-stream target selection, rollout triggering, pause, and cross-cluster upgrade status monitoring. |
+
+**E2E testing:** E2E coverage for upgrade initiation, status tracking, upgrade history, and pending upgrade cancellation in osac-test-infra.
+
+**Documentation:** User guides for upgrade initiation and monitoring (Tenant User), z-stream upgrade visibility (Tenant Admin), and fleet-wide z-stream management (Cloud Provider Admin).
+
+**Interfaces:** Fulfillment API, CLI, and UI console.
 
 ---
 
@@ -124,4 +105,4 @@ Final: revise @ prd 0.6.3 - 6ec8c11, workspace main @ d22bfa1
 
 > Context changed between respond and revise.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"6ec8c11","source_repo":"d22bfa1","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise","revise","revise","revise","revise","revise","revise","revise"],"authoring_modes":["skill"],"context_changed":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"6ec8c11","source_repo":"d22bfa1","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise","revise","revise","revise","revise","revise","revise","revise","revise","revise"],"authoring_modes":["skill"],"context_changed":true} -->

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -36,8 +36,8 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 - As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to select an upgrade version for a cluster component that is directly reachable (one hop) and allowed by the platform, so that I can initiate a valid upgrade.
 - As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to review any risks associated with a target upgrade version before initiating an upgrade, so that I can make an informed upgrade decision.
 - As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to acknowledge the risks associated with an upgrade version and proceed, or decline and keep the current version, so that the cluster remains operational and supported.
+- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want a brief cancellation window during which the upgrade remains pending after I initiate it, so that I can cancel the upgrade, correct a mistake, and re-initiate if needed.
 - As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to monitor the status of an upgrade — its current state (pending, running, succeeded, or failed), the source and target versions, and when each state transition happened, so that I can take an appropriate action in a timely manner.
-- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want a brief cancellation window after initiating an upgrade, so that I can cancel the upgrade, correct a mistake, and re-initiate if needed.
 - As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to see when a cluster has entered limited support state due to a failed forced EOL upgrade, so that I understand the impact on the cluster's support status.
 
 ### Tenant User
@@ -91,4 +91,4 @@ Final: revise @ prd 0.7.1 - b8b3f86, workspace main @ 8f899d5
 
 > This document's phase history does not include an initial /draft — structure was not verified against the template from origin.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"8f899d5","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise","revise","revise","revise","revise","revise","revise","revise","revise","revise","manual-edit","revise","revise"],"authoring_modes":["manual","skill"],"context_changed":true,"origin_untracked":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"8f899d5","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise","revise","revise","revise","revise","revise","revise","revise","revise","revise","manual-edit","revise","revise","revise"],"authoring_modes":["manual","skill"],"context_changed":true,"origin_untracked":true} -->

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -43,21 +43,21 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 - Tenant Users and Tenant Admins receive a warning condition on a node pool when it approaches the N-2 minor version skew limit relative to the control plane, so they can initiate a node pool upgrade before the node pool falls out of the supported range
 
 **Platform-managed z-stream upgrades:**
-- The Cloud Provider Admin selects the fleet-wide z-stream target version for control plane upgrades and applies it across all clusters via progressive rollout; available z-stream versions are sourced from the cluster's available update graph, the same mechanism used for tenant-visible upgrade versions
+- The Cloud Provider Admin selects the fleet-wide z-stream target version for the control plane's current minor version and applies it across all clusters via progressive rollout; available z-stream versions are sourced from the cluster's available update graph, the same mechanism used for tenant-visible upgrade versions
 - Z-stream upgrades are triggered on-demand by the Cloud Provider Admin; the regular cadence targets critical CVE remediation within FedRAMP-aligned timelines (High CVEs: 30 days, Medium: 90 days)
 - If a z-stream rollout causes a significant regression, the Cloud Provider Admin can pause the rollout and roll back affected control planes
 - Tenants cannot select or initiate z-stream control plane upgrades; these are applied by the Cloud Provider Admin
 - If the fleet-wide z-stream target version is not reachable from a cluster's available update graph, the cluster is flagged as an error in the rollout status and no upgrade is initiated for that cluster
 - Tenant Users and Tenant Admins are notified via resource status conditions when the platform applies a z-stream upgrade to their cluster
-- The Cloud Provider Admin can force a control plane y-stream upgrade for a specific cluster at end-of-life; node pools remain at their current version during the forced upgrade and continue to serve workloads — if the current node pool version is approaching the N-2 minor version skew limit relative to the forced target, a warning condition surfaces on the node pool; if the forced upgrade fails, the cluster enters a limited-support state (SLA no longer applies, but support remains available); a status condition on the cluster signals the limited-support state to tenants
+- The Cloud Provider Admin can force a control plane y-stream upgrade for a specific cluster at end-of-life; each forced upgrade is a single one-hop operation — the target version must be directly reachable from the cluster's available update graph; if reaching the desired target requires multiple hops, the Cloud Provider Admin is responsible for planning and executing the intermediate upgrades sequentially; node pools remain at their current version during the forced upgrade and continue to serve workloads — if the current node pool version is approaching the N-2 minor version skew limit relative to the forced target, a warning condition surfaces on the node pool; if the forced upgrade fails, the cluster enters a limited-support state (SLA no longer applies, but support remains available); a status condition on the cluster signals the limited-support state to tenants
 
 **User-facing API surfaces:**
 
 | Surface | Change |
 |---------|--------|
-| Fulfillment API (gRPC and REST) | New upgrade sub-resource per cluster component (control plane and node pool) with full CRUD and status. Available upgrade versions endpoint per cluster component. Org-scoped endpoint for Tenant Admins to list upgrade records across all clusters in their organization. |
-| CLI | Upgrade lifecycle commands: list available versions, initiate upgrade, cancel pending upgrade, view upgrade status, view upgrade history. |
-| UI | Upgrade lifecycle actions and history in the cluster detail view. Available versions and risk display before upgrade initiation. Cloud Provider Admin: fleet-wide z-stream target selection and upgrade status monitoring. |
+| Fulfillment API (gRPC and REST) | New upgrade sub-resource per cluster component (control plane and node pool) with full CRUD and status. Available upgrade versions endpoint per cluster component. Org-scoped endpoint for Tenant Admins to list upgrade records across all clusters in their organization. Fleet-wide z-stream upgrade target resource for Cloud Provider Admins (set target version, trigger rollout, pause, rollback). Fleet-wide rollout status endpoint exposing per-cluster upgrade state. |
+| CLI | Upgrade lifecycle commands: list available versions, initiate upgrade, cancel pending upgrade, view upgrade status, view upgrade history. Cloud Provider Admin: set fleet-wide z-stream target, trigger and monitor rollout, pause and roll back rollout, force EOL upgrade on a specific cluster. |
+| UI | Upgrade lifecycle actions and history in the cluster detail view. Available versions and risk display before upgrade initiation. Cloud Provider Admin: fleet-wide z-stream target selection, rollout triggering, pause, rollback, and cross-cluster upgrade status monitoring. |
 
 **E2E testing:** E2E coverage for upgrade initiation, status tracking, upgrade history, and pending upgrade cancellation in osac-test-infra.
 
@@ -145,8 +145,8 @@ No active role in this feature; all platform-level upgrade operations are covere
 
 ## Provenance
 
-Committed: commit @ prd 0.6.1 - 96de078, workspace prd/OSAC-1415 @ 5a21f81 (295 behind origin/main, dirty)
+Committed: commit @ prd 0.6.1 - 96de078, workspace prd/OSAC-1415 @ 7e2344f (295 behind origin/main, dirty)
 
 > Authoring phases not recorded this session (commit-time snapshot only).
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.6.1","ai_workflows":"96de078","source_repo":"5a21f81 (dirty)","source_repo_branch":"prd/OSAC-1415","commits_behind_main":295,"commits_ahead_main":2,"main_ref":"main","phases":["commit","commit"],"authoring_modes":["skill"],"context_changed":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.6.1","ai_workflows":"96de078","source_repo":"7e2344f (dirty)","source_repo_branch":"prd/OSAC-1415","commits_behind_main":295,"commits_ahead_main":3,"main_ref":"main","phases":["commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true} -->

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -20,6 +20,8 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 - Platform-forced end-of-life (EOL) y-stream control plane upgrades
 - Platform-initiated z-stream (patch version, e.g., 4.15.10 → 4.15.11) control plane upgrades
 - Tenant-initiated node pool upgrades
+- Console (UI) support for version selection, risk review, status monitoring, and cancellation (Tenant User, Tenant Admin), and fleet-wide z-stream rollout management (Cloud Provider Admin)
+- User documentation for upgrade initiation, monitoring, and fleet-wide rollout management
 
 ## Out of Scope
 
@@ -80,15 +82,4 @@ No active role in this feature; all platform-level upgrade operations are covere
 
 - **OSAC-1269 (ClusterVersion API):** A version is available for upgrade only if an allowed (not blocked) ClusterVersion exists for it
 
----
-
-## Provenance
-
-Authored: respond @ prd 0.6.3 - 68284c8, workspace main @ 43c34a8
-Final: revise @ prd 0.7.1 - b8b3f86, workspace main @ 8f899d5
-
-> Context changed between respond and revise.
-
-> This document's phase history does not include an initial /draft — structure was not verified against the template from origin.
-
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"8f899d5","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise","revise","revise","revise","revise","revise","revise","revise","revise","revise","manual-edit","revise","revise","revise"],"authoring_modes":["manual","skill"],"context_changed":true,"origin_untracked":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"declined"} -->

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -8,7 +8,7 @@
 
 ## Problem Statement
 
-OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion — but provides no managed path for upgrading a cluster's OpenShift version. Clusters are provisioned via Hosted Control Planes (HCP), where the control plane and worker node pools are independent upgrade targets with distinct ownership and ordering constraints; today neither target has first-class support in the OSAC API. Tenants who need a newer version must interact directly with HCP infrastructure, bypassing OSAC governance entirely: upgrades proceed without organizational oversight, leave no record in OSAC, and are invisible to OSAC's monitoring. As clusters age, the gap compounds: EOL versions lose Red Hat support coverage and security patches, but OSAC has no mechanism to surface upgrade readiness, track version transitions, or enforce upgrade progress.
+OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion — but provides no managed path for upgrading a cluster's OpenShift version. Clusters are provisioned via Hosted Control Planes (HCP), where the control plane and worker node pools are independent upgrade targets with distinct ownership and ordering constraints; today neither target has first-class support in the OSAC API. Tenants who need a newer version must interact directly with HCP infrastructure, bypassing OSAC entirely: upgrades leave no record in OSAC and are invisible to its monitoring. As clusters age, the gap compounds: EOL versions lose Red Hat support coverage and security patches, but OSAC has no mechanism to surface upgrade readiness, track version transitions, or apply platform-wide patches.
 
 ## In Scope
 
@@ -16,7 +16,10 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 
 **Tenant upgrade capabilities:**
 - Each cluster has an update channel assigned at cluster creation time, which scopes the cluster's available update graph and the set of versions eligible for upgrade
-- Tenant Users and Tenant Admins can view available upgrade versions for a cluster's control plane and node pools; for both components, versions are sourced from the cluster's available update graph (only directly reachable versions are surfaced) and filtered by the cluster's update channel
+- Tenant Users and Tenant Admins can view available upgrade versions for a cluster's control plane and node pools
+  - Versions are sourced from the cluster's available update graph — only directly reachable versions are surfaced
+  - Versions are filtered by the cluster's update channel
+  - A version is only available for upgrade if an enabled ClusterVersion (OSAC-1269) exists for it
 - Available node pool versions are additionally capped at the current control plane version; a node pool cannot be upgraded past the version of its control plane
 - Tenant Users and Tenant Admins can initiate a control plane y-stream upgrade to any directly reachable version, one hop at a time
 - Tenant Users and Tenant Admins can initiate a node pool upgrade (y-stream or z-stream), one hop at a time
@@ -25,17 +28,7 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 - Only one active upgrade per cluster component (control plane or node pool) is permitted at a time; control plane and node pool upgrades are independent and may proceed concurrently
 
 **Upgrade tracking and visibility:**
-- Each upgrade is tracked as a discrete record per cluster component, with a stable lifecycle: pending (within cancellation window), running, succeeded, or failed
-- Each upgrade record includes the following fields:
-
-  | Field | Description |
-  |-------|-------------|
-  | Target version | The OpenShift version the upgrade is moving to |
-  | Upgrade type | Control plane or node pool |
-  | Node pool identifier | The name of the node pool being upgraded; present only for node pool upgrade records |
-  | State | Current lifecycle state (pending, running, succeeded, failed) with a human-readable description |
-  | Creation timestamp | When the upgrade was initiated |
-  | Last update timestamp | When the state last changed |
+- Each upgrade is tracked as a discrete record per cluster component, with a stable lifecycle: pending (within cancellation window), running, succeeded, or failed. Each record identifies the cluster and the component being upgraded — control plane, or a specific named node pool — along with the source version, the target version, the current lifecycle state with a human-readable description, and the timestamps for when the upgrade was initiated and when the state last changed.
 
 - Upgrade status and progress are visible through conditions on each upgrade record
 - Control plane and node pool upgrade records are independent; when component versions diverge (e.g., after a partial upgrade or NP upgrade failure), the cluster resource surfaces a condition indicating the mismatch and exposes the current version of each component — control plane and each node pool — so tenants can assess the state without consulting individual upgrade records; the supported next action is to initiate a new node pool upgrade to retry independently
@@ -45,7 +38,7 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 **Platform-managed z-stream upgrades:**
 - The Cloud Provider Admin selects the fleet-wide z-stream target version for the control plane's current minor version and applies it across all clusters via progressive rollout; available z-stream versions are sourced from the cluster's available update graph, the same mechanism used for tenant-visible upgrade versions
 - Z-stream upgrades are triggered on-demand by the Cloud Provider Admin; the regular cadence targets critical CVE remediation within FedRAMP-aligned timelines (High CVEs: 30 days, Medium: 90 days)
-- If a z-stream rollout causes a significant regression, the Cloud Provider Admin can pause the rollout and roll back affected control planes
+- If a z-stream rollout causes a significant regression, the Cloud Provider Admin can pause the rollout to prevent further clusters from being upgraded; clusters that have already been upgraded cannot be automatically rolled back (HCP does not support control plane version downgrade) — remediation for already-affected clusters requires manual intervention, such as opening a support case with Red Hat
 - Tenants cannot select or initiate z-stream control plane upgrades; these are applied by the Cloud Provider Admin
 - If the fleet-wide z-stream target version is not reachable from a cluster's available update graph, the cluster is flagged as an error in the rollout status and no upgrade is initiated for that cluster
 - Tenant Users and Tenant Admins are notified via resource status conditions when the platform applies a z-stream upgrade to their cluster
@@ -55,21 +48,21 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 
 | Surface | Change |
 |---------|--------|
-| Fulfillment API (gRPC and REST) | New upgrade sub-resource per cluster component (control plane and node pool) with full CRUD and status. Available upgrade versions endpoint per cluster component. Org-scoped endpoint for Tenant Admins to list upgrade records across all clusters in their organization. Fleet-wide z-stream upgrade target resource for Cloud Provider Admins (set target version, trigger rollout, pause, rollback). Fleet-wide rollout status endpoint exposing per-cluster upgrade state. |
-| CLI | Upgrade lifecycle commands: list available versions, initiate upgrade, cancel pending upgrade, view upgrade status, view upgrade history. Cloud Provider Admin: set fleet-wide z-stream target, trigger and monitor rollout, pause and roll back rollout, force EOL upgrade on a specific cluster. |
-| UI | Upgrade lifecycle actions and history in the cluster detail view. Available versions and risk display before upgrade initiation. Cloud Provider Admin: fleet-wide z-stream target selection, rollout triggering, pause, rollback, and cross-cluster upgrade status monitoring. |
+| Fulfillment API | New upgrade sub-resource per cluster component (control plane and node pool). Available upgrade versions endpoint per cluster component. Org-scoped endpoint for Tenant Admins to list upgrade records across all clusters in their organization. Fleet-wide z-stream upgrade resource for Cloud Provider Admins (set target version, trigger rollout, pause, and monitor per-cluster status). |
+| CLI | Upgrade lifecycle commands: list available versions, initiate upgrade, cancel pending upgrade, view upgrade status, view upgrade history. Cloud Provider Admin: set fleet-wide z-stream target, trigger and monitor rollout, pause rollout, force EOL upgrade on a specific cluster. |
+| UI | Upgrade lifecycle actions and history in the cluster detail view. Available versions and risk display before upgrade initiation. Cloud Provider Admin: fleet-wide z-stream target selection, rollout triggering, pause, and cross-cluster upgrade status monitoring. |
 
 **E2E testing:** E2E coverage for upgrade initiation, status tracking, upgrade history, and pending upgrade cancellation in osac-test-infra.
 
 **Documentation:** User guides for upgrade initiation and monitoring (Tenant User), z-stream upgrade visibility (Tenant Admin), and fleet-wide z-stream management (Cloud Provider Admin).
 
-**Interfaces:** Fulfillment API (gRPC and REST), CLI, and UI console.
+**Interfaces:** Fulfillment API, CLI, and UI console.
 
 ## Out of Scope
 
 - SNO and traditional (non-HCP) control plane node upgrades
 - Fully automatic z-stream control plane upgrades triggered by version availability; unlike ROSA's auto-upgrade mechanism, z-stream upgrades in this version are on-demand operations initiated explicitly by the Cloud Provider Admin
-- Tenant-initiated upgrade rollback — clusters cannot be rolled back by tenants; rollback is a platform-level operation reserved for Cloud Provider Admins
+- Automated upgrade rollback — HCP does not support control plane version downgrade; neither tenants nor Cloud Provider Admins can roll back a completed upgrade through OSAC; remediation for a regressed upgrade requires manual intervention (e.g., a Red Hat support case)
 - Maintenance windows and upgrade exclusion windows; scheduled upgrades and maintenance windows are both future work
 - One-off scheduled upgrades; upgrades are initiated on-demand and begin after the cancellation window expires
 - Tenant admin version allowlist; version availability is determined by the cluster's available update graph
@@ -81,6 +74,7 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 - Custom release image upgrades; users can only select from versions surfaced by the cluster's available update graph
 - Upgrade policies per cluster tier; configuring different upgrade rules for dev, staging, and production clusters is deferred
 - Cancelling an in-progress upgrade; once the cancellation window closes, the upgrade cannot be stopped
+- Channel switching for installed clusters (e.g., moving from Stable to Fast or EUS); the cluster's update channel is set at creation time and inherited by the upgrade feature — switching channels on an existing cluster is a separate capability
 
 ## User Stories
 
@@ -145,8 +139,7 @@ No active role in this feature; all platform-level upgrade operations are covere
 
 ## Provenance
 
-Committed: commit @ prd 0.6.1 - 96de078, workspace prd/OSAC-1415 @ 7e2344f (295 behind origin/main, dirty)
+Authored: revise @ prd 0.6.3 - 68284c8, workspace main @ 43c34a8
+Phases: respond, revise
 
-> Authoring phases not recorded this session (commit-time snapshot only).
-
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.6.1","ai_workflows":"96de078","source_repo":"7e2344f (dirty)","source_repo_branch":"prd/OSAC-1415","commits_behind_main":295,"commits_ahead_main":3,"main_ref":"main","phases":["commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"68284c8","source_repo":"43c34a8","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise"],"authoring_modes":["skill"],"context_changed":false} -->

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -8,7 +8,7 @@
 
 ## Problem Statement
 
-OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion — but provides no managed path for upgrading a cluster's OpenShift version. Clusters are provisioned via Hosted Control Planes (HCP), where the control plane and node pools are independent upgrade targets with distinct ownership and ordering constraints; today neither has first-class support in the OSAC API. Tenants who need a newer version must interact directly with HCP infrastructure, bypassing OSAC entirely. As clusters age, the gap widens: end-of-life (EOL) versions lose Red Hat support coverage and security patches, but OSAC has no mechanism to surface upgrade readiness, track version transitions, or apply platform-wide patches.
+OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion — but provides no managed path for upgrading a cluster's OpenShift version. Clusters are provisioned via Hosted Control Planes (HCP), where the control plane and node pools are independent upgrade targets with distinct ownership and ordering constraints; today neither has first-class support in the OSAC API. Tenants who need a newer version have no way to upgrade their cluster at all — they cannot access the underlying HCP infrastructure directly, and OSAC exposes no upgrade capability in its place. As clusters age, the gap widens: end-of-life (EOL) versions lose Red Hat support coverage and security patches, but OSAC has no mechanism to surface upgrade readiness, track version transitions, or apply platform-wide patches.
 
 ## In Scope
 

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -14,34 +14,23 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 
 **Services:** CaaS — OpenShift clusters provisioned by OSAC via Hosted Control Planes.
 
-**Tenant upgrade capabilities:**
-- Each cluster has an update channel assigned at cluster creation time, which scopes the cluster's available update graph and the set of versions eligible for upgrade
-- Tenant Users and Tenant Admins can view available upgrade versions for a cluster's control plane and node pools
-  - Versions are sourced from the cluster's available update graph — only directly reachable versions are surfaced
-  - Versions are filtered by the cluster's update channel
-  - A version is only available for upgrade if an enabled ClusterVersion (OSAC-1269) exists for it
-- Available node pool versions are additionally capped at the current control plane version; a node pool cannot be upgraded past the version of its control plane
-- Tenant Users and Tenant Admins can initiate a control plane y-stream upgrade to any directly reachable version, one hop at a time
-- Tenant Users and Tenant Admins can initiate a node pool upgrade (y-stream or z-stream), one hop at a time
-- When the platform identifies risks for a target version, those risks are presented to the user before the upgrade can be initiated; the user must explicitly acknowledge the risks to proceed
-- After initiating an upgrade, a cancellation window of a few minutes allows the user to cancel before the upgrade begins; once the window closes, the upgrade cannot be stopped
-- Only one active upgrade per cluster component (control plane or node pool) is permitted at a time; control plane and node pool upgrades are independent and may proceed concurrently
-
-**Upgrade tracking and visibility:**
-- Each active upgrade has a visible lifecycle state — pending (within the cancellation window), running, succeeded, or failed — along with a human-readable description, the source and target versions, and timestamps for initiation and last state change
-- Upgrade status and progress are visible per cluster component (control plane and each named node pool)
-- Control plane and node pool upgrades are independent; when component versions diverge (e.g., after a partial upgrade or node pool upgrade failure), the cluster surfaces a condition indicating the mismatch and exposes the current version of each component — control plane and each node pool — so tenants can assess the state; the supported next action is to initiate a new node pool upgrade to retry independently
-- Past upgrade transitions and their outcomes are visible per cluster component as upgrade history; history is tied to the cluster's lifetime and is removed when the cluster is deleted
-- Tenant Users and Tenant Admins receive a warning condition on a node pool when it approaches the N-2 minor version skew limit relative to the control plane, so they can initiate a node pool upgrade before the node pool falls out of the supported range
+**Upgrade constraints:**
+- Available versions are directly reachable (one hop) in the cluster's update graph, filtered by the cluster's update channel
+- A reachable version is only available for upgrade if an enabled ClusterVersion (OSAC-1269) exists for it
+- Node pool versions are additionally capped at the current control plane version
+- Only one active upgrade per cluster component (control plane or node pool) is permitted; control plane and node pool upgrades are independent and may proceed concurrently
+- A cancellation window of a few minutes exists after upgrade initiation
 
 **Platform-managed z-stream upgrades:**
-- The Cloud Provider Admin selects the fleet-wide z-stream target version for the control plane's current minor version and applies it across all clusters via progressive rollout; available z-stream versions are sourced from the cluster's available update graph, the same mechanism used for tenant-visible upgrade versions
-- Z-stream upgrades are triggered on-demand by the Cloud Provider Admin; the regular cadence targets critical CVE remediation within FedRAMP-aligned timelines (High CVEs: 30 days, Medium: 90 days)
-- If a z-stream rollout causes a significant regression, the Cloud Provider Admin can pause the rollout to prevent further clusters from being upgraded; clusters that have already been upgraded cannot be automatically rolled back (HCP does not support control plane version downgrade) — remediation for already-affected clusters requires manual intervention, such as opening a support case with Red Hat
-- Tenants cannot select or initiate z-stream control plane upgrades; these are applied by the Cloud Provider Admin
-- If the fleet-wide z-stream target version is not reachable from a cluster's available update graph, the cluster is flagged as an error in the rollout status and no upgrade is initiated for that cluster
-- Tenant Users and Tenant Admins are notified via resource status conditions when the platform applies a z-stream upgrade to their cluster
-- The Cloud Provider Admin can force a control plane y-stream upgrade for a specific cluster at end-of-life; each forced upgrade is a single one-hop operation — the target version must be directly reachable from the cluster's available update graph; if reaching the desired target requires multiple hops, the Cloud Provider Admin is responsible for planning and executing the intermediate upgrades sequentially; node pools remain at their current version during the forced upgrade and continue to serve workloads — if the current node pool version is approaching the N-2 minor version skew limit relative to the forced target, a warning condition surfaces on the node pool; if the forced upgrade fails, the cluster enters a limited-support state (SLA no longer applies, but support remains available); a status condition on the cluster signals the limited-support state to tenants
+- Tenants cannot select or initiate z-stream control plane upgrades; these are applied by the Cloud Provider Admin via progressive rollout
+- Available z-stream versions follow the same one-hop reachability constraint as tenant-visible versions
+- Z-stream upgrades are triggered on-demand; the regular cadence targets FedRAMP-aligned CVE remediation timelines (High CVEs: 30 days, Medium: 90 days)
+- If the fleet-wide z-stream target version is not reachable from a cluster's available update graph, the cluster is flagged in the rollout status and no upgrade is initiated for that cluster
+
+**Forced EOL y-stream upgrades (Cloud Provider Admin):**
+- Each forced upgrade is a single one-hop operation; if reaching the desired target requires multiple hops, the Cloud Provider Admin is responsible for executing them sequentially
+- Node pools remain at their current version during a forced upgrade and continue to serve workloads
+- If a forced upgrade fails, the cluster enters a limited-support state (SLA no longer applies, but support remains available); the limited-support state is visible to tenants on the cluster
 
 **User-facing API surfaces:**
 
@@ -60,20 +49,8 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 ## Out of Scope
 
 - SNO and traditional (non-HCP) control plane node upgrades
-- Fully automatic z-stream control plane upgrades triggered by version availability; unlike ROSA's auto-upgrade mechanism, z-stream upgrades in this version are on-demand operations initiated explicitly by the Cloud Provider Admin
-- Automated upgrade rollback — HCP does not support control plane version downgrade; neither tenants nor Cloud Provider Admins can roll back a completed upgrade through OSAC; remediation for a regressed upgrade requires manual intervention (e.g., a Red Hat support case)
-- Maintenance windows and upgrade exclusion windows; scheduled upgrades and maintenance windows are both future work
-- One-off scheduled upgrades; upgrades are initiated on-demand and begin after the cancellation window expires
-- Tenant admin version allowlist; version availability is determined by the cluster's available update graph
-- Push notification infrastructure (email, webhook, or external alerting)
-- Installation and configuration of the OpenShift Update Service Operator for disconnected environments
-- Drift detection; out-of-band version changes are not tracked as a distinct event type
-- Upgrade history retention after cluster deletion; history does not outlive the cluster
-- Standalone audit trail; full operational auditing is a separate capability
-- Custom release image upgrades; users can only select from versions surfaced by the cluster's available update graph
-- Upgrade policies per cluster tier; configuring different upgrade rules for dev, staging, and production clusters is deferred
-- Cancelling an in-progress upgrade; once the cancellation window closes, the upgrade cannot be stopped
-- Channel switching for installed clusters (e.g., moving from Stable to Fast or EUS); the cluster's update channel is set at creation time and inherited by the upgrade feature — switching channels on an existing cluster is a separate capability
+- Rollback of completed upgrades — HCP does not support control plane version downgrade; completed upgrades cannot be reversed through OSAC
+- Cancelling an upgrade once it is in progress; only pending upgrades within the cancellation window can be cancelled
 
 ## User Stories
 
@@ -100,24 +77,28 @@ flowchart TD
 - As a Tenant User, I want to view the available upgrade versions for my cluster's control plane and node pools, including any known risks per version, so that I can make an informed upgrade decision.
 - As a Tenant User, I want to initiate a control plane y-stream upgrade for my cluster, acknowledging any identified risks, so that I can keep my cluster's OpenShift version current.
 - As a Tenant User, I want to initiate a node pool upgrade for my cluster — acknowledging any identified risks — so that my worker nodes run a supported OpenShift version.
-- As a Tenant User, I want to cancel an upgrade I initiated before it starts, so that I can correct a mistake within the cancellation window.
-- As a Tenant User, I want to monitor the status and progress of an in-progress upgrade through resource conditions, so that I can track when the upgrade completes or fails.
-- As a Tenant User, I want to see a warning condition when a node pool is approaching the N-2 minor version skew limit relative to the control plane, so that I can initiate a node pool upgrade before it falls out of the supported range.
+- As a Tenant User, I want to monitor the status of an upgrade — its current state (pending, running, succeeded, or failed), the source and target versions, and when each state transition happened.
+- As a Tenant User, I want to be warned when a node pool is approaching the N-2 minor version skew limit relative to the control plane, so that I can initiate a node pool upgrade before it falls out of the supported range.
+- As a Tenant User, I want to be informed when my cluster's control plane and node pool versions have diverged and a node pool upgrade is needed.
 - As a Tenant User, I want to view the upgrade history for my cluster, so that I can see which version transitions have occurred and their outcomes.
-- As a Tenant User, I want to be notified via a status condition when the platform applies a z-stream upgrade to my cluster, so that I am aware of platform-managed changes to my cluster's version.
+- As a Tenant User, I want to be notified when the platform applies a z-stream upgrade to my cluster, so that I am aware of platform-managed changes to my cluster's version.
+
+### Tenant Admin / Tenant User
+
+- As a Tenant Admin or Tenant User, I want to cancel an upgrade I initiated before it starts, so that I can correct a mistake within the cancellation window.
 
 ### Tenant Admin
 
 - As a Tenant Admin, I want to view the available upgrade versions for each cluster's control plane and node pools within my organization, so that I can plan and coordinate upgrades across my teams.
 - As a Tenant Admin, I want to initiate a control plane y-stream upgrade for any cluster in my organization — acknowledging any identified risks — so that I can manage the OpenShift version lifecycle on behalf of my organization.
 - As a Tenant Admin, I want to initiate a node pool upgrade for any cluster in my organization — acknowledging any identified risks — so that worker nodes remain within a supported version range.
-- As a Tenant Admin, I want to cancel an upgrade I initiated before it starts, so that I can correct a mistake within the cancellation window.
 - As a Tenant Admin, I want to view the upgrade history for any cluster in my organization, so that I can see which version transitions have occurred and their outcomes.
-- As a Tenant Admin, I want to be notified via a status condition when the platform applies a z-stream upgrade to a cluster in my organization, so that I have visibility into platform-managed changes affecting my clusters.
+- As a Tenant Admin, I want to be notified when the platform applies a z-stream upgrade to a cluster in my organization, so that I have visibility into platform-managed changes affecting my clusters.
 
 ### Cloud Provider Admin
 
 - As a Cloud Provider Admin, I want to select and publish the fleet-wide z-stream target version for control plane upgrades, so that all managed clusters run a consistent, supported patch version without requiring tenant action.
+- As a Cloud Provider Admin, I want to pause a z-stream rollout that is causing regressions, so that I can stop further clusters from being upgraded while I assess the impact.
 - As a Cloud Provider Admin, I want to monitor control plane upgrade status across all clusters, so that I can detect stalled or failed upgrades and intervene.
 - As a Cloud Provider Admin, I want to force a control plane y-stream upgrade for a specific cluster approaching end-of-life, so that the platform can maintain supportability independently of tenant scheduling.
 
@@ -132,15 +113,15 @@ No active role in this feature; all platform-level upgrade operations are covere
 ## Risks
 
 - **Version discovery availability**: if the update service is unreachable (e.g., network partition or local OpenShift Update Service failure in a disconnected environment), the platform cannot surface available upgrade versions or per-version risk data; the design will specify error behavior and retry semantics.
-- **Upgrade duration variability**: cluster upgrades can take minutes to hours depending on cluster size, workload, and the number of node pools; the platform exposes upgrade progress via conditions but makes no completion time guarantee.
+- **Upgrade duration variability**: cluster upgrades can take minutes to hours depending on cluster size, workload, and the number of node pools; the platform exposes upgrade progress but makes no completion time guarantee.
 
 ---
 
 ## Provenance
 
 Authored: respond @ prd 0.6.3 - 68284c8, workspace main @ 43c34a8
-Final: revise @ prd 0.6.3 - c045d41, workspace main @ d22bfa1
+Final: revise @ prd 0.6.3 - 6ec8c11, workspace main @ d22bfa1
 
 > Context changed between respond and revise.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"c045d41","source_repo":"d22bfa1","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise","revise","revise"],"authoring_modes":["skill"],"context_changed":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"6ec8c11","source_repo":"d22bfa1","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise","revise","revise","revise","revise","revise","revise","revise"],"authoring_modes":["skill"],"context_changed":true} -->

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -57,7 +57,7 @@ flowchart TD
 
 ### Cloud Provider Admin
 
-- As a Cloud Provider Admin, I want to select and publish the fleet-wide z-stream target version for control plane upgrades, so that all managed clusters run a consistent, supported patch version without requiring tenant action.
+- As a Cloud Provider Admin, I want to select and publish a z-stream target version per minor version cohort for control plane upgrades, so that all clusters running that minor version are brought to a consistent patch level without requiring tenant action.
 - As a Cloud Provider Admin, I want to pause a z-stream rollout that is causing regressions, so that I can stop further clusters from being upgraded while I assess the impact.
 - As a Cloud Provider Admin, I want to monitor control plane upgrade status across all clusters, so that I can detect stalled or failed upgrades and intervene.
 - As a Cloud Provider Admin, I want to force a control plane y-stream upgrade for a specific cluster approaching EOL, so that the platform can maintain supportability independently of tenant scheduling.
@@ -70,9 +70,12 @@ No active role in this feature; all platform-level upgrade operations are covere
 
 - Only CaaS-provisioned, HCP OpenShift clusters are covered: SNO and traditional (non-HCP) control plane node upgrades are not managed by OSAC
 - Available versions are directly reachable (one hop) in the cluster's update graph, filtered by the cluster's update channel
-- A reachable version is only available for upgrade if an enabled ClusterVersion (OSAC-1269) exists for it
-- Node pool versions are additionally capped at the current control plane version
-- Only one active upgrade per cluster component (control plane or node pool) is permitted; control plane and node pool upgrades are independent and may proceed concurrently
+- A reachable version is only available for upgrade if an enabled ClusterVersion (OSAC-1269) exists for it; "enabled" here corresponds to the ACTIVE or DEPRECATED states defined in OSAC-1269
+- Node pool versions are additionally capped at the control plane's committed version — the version it has successfully reached
+- If a control plane upgrade is in progress, the cap remains at the pre-upgrade version; it advances to the new version only once the control plane upgrade completes successfully
+- All node sets in a cluster share the same target OCP version; node pool upgrades apply uniformly across all node sets
+- Only one active upgrade per cluster component is permitted; the two components are the control plane and the node pool tier; control plane and node pool tier upgrades are independent and may proceed concurrently
+- If any node set fails to upgrade, the node pool tier upgrade is treated as failed; failure details identify which node set(s) did not complete the transition
 - A cancellation window of a few minutes exists after upgrade initiation
 - In-progress upgrades cannot be cancelled
 - Completed upgrades cannot be rolled back through OSAC

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -15,7 +15,8 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 **Services:** CaaS — OpenShift clusters provisioned by OSAC via Hosted Control Planes.
 
 **Tenant upgrade capabilities:**
-- Tenant Users and Tenant Admins can view available upgrade versions for a cluster's control plane and node pools; for both components, versions are sourced from the cluster's own Cincinnati evaluation (only directly reachable versions are surfaced) and filtered by the cluster's update channel
+- Each cluster has an update channel assigned at cluster creation time, which scopes the cluster's available update graph and the set of versions eligible for upgrade
+- Tenant Users and Tenant Admins can view available upgrade versions for a cluster's control plane and node pools; for both components, versions are sourced from the cluster's available update graph (only directly reachable versions are surfaced) and filtered by the cluster's update channel
 - Available node pool versions are additionally capped at the current control plane version; a node pool cannot be upgraded past the version of its control plane
 - Tenant Users and Tenant Admins can initiate a control plane y-stream upgrade to any directly reachable version, one hop at a time
 - Tenant Users and Tenant Admins can initiate a node pool upgrade (y-stream or z-stream), one hop at a time
@@ -37,16 +38,16 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
   | Last update timestamp | When the state last changed |
 
 - Upgrade status and progress are visible through conditions on each upgrade record
-- Control plane and node pool upgrade records are independent; if a node pool upgrade fails after the control plane upgrade has already succeeded, the tenant can initiate a new node pool upgrade to retry independently
+- Control plane and node pool upgrade records are independent; when component versions diverge (e.g., after a partial upgrade or NP upgrade failure), the cluster resource surfaces a condition indicating the mismatch and exposes the current version of each component — control plane and each node pool — so tenants can assess the state without consulting individual upgrade records; the supported next action is to initiate a new node pool upgrade to retry independently
 - Past upgrades per cluster component are available as a history, recording version transitions and their outcomes; history is tied to the cluster's lifetime and is removed when the cluster is deleted
 - Tenant Users and Tenant Admins receive a warning condition on a node pool when it approaches the N-2 minor version skew limit relative to the control plane, so they can initiate a node pool upgrade before the node pool falls out of the supported range
 
 **Platform-managed z-stream upgrades:**
-- The Cloud Provider Admin selects the fleet-wide z-stream target version for control plane upgrades and applies it across all clusters via progressive rollout; available z-stream versions are sourced from the cluster's own Cincinnati evaluation, the same mechanism used for tenant-visible upgrade versions
+- The Cloud Provider Admin selects the fleet-wide z-stream target version for control plane upgrades and applies it across all clusters via progressive rollout; available z-stream versions are sourced from the cluster's available update graph, the same mechanism used for tenant-visible upgrade versions
 - Z-stream upgrades are triggered on-demand by the Cloud Provider Admin; the regular cadence targets critical CVE remediation within FedRAMP-aligned timelines (High CVEs: 30 days, Medium: 90 days)
 - If a z-stream rollout causes a significant regression, the Cloud Provider Admin can pause the rollout and roll back affected control planes
 - Tenants cannot select or initiate z-stream control plane upgrades; these are applied by the Cloud Provider Admin
-- If the fleet-wide z-stream target version is not reachable from a cluster's current Cincinnati graph, the cluster is flagged as an error in the rollout status and no upgrade is initiated for that cluster
+- If the fleet-wide z-stream target version is not reachable from a cluster's available update graph, the cluster is flagged as an error in the rollout status and no upgrade is initiated for that cluster
 - Tenant Users and Tenant Admins are notified via resource status conditions when the platform applies a z-stream upgrade to their cluster
 - The Cloud Provider Admin can force a control plane y-stream upgrade for a specific cluster at end-of-life; node pools remain at their current version during the forced upgrade and continue to serve workloads — if the current node pool version is approaching the N-2 minor version skew limit relative to the forced target, a warning condition surfaces on the node pool; if the forced upgrade fails, the cluster enters a limited-support state (SLA no longer applies, but support remains available); a status condition on the cluster signals the limited-support state to tenants
 
@@ -71,14 +72,13 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 - Tenant-initiated upgrade rollback — clusters cannot be rolled back by tenants; rollback is a platform-level operation reserved for Cloud Provider Admins
 - Maintenance windows and upgrade exclusion windows; scheduled upgrades and maintenance windows are both future work
 - One-off scheduled upgrades; upgrades are initiated on-demand and begin after the cancellation window expires
-- Tenant admin version allowlist; version availability is determined by the cluster's Cincinnati evaluation
-- Channel selection; channel is set at cluster creation (OSAC-1269)
+- Tenant admin version allowlist; version availability is determined by the cluster's available update graph
 - Push notification infrastructure (email, webhook, or external alerting)
 - Installation and configuration of the OpenShift Update Service Operator for disconnected environments
 - Drift detection; out-of-band version changes are not tracked as a distinct event type
 - Upgrade history retention after cluster deletion; history does not outlive the cluster
 - Standalone audit trail; full operational auditing is a separate capability
-- Custom release image upgrades; users can only select from versions surfaced by the cluster's Cincinnati evaluation
+- Custom release image upgrades; users can only select from versions surfaced by the cluster's available update graph
 - Upgrade policies per cluster tier; configuring different upgrade rules for dev, staging, and production clusters is deferred
 - Cancelling an in-progress upgrade; once the cancellation window closes, the upgrade cannot be stopped
 
@@ -134,17 +134,19 @@ No active role in this feature; all platform-level upgrade operations are covere
 
 ## Dependencies
 
-- **OSAC-1269** (Managed Cluster Versions): must be complete before OSAC-1415 ships; provides cluster channel assignment at creation time, which determines the Cincinnati update graph used by this feature.
-- **Cincinnati / OpenShift Update Service**: source of available upgrade versions and per-version risk data, read from each cluster's own evaluation. In disconnected environments, the OpenShift Update Service Operator must be pre-configured as a prerequisite.
 - **HCP (HostedCluster + NodePool)**: source of upgrade state, conditions, and history; the design will confirm the specific HyperShift API surface used.
+
+## Risks
+
+- **Version discovery availability**: if the update service is unreachable (e.g., network partition or local OpenShift Update Service failure in a disconnected environment), the platform cannot surface available upgrade versions or per-version risk data; the design will specify error behavior and retry semantics.
+- **Upgrade duration variability**: cluster upgrades can take minutes to hours depending on cluster size, workload, and the number of node pools; the platform exposes upgrade progress via conditions but makes no completion time guarantee.
 
 ---
 
 ## Provenance
 
-Authored: draft @ prd 0.6.0 - 139e6c1, workspace main @ 411e256
-Final: revise @ prd 0.6.1 - 96de078, workspace main @ 7b4fff2
+Committed: commit @ prd 0.6.1 - 96de078, workspace prd/OSAC-1415 @ 5a21f81 (295 behind origin/main, dirty)
 
-> Context changed between draft and revise.
+> Authoring phases not recorded this session (commit-time snapshot only).
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.1","ai_workflows":"96de078","source_repo":"7b4fff2","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise","revise","revise","revise","revise","revise","revise","revise","revise"],"authoring_modes":["skill"],"context_changed":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.6.1","ai_workflows":"96de078","source_repo":"5a21f81 (dirty)","source_repo_branch":"prd/OSAC-1415","commits_behind_main":295,"commits_ahead_main":2,"main_ref":"main","phases":["commit","commit"],"authoring_modes":["skill"],"context_changed":false} -->

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -28,11 +28,10 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 - Only one active upgrade per cluster component (control plane or node pool) is permitted at a time; control plane and node pool upgrades are independent and may proceed concurrently
 
 **Upgrade tracking and visibility:**
-- Each upgrade is tracked as a discrete record per cluster component, with a stable lifecycle: pending (within cancellation window), running, succeeded, or failed. Each record identifies the cluster and the component being upgraded — control plane, or a specific named node pool — along with the source version, the target version, the current lifecycle state with a human-readable description, and the timestamps for when the upgrade was initiated and when the state last changed.
-
-- Upgrade status and progress are visible through conditions on each upgrade record
-- Control plane and node pool upgrade records are independent; when component versions diverge (e.g., after a partial upgrade or NP upgrade failure), the cluster resource surfaces a condition indicating the mismatch and exposes the current version of each component — control plane and each node pool — so tenants can assess the state without consulting individual upgrade records; the supported next action is to initiate a new node pool upgrade to retry independently
-- Past upgrades per cluster component are available as a history, recording version transitions and their outcomes; history is tied to the cluster's lifetime and is removed when the cluster is deleted
+- Each active upgrade has a visible lifecycle state — pending (within the cancellation window), running, succeeded, or failed — along with a human-readable description, the source and target versions, and timestamps for initiation and last state change
+- Upgrade status and progress are visible per cluster component (control plane and each named node pool)
+- Control plane and node pool upgrades are independent; when component versions diverge (e.g., after a partial upgrade or node pool upgrade failure), the cluster surfaces a condition indicating the mismatch and exposes the current version of each component — control plane and each node pool — so tenants can assess the state; the supported next action is to initiate a new node pool upgrade to retry independently
+- Past upgrade transitions and their outcomes are visible per cluster component as upgrade history; history is tied to the cluster's lifetime and is removed when the cluster is deleted
 - Tenant Users and Tenant Admins receive a warning condition on a node pool when it approaches the N-2 minor version skew limit relative to the control plane, so they can initiate a node pool upgrade before the node pool falls out of the supported range
 
 **Platform-managed z-stream upgrades:**
@@ -48,7 +47,7 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 
 | Surface | Change |
 |---------|--------|
-| Fulfillment API | New upgrade sub-resource per cluster component (control plane and node pool). Available upgrade versions endpoint per cluster component. Org-scoped endpoint for Tenant Admins to list upgrade records across all clusters in their organization. Fleet-wide z-stream upgrade resource for Cloud Provider Admins (set target version, trigger rollout, pause, and monitor per-cluster status). |
+| Fulfillment API | Upgrade initiation and cancellation per cluster component (control plane and node pool). Available upgrade versions query per cluster component. Upgrade status, progress, and history per cluster component. Org-wide upgrade visibility for Tenant Admins. Fleet-wide z-stream target management, rollout triggering and pausing, and per-cluster rollout status for Cloud Provider Admins. |
 | CLI | Upgrade lifecycle commands: list available versions, initiate upgrade, cancel pending upgrade, view upgrade status, view upgrade history. Cloud Provider Admin: set fleet-wide z-stream target, trigger and monitor rollout, pause rollout, force EOL upgrade on a specific cluster. |
 | UI | Upgrade lifecycle actions and history in the cluster detail view. Available versions and risk display before upgrade initiation. Cloud Provider Admin: fleet-wide z-stream target selection, rollout triggering, pause, and cross-cluster upgrade status monitoring. |
 
@@ -89,11 +88,11 @@ flowchart TD
     D --> E
     E --> F[Cancellation window opens]
     F --> G{User cancels\nwithin window?}
-    G -- Yes --> H[Pending upgrade record deleted]
+    G -- Yes --> H[Pending upgrade cancelled]
     G -- No --> I[Upgrade begins]
     I --> J{Outcome}
-    J -- Succeeded --> K[Upgrade record: succeeded]
-    J -- Failed --> L[Upgrade record: failed\nwith details]
+    J -- Succeeded --> K[Upgrade state: succeeded]
+    J -- Failed --> L[Upgrade state: failed\nwith details]
 ```
 
 ### Tenant User
@@ -139,7 +138,9 @@ No active role in this feature; all platform-level upgrade operations are covere
 
 ## Provenance
 
-Authored: revise @ prd 0.6.3 - 68284c8, workspace main @ 43c34a8
-Phases: respond, revise
+Authored: respond @ prd 0.6.3 - 68284c8, workspace main @ 43c34a8
+Final: revise @ prd 0.6.3 - c045d41, workspace main @ d22bfa1
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"68284c8","source_repo":"43c34a8","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise"],"authoring_modes":["skill"],"context_changed":false} -->
+> Context changed between respond and revise.
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"c045d41","source_repo":"d22bfa1","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise","revise","revise"],"authoring_modes":["skill"],"context_changed":true} -->

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -1,0 +1,151 @@
+# Cluster Upgrade — CaaS
+
+| Field      | Value                                                                      |
+|------------|----------------------------------------------------------------------------|
+| Author(s)  | Vitaliy Emporopulo                                                         |
+| Jira       | [OSAC-1415](https://redhat.atlassian.net/browse/OSAC-1415)                 |
+| Date       | 2026-07-27                                                                 |
+
+## Problem Statement
+
+OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion — but provides no managed path for upgrading a cluster's OpenShift version. Clusters are provisioned via Hosted Control Planes (HCP), where the control plane and worker node pools are independent upgrade targets with distinct ownership and ordering constraints; today neither target has first-class support in the OSAC API. Tenants who need a newer version must interact directly with HCP infrastructure, bypassing OSAC governance entirely: upgrades proceed without organizational oversight, leave no record in OSAC, and are invisible to OSAC's monitoring. As clusters age, the gap compounds: EOL versions lose Red Hat support coverage and security patches, but OSAC has no mechanism to surface upgrade readiness, track version transitions, or enforce upgrade progress.
+
+## In Scope
+
+**Services:** CaaS — OpenShift clusters provisioned by OSAC via Hosted Control Planes.
+
+**Tenant upgrade capabilities:**
+- Tenant Users and Tenant Admins can view available upgrade versions for a cluster's control plane and node pools; for both components, versions are sourced from the cluster's own Cincinnati evaluation (only directly reachable versions are surfaced) and filtered by the cluster's update channel
+- Available node pool versions are additionally capped at the current control plane version; a node pool cannot be upgraded past the version of its control plane
+- Tenant Users and Tenant Admins can initiate a control plane y-stream upgrade to any directly reachable version, one hop at a time
+- Tenant Users and Tenant Admins can initiate a node pool upgrade (y-stream or z-stream)
+- When the platform identifies risks for a target version, those risks are presented to the user before the upgrade can be initiated; the user must explicitly acknowledge the risks to proceed
+- After initiating an upgrade, a short cancellation window allows the user to cancel before the upgrade begins; once the window closes, the upgrade cannot be stopped
+- Only one active upgrade per cluster component (control plane or node pool) is permitted at a time
+
+**Upgrade tracking and visibility:**
+- Each upgrade is tracked as a discrete record per cluster component, with a stable lifecycle: pending (within cancellation window), running, succeeded, or failed
+- Each upgrade record includes the following fields:
+
+  | Field | Description |
+  |-------|-------------|
+  | Target version | The OpenShift version the upgrade is moving to |
+  | Upgrade type | Control plane or node pool |
+  | State | Current lifecycle state (pending, running, succeeded, failed) with a human-readable description |
+  | Creation timestamp | When the upgrade was initiated |
+  | Last update timestamp | When the state last changed |
+
+- Upgrade status and progress are visible through conditions on each upgrade record
+- Past upgrades per cluster component are available as a history, recording version transitions and their outcomes; history is tied to the cluster's lifetime and is removed when the cluster is deleted
+- Tenant Users and Tenant Admins receive a warning condition on a node pool when it approaches the N-2 minor version skew limit relative to the control plane, so they can initiate a node pool upgrade before the node pool falls out of the supported range
+
+**Platform-managed z-stream upgrades:**
+- The Cloud Provider Admin selects the fleet-wide z-stream target version for control plane upgrades and applies it across all clusters via progressive rollout; available z-stream versions are sourced from the cluster's own Cincinnati evaluation, the same mechanism used for tenant-visible upgrade versions
+- Z-stream upgrades are triggered on-demand by the Cloud Provider Admin; the regular cadence targets critical CVE remediation within FedRAMP-aligned timelines (High CVEs: 30 days, Medium: 90 days)
+- If a z-stream rollout causes a significant regression, the Cloud Provider Admin can pause the rollout and roll back affected control planes
+- Tenants cannot select or initiate z-stream control plane upgrades; these are applied automatically by the platform
+- Tenant Users and Tenant Admins are notified via resource status conditions when the platform applies a z-stream upgrade to their cluster
+- The Cloud Provider Admin can force a control plane y-stream upgrade for a specific cluster at end-of-life; if the forced upgrade fails, the cluster enters a limited-support state (SLA no longer applies, but support remains available)
+
+**User-facing API surfaces:**
+
+| Surface | Change |
+|---------|--------|
+| Fulfillment API (gRPC and REST) | New upgrade sub-resource per cluster component (control plane and node pool) with full CRUD and status. Available upgrade versions endpoint per cluster component. |
+| CLI | Upgrade lifecycle commands: list available versions, initiate upgrade, cancel pending upgrade, view upgrade status, view upgrade history. |
+| UI | Upgrade lifecycle actions and history in the cluster detail view. Available versions and risk display before upgrade initiation. Cloud Provider Admin: fleet-wide z-stream target selection and upgrade status monitoring. |
+
+**E2E testing:** E2E coverage for upgrade initiation, status tracking, upgrade history, and pending upgrade cancellation in osac-test-infra.
+
+**Documentation:** User guides for upgrade initiation and monitoring (Tenant User), z-stream upgrade visibility (Tenant Admin), and fleet-wide z-stream management (Cloud Provider Admin).
+
+**Interfaces:** Fulfillment API (gRPC and REST), CLI, and UI console.
+
+## Out of Scope
+
+- SNO and traditional (non-HCP) control plane node upgrades
+- Tenant-initiated upgrade rollback — clusters cannot be rolled back by tenants; rollback is a platform-level operation reserved for Cloud Provider Admins
+- Maintenance windows and upgrade exclusion windows; scheduled upgrades and maintenance windows are both future work
+- One-off scheduled upgrades; upgrades execute immediately upon initiation
+- Tenant admin version allowlist; version availability is determined by the cluster's Cincinnati evaluation
+- Channel selection; channel is set at cluster creation (OSAC-1269)
+- Push notification infrastructure (email, webhook, or external alerting)
+- Installation and configuration of the OpenShift Update Service Operator for disconnected environments
+- Drift detection; out-of-band version changes are not tracked as a distinct event type
+- Upgrade history retention after cluster deletion; history does not outlive the cluster
+- Standalone audit trail; full operational auditing is a separate capability
+- Custom release image upgrades; users can only select from versions surfaced by the cluster's Cincinnati evaluation
+- Upgrade policies per cluster tier; configuring different upgrade rules for dev, staging, and production clusters is deferred
+- Cancelling an in-progress upgrade; once the cancellation window closes, the upgrade cannot be stopped
+
+## User Stories
+
+The following diagram shows the tenant-initiated upgrade flow. It applies equally to control plane y-stream upgrades and node pool upgrades.
+
+```mermaid
+flowchart TD
+    A[User requests available upgrade versions] --> B[Platform returns versions\nwith associated risks]
+    B --> C{Risks identified\nfor target version?}
+    C -- Yes --> D[User acknowledges risks\nin upgrade request]
+    C -- No --> E[Upgrade initiated]
+    D --> E
+    E --> F[Cancellation window opens]
+    F --> G{User cancels\nwithin window?}
+    G -- Yes --> H[Upgrade record: cancelled]
+    G -- No --> I[Upgrade begins]
+    I --> J{Outcome}
+    J -- Succeeded --> K[Upgrade record: succeeded]
+    J -- Failed --> L[Upgrade record: failed\nwith details]
+```
+
+### Tenant User
+
+- As a Tenant User, I want to view the available upgrade versions for my cluster's control plane and node pools, including any known risks per version, so that I can make an informed upgrade decision.
+- As a Tenant User, I want to initiate a control plane y-stream upgrade for my cluster, acknowledging any identified risks, so that I can keep my cluster's OpenShift version current.
+- As a Tenant User, I want to initiate a node pool upgrade for my cluster — acknowledging any identified risks — so that my worker nodes run a supported OpenShift version.
+- As a Tenant User, I want to cancel an upgrade I initiated before it starts, so that I can correct a mistake within the cancellation window.
+- As a Tenant User, I want to monitor the status and progress of an in-progress upgrade through resource conditions, so that I can track when the upgrade completes or fails.
+- As a Tenant User, I want to see a warning condition when a node pool is approaching the N-2 minor version skew limit relative to the control plane, so that I can initiate a node pool upgrade before it falls out of the supported range.
+- As a Tenant User, I want to view the upgrade history for my cluster, so that I can see which version transitions have occurred and their outcomes.
+- As a Tenant User, I want to be notified via a status condition when the platform applies a z-stream upgrade to my cluster, so that I am aware of platform-managed changes to my cluster's version.
+
+### Tenant Admin
+
+- As a Tenant Admin, I want to view the available upgrade versions for each cluster's control plane and node pools within my organization, so that I can plan and coordinate upgrades across my teams.
+- As a Tenant Admin, I want to initiate a control plane y-stream upgrade for any cluster in my organization — acknowledging any identified risks — so that I can manage the OpenShift version lifecycle on behalf of my organization.
+- As a Tenant Admin, I want to initiate a node pool upgrade for any cluster in my organization — acknowledging any identified risks — so that worker nodes remain within a supported version range.
+- As a Tenant Admin, I want to cancel an upgrade I initiated before it starts, so that I can correct a mistake within the cancellation window.
+- As a Tenant Admin, I want to view the upgrade history for any cluster in my organization, so that I can see which version transitions have occurred and their outcomes.
+- As a Tenant Admin, I want to be notified via a status condition when the platform applies a z-stream upgrade to a cluster in my organization, so that I have visibility into platform-managed changes affecting my clusters.
+
+### Cloud Provider Admin
+
+- As a Cloud Provider Admin, I want to select and publish the fleet-wide z-stream target version for control plane upgrades, so that all managed clusters run a consistent, supported patch version without requiring tenant action.
+- As a Cloud Provider Admin, I want to monitor control plane upgrade status across all clusters, so that I can detect stalled or failed upgrades and intervene.
+- As a Cloud Provider Admin, I want to force a control plane y-stream upgrade for a specific cluster approaching end-of-life, so that the platform can maintain supportability independently of tenant scheduling.
+
+## Dependencies
+
+- **OSAC-1269** (Managed Cluster Versions): must be complete before OSAC-1415 ships; provides cluster channel assignment at creation time, which determines the Cincinnati update graph used by this feature.
+- **Cincinnati / OpenShift Update Service**: source of available upgrade versions and per-version risk data, read from each cluster's own evaluation. In disconnected environments, the OpenShift Update Service Operator must be pre-configured as a prerequisite.
+- **HCP (HostedCluster + NodePool)**: source of upgrade state, conditions, and history; the design will confirm the specific HyperShift API surface used.
+
+## Open Questions
+
+### Q1: Cancelled as a lifecycle state
+
+ROSA includes `cancelled` as a transient lifecycle state — when a user cancels a pending upgrade, the record transitions to `cancelled` before being removed. Should OSAC follow this pattern (cancelled as a transient state before record removal), or should cancellation simply delete the pending record with no intermediate state?
+
+**Owner:** CaaS team
+**Impact:** Upgrade record lifecycle definition; API behavior on cancellation.
+
+---
+
+## Provenance
+
+Authored: draft @ prd 0.6.0 - 139e6c1, workspace main @ 411e256
+Final: revise @ prd 0.6.1 - 96de078, workspace main @ 7b4fff2
+
+> Context changed between draft and revise.
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.1","ai_workflows":"96de078","source_repo":"7b4fff2","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise","revise","revise","revise","revise","revise","revise","revise"],"authoring_modes":["skill"],"context_changed":true} -->

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -16,9 +16,9 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 - Upgrade version discovery and restrictions
 - Upgrade initiation, monitoring
 - Cancellation of pending upgrades
-- Tenant-initiated y-stream control plane upgrades
+- Tenant-initiated y-stream (minor version, e.g., 4.15 → 4.16) control plane upgrades
 - Platform-forced end-of-life (EOL) y-stream control plane upgrades
-- Platform-intitiated z-stream control plane upgrades
+- Platform-initiated z-stream (patch version, e.g., 4.15.10 → 4.15.11) control plane upgrades
 - Tenant-initiated node pool upgrades
 
 ## Out of Scope
@@ -27,48 +27,48 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 - Upgrade rollback or version downgrade
 - Tenant-initiated z-stream control plane upgrades
 - Platform-initiated node pool upgrades
-- Cancellation of in-progress upgrades
+- Cancellation of running upgrades
 
 ## User Stories
 
 ### Tenant User / Tenant Admin / Cloud Provider Admin
 
-- As a User, I want to select a directly reacheable (one hop) and allowed by the platform upgrade version for my cluster component, so that I can initiate an valid upgrade.
-- As a User, I want to review any risks associated with a target upgrade version before initiating an upgrade, so that I can make an informed upgrade decision.
-- As a User, I want to aknowlege the risks associated with an upgrade version and proceed, or decline and keep the current version, so that my cluster remains operational and supported.
-- As a User, I want to monitor the status of an upgrade — its current state (pending, running, succeeded, or failed), the source and target versions, and when each state transition happened, so that I can take an appropriate action in a timely manner.
-- As a User, I want a brief cancellation window after initiating an upgrade, so that I can cancel the upgrade, correct a mistake, and re-initiate if needed.
-- As a User, I want to see when a cluster has entered limited-support state due to a failed forced EOL upgrade, so that I understand the SLA and support changes.
+- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to select an upgrade version for a cluster component that is directly reachable (one hop) and allowed by the platform, so that I can initiate a valid upgrade.
+- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to review any risks associated with a target upgrade version before initiating an upgrade, so that I can make an informed upgrade decision.
+- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to acknowledge the risks associated with an upgrade version and proceed, or decline and keep the current version, so that the cluster remains operational and supported.
+- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to monitor the status of an upgrade — its current state (pending, running, succeeded, or failed), the source and target versions, and when each state transition happened, so that I can take an appropriate action in a timely manner.
+- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want a brief cancellation window after initiating an upgrade, so that I can cancel the upgrade, correct a mistake, and re-initiate if needed.
+- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to see when a cluster has entered limited support state due to a failed forced EOL upgrade, so that I understand the impact on the cluster's support status.
 
 ### Tenant User
 
 - As a Tenant User, I want to initiate a node pool version upgrade, so that my cluster remains operational and supported.
 - As a Tenant User, I want to initiate a control plane y-stream upgrade, so that my cluster remains operational and supported.
-- As a Tenant User, I want the same target version applied uniformly across all node sets, so that the version of all node sets in the same cluster are aligned.
+- As a Tenant User, I want the same target version applied uniformly across all node sets within a node pool when I upgrade it, so that all node sets in that pool remain aligned.
 - As a Tenant User, I want a node pool upgrade marked as failed if any node set fails to upgrade, so that I can investigate and remediate the problem.
-- As a Tenant User, I want to see failure details per node pool when a node pool upgrade fails, so that I can identify and address the problem.
-- As a Tenant User, I want the node pool version capped at the control plane version of the same cluster, so that the cluster reamins operational and supported.
+- As a Tenant User, I want to see failure details per node set when a node pool upgrade fails, so that I can identify and address the problem.
+- As a Tenant User, I want the node pool version capped at the control plane version of the same cluster, so that the cluster remains operational and supported.
 - As a Tenant User, if a control plane upgrade is in progress, I want the node pool version cap to remain at the control plane's current version until the upgrade succeeds, so that the node pool version always remains correctly capped, even if the control plane upgrade fails.
-- As a Tenant User, I want to be informed when a node pool is approaching the N-2 minor version skew limit relative to the control plane, so that I can initiate a node pool upgrade before it falls out of the supported range.
+- As a Tenant User, I want to be informed when a node pool is approaching the N-2 y-stream (minor) version skew limit relative to the control plane, so that I can initiate a node pool upgrade before it falls out of the supported range.
 - As a Tenant User, I want to view the upgrade history for my cluster (control plane and node pool), so that I can see which version transitions have occurred and their outcomes.
 - As a Tenant User, I want to know when the platform applies a control plane upgrade to my cluster, so that I am aware of platform-managed changes to my cluster's version.
-- As a Tenant User, I want to be informed when my cluster's control plane and node pool versions have diverged and a node pool upgrade is needed, so that I can keep my cluster working and supported.
+- As a Tenant User, I want to be informed whenever my cluster's control plane and node pool versions diverge — even within the supported skew range — so that I can decide when to initiate a node pool upgrade and keep versions aligned.
 - As a Tenant User, I want my cluster's control plane and node pool to be upgraded concurrently, so that I can minimize the total upgrade duration.
-- As a Tenant User, I want only one upgrade at a time to be active per component, so that I can avoid conflicts and race conditions.
+- As a Tenant User, I want only one upgrade at a time to be active for a given cluster component (control plane or node pool), so that I can avoid conflicts and race conditions.
 
 ### Tenant Admin
 
 - As a Tenant Admin, I want to act as the Tenant User on any cluster within my organization, so that I can manage the version lifecycle on behalf of my organization.
-- As a Tenant Admin, I want to be informed when a cluster in my organization has diverged control plane and node pool versions and a node pool upgrade is needed, so that I can coordinate the upgrade.
+- As a Tenant Admin, I want to see which clusters across my organization have diverged control plane and node pool versions needing a node pool upgrade, so that I can coordinate upgrades across my fleet without checking each cluster individually.
 
 ### Cloud Provider Admin
 
-- As a Cloud Provider Admin, I want all upgrades to target only versions allowed by the platform as per OSAC-1269, namely versions for which `ClusterVersion` exists, and has status `ACTIVE` or `DEPRECATED`, so that the platform runs only approved and supported versions.
+- As a Cloud Provider Admin, I want all upgrades to target only versions allowed by the platform as per OSAC-1269 (i.e., not blocked), so that the platform runs only approved and supported versions.
 - As a Cloud Provider Admin, I want all control plane y-stream upgrades capped at the target y-stream's current fleet-wide z-stream version, so that all z-stream versions remain aligned and managed by the platform.
-- As a Cloud Provider Admin, I want to select a z-stream target version y-stream version cohort and initiate a progressive rollout, so that all clusters running that y-stream version that can be directly upgraded are brought to a consistent z-stream level without requiring tenant action.
+- As a Cloud Provider Admin, I want to select a target z-stream version for a given y-stream version cohort and initiate a progressive rollout, so that all clusters running that y-stream version that can be directly upgraded are brought to a consistent z-stream level without requiring tenant action.
 - As a Cloud Provider Admin, I want to pause a z-stream rollout that is causing regressions, so that I can stop further clusters from being upgraded while I assess the impact.
 - As a Cloud Provider Admin, I want to resume a paused z-stream rollout once the regression is resolved, so that clusters not yet upgraded at the time of pause continue receiving the upgrade.
-- As a Cloud Provider Admin, I want to monitor control plane upgrade status across all clusters, so that I can detect stalled or failed upgrades and intervene.
+- As a Cloud Provider Admin, I want to monitor the progress of a z-stream rollout across all targeted clusters, so that I can detect clusters with stalled or failed upgrades and intervene.
 - As a Cloud Provider Admin, I want to know which clusters in a z-stream rollout will be excluded because the target version is not directly reachable from their current version, so that I can assess the cause and plan remediation.
 - As a Cloud Provider Admin, I want to force a control plane y-stream upgrade for a specific cluster approaching EOL, so that the platform can maintain supportability independently of tenant scheduling.
 
@@ -91,4 +91,4 @@ Final: revise @ prd 0.7.1 - b8b3f86, workspace main @ 8f899d5
 
 > This document's phase history does not include an initial /draft — structure was not verified against the template from origin.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"8f899d5","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise","revise","revise","revise","revise","revise","revise","revise","revise","revise","manual-edit","revise"],"authoring_modes":["manual","skill"],"context_changed":true,"origin_untracked":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"8f899d5","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise","revise","revise","revise","revise","revise","revise","revise","revise","revise","manual-edit","revise","revise"],"authoring_modes":["manual","skill"],"context_changed":true,"origin_untracked":true} -->

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -8,107 +8,87 @@
 
 ## Problem Statement
 
-OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion — but provides no managed path for upgrading a cluster's OpenShift version. Clusters are provisioned via Hosted Control Planes (HCP), where the control plane and worker node pools are independent upgrade targets with distinct ownership and ordering constraints; today neither target has first-class support in the OSAC API. Tenants who need a newer version must interact directly with HCP infrastructure, bypassing OSAC entirely. As clusters age, the gap compounds: end-of-life (EOL) versions lose Red Hat support coverage and security patches, but OSAC has no mechanism to surface upgrade readiness, track version transitions, or apply platform-wide patches.
+OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion — but provides no managed path for upgrading a cluster's OpenShift version. Clusters are provisioned via Hosted Control Planes (HCP), where the control plane and node pools are independent upgrade targets with distinct ownership and ordering constraints; today neither has first-class support in the OSAC API. Tenants who need a newer version must interact directly with HCP infrastructure, bypassing OSAC entirely. As clusters age, the gap widens: end-of-life (EOL) versions lose Red Hat support coverage and security patches, but OSAC has no mechanism to surface upgrade readiness, track version transitions, or apply platform-wide patches.
+
+## In Scope
+
+- Upgrading CaaS-provisioned, HCP OpenShift clusters
+- Upgrade version discovery and restrictions
+- Upgrade initiation, monitoring
+- Cancellation of pending upgrades
+- Tenant-initiated y-stream control plane upgrades
+- Platform-forced end-of-life (EOL) y-stream control plane upgrades
+- Platform-intitiated z-stream control plane upgrades
+- Tenant-initiated node pool upgrades
+
+## Out of Scope
+
+- SNO and traditional (non-HCP) cluster upgrades
+- Upgrade rollback or version downgrade
+- Tenant-initiated z-stream control plane upgrades
+- Platform-initiated node pool upgrades
+- Cancellation of in-progress upgrades
 
 ## User Stories
 
-The following diagram shows the tenant-initiated upgrade flow. It applies equally to control plane y-stream upgrades and node pool upgrades.
+### Tenant User / Tenant Admin / Cloud Provider Admin
 
-```mermaid
-flowchart TD
-    A[User requests available upgrade versions] --> B[Platform returns versions\nwith associated risks]
-    B --> C{Risks identified\nfor target version?}
-    C -- Yes --> D[User acknowledges risks\nin upgrade request]
-    C -- No --> E[Upgrade initiated]
-    D --> E
-    E --> F[Cancellation window opens]
-    F --> G{User cancels\nwithin window?}
-    G -- Yes --> H[Pending upgrade cancelled]
-    G -- No --> I[Upgrade begins]
-    I --> J{Outcome}
-    J -- Succeeded --> K[Upgrade state: succeeded]
-    J -- Failed --> L[Upgrade state: failed\nwith details]
-```
+- As a User, I want to select a directly reacheable (one hop) and allowed by the platform upgrade version for my cluster component, so that I can initiate an valid upgrade.
+- As a User, I want to review any risks associated with a target upgrade version before initiating an upgrade, so that I can make an informed upgrade decision.
+- As a User, I want to aknowlege the risks associated with an upgrade version and proceed, or decline and keep the current version, so that my cluster remains operational and supported.
+- As a User, I want to monitor the status of an upgrade — its current state (pending, running, succeeded, or failed), the source and target versions, and when each state transition happened, so that I can take an appropriate action in a timely manner.
+- As a User, I want a brief cancellation window after initiating an upgrade, so that I can cancel the upgrade, correct a mistake, and re-initiate if needed.
+- As a User, I want to see when a cluster has entered limited-support state due to a failed forced EOL upgrade, so that I understand the SLA and support changes.
 
 ### Tenant User
 
-- As a Tenant User, I want to view the available upgrade versions for my cluster's control plane and node pools, including any known risks per version, so that I can make an informed upgrade decision.
-- As a Tenant User, I want to initiate a control plane y-stream upgrade for my cluster, acknowledging any identified risks, so that I can keep my cluster's OpenShift version current.
-- As a Tenant User, I want to initiate a node pool upgrade for my cluster — acknowledging any identified risks — so that my worker nodes run a supported OpenShift version.
-- As a Tenant User, I want to monitor the status of an upgrade — its current state (pending, running, succeeded, or failed), the source and target versions, and when each state transition happened, so that I can take an appropriate action in a timely manner.
-- As a Tenant User, I want to be warned when a node pool is approaching the N-2 minor version skew limit relative to the control plane, so that I can initiate a node pool upgrade before it falls out of the supported range.
+- As a Tenant User, I want to initiate a node pool version upgrade, so that my cluster remains operational and supported.
+- As a Tenant User, I want to initiate a control plane y-stream upgrade, so that my cluster remains operational and supported.
+- As a Tenant User, I want the same target version applied uniformly across all node sets, so that the version of all node sets in the same cluster are aligned.
+- As a Tenant User, I want a node pool upgrade marked as failed if any node set fails to upgrade, so that I can investigate and remediate the problem.
+- As a Tenant User, I want to see failure details per node pool when a node pool upgrade fails, so that I can identify and address the problem.
+- As a Tenant User, I want the node pool version capped at the control plane version of the same cluster, so that the cluster reamins operational and supported.
+- As a Tenant User, if a control plane upgrade is in progress, I want the node pool version cap to remain at the control plane's current version until the upgrade succeeds, so that the node pool version always remains correctly capped, even if the control plane upgrade fails.
+- As a Tenant User, I want to be informed when a node pool is approaching the N-2 minor version skew limit relative to the control plane, so that I can initiate a node pool upgrade before it falls out of the supported range.
+- As a Tenant User, I want to view the upgrade history for my cluster (control plane and node pool), so that I can see which version transitions have occurred and their outcomes.
+- As a Tenant User, I want to know when the platform applies a control plane upgrade to my cluster, so that I am aware of platform-managed changes to my cluster's version.
 - As a Tenant User, I want to be informed when my cluster's control plane and node pool versions have diverged and a node pool upgrade is needed, so that I can keep my cluster working and supported.
-- As a Tenant User, I want to view the upgrade history for my cluster, so that I can see which version transitions have occurred and their outcomes.
-- As a Tenant User, I want to know when the platform applies a z-stream upgrade to my cluster, so that I am aware of platform-managed changes to my cluster's version.
-- As a Tenant User, I want to see when my cluster has entered limited-support state due to a failed forced EOL upgrade, so that I understand the SLA change and know that support remains available.
-
-### Tenant Admin / Tenant User
-
-- As a Tenant Admin or Tenant User, I want to cancel an upgrade I initiated before it starts, so that I can correct a mistake within the cancellation window.
+- As a Tenant User, I want my cluster's control plane and node pool to be upgraded concurrently, so that I can minimize the total upgrade duration.
+- As a Tenant User, I want only one upgrade at a time to be active per component, so that I can avoid conflicts and race conditions.
 
 ### Tenant Admin
 
-- As a Tenant Admin, I want to view the available upgrade versions for each cluster's control plane and node pools within my organization, so that I can plan and coordinate upgrades across my teams.
-- As a Tenant Admin, I want to initiate a control plane y-stream upgrade for any cluster in my organization — acknowledging any identified risks — so that I can manage the OpenShift version lifecycle on behalf of my organization.
-- As a Tenant Admin, I want to initiate a node pool upgrade for any cluster in my organization — acknowledging any identified risks — so that worker nodes remain within a supported version range.
-- As a Tenant Admin, I want to monitor the status of an upgrade for any cluster in my organization — its current state (pending, running, succeeded, or failed), the source and target versions, and when each state transition happened.
-- As a Tenant Admin, I want to be informed when a cluster in my organization has its control plane and node pool versions diverged and a node pool upgrade is needed.
-- As a Tenant Admin, I want to view the upgrade history for any cluster in my organization, so that I can see which version transitions have occurred and their outcomes.
-- As a Tenant Admin, I want to know when the platform applies a z-stream upgrade to a cluster in my organization, so that I have visibility into platform-managed changes affecting my clusters.
+- As a Tenant Admin, I want to act as the Tenant User on any cluster within my organization, so that I can manage the version lifecycle on behalf of my organization.
+- As a Tenant Admin, I want to be informed when a cluster in my organization has diverged control plane and node pool versions and a node pool upgrade is needed, so that I can coordinate the upgrade.
 
 ### Cloud Provider Admin
 
-- As a Cloud Provider Admin, I want to select and publish a z-stream target version per minor version cohort for control plane upgrades, so that all clusters running that minor version are brought to a consistent patch level without requiring tenant action.
+- As a Cloud Provider Admin, I want all upgrades to target only versions allowed by the platform as per OSAC-1269, namely versions for which `ClusterVersion` exists, and has status `ACTIVE` or `DEPRECATED`, so that the platform runs only approved and supported versions.
+- As a Cloud Provider Admin, I want all control plane y-stream upgrades capped at the target y-stream's current fleet-wide z-stream version, so that all z-stream versions remain aligned and managed by the platform.
+- As a Cloud Provider Admin, I want to select a z-stream target version y-stream version cohort and initiate a progressive rollout, so that all clusters running that y-stream version that can be directly upgraded are brought to a consistent z-stream level without requiring tenant action.
 - As a Cloud Provider Admin, I want to pause a z-stream rollout that is causing regressions, so that I can stop further clusters from being upgraded while I assess the impact.
 - As a Cloud Provider Admin, I want to resume a paused z-stream rollout once the regression is resolved, so that clusters not yet upgraded at the time of pause continue receiving the upgrade.
 - As a Cloud Provider Admin, I want to monitor control plane upgrade status across all clusters, so that I can detect stalled or failed upgrades and intervene.
+- As a Cloud Provider Admin, I want to know which clusters in a z-stream rollout will be excluded because the target version is not directly reachable from their current version, so that I can assess the cause and plan remediation.
 - As a Cloud Provider Admin, I want to force a control plane y-stream upgrade for a specific cluster approaching EOL, so that the platform can maintain supportability independently of tenant scheduling.
 
 ### Cloud Infrastructure Admin
 
 No active role in this feature; all platform-level upgrade operations are covered by the Cloud Provider Admin stories above.
 
-## Constraints
+## Dependencies
 
-- Only CaaS-provisioned, HCP OpenShift clusters are covered: SNO and traditional (non-HCP) control plane node upgrades are not managed by OSAC
-- Available versions are directly reachable (one hop) in the cluster's update graph, filtered by the cluster's update channel
-- A reachable version is only available for upgrade if an enabled ClusterVersion (OSAC-1269) exists for it; "enabled" here corresponds to the ACTIVE or DEPRECATED states defined in OSAC-1269
-- Node pool versions are additionally capped at the control plane's committed version — the version it has successfully reached
-- If a control plane upgrade is in progress, the cap remains at the pre-upgrade version; it advances to the new version only once the control plane upgrade completes successfully
-- All node sets in a cluster share the same target OCP version; node pool upgrades apply uniformly across all node sets
-- Only one active upgrade per cluster component is permitted; the two components are the control plane and the node pool tier; control plane and node pool tier upgrades are independent and may proceed concurrently
-- If any node set fails to upgrade, the node pool tier upgrade is treated as failed; failure details identify which node set(s) did not complete the transition
-- A cancellation window of a few minutes exists after upgrade initiation
-- In-progress upgrades cannot be cancelled
-- Completed upgrades cannot be rolled back through OSAC; HCP does not support control plane version downgrade, so remediation for regression-affected clusters requires intervention outside of OSAC
-- Tenants cannot select or initiate z-stream control plane upgrades; these are applied by the Cloud Provider Admin via progressive rollout
-- Z-stream upgrades are triggered on-demand; the regular cadence targets FedRAMP-aligned CVE remediation timelines (High CVEs: 30 days, Medium: 90 days)
-- A paused rollout is visible as a distinct state in the rollout status; pausing stops new clusters from being selected for the rollout; resuming targets clusters in the cohort that had not yet been upgraded at pause time
-- If the fleet-wide z-stream target version is not reachable from a cluster's available update graph, the cluster is flagged in the rollout status and no upgrade is initiated for that cluster
-- During a forced EOL upgrade, node pools remain at their current version and continue to serve workloads
-- If a forced EOL upgrade fails, the cluster enters a limited-support state (SLA no longer applies, but support remains available)
-
-**User-facing API surfaces:**
-
-| Surface | Change |
-|---------|--------|
-| Fulfillment API | Upgrade initiation and cancellation per cluster component (control plane and node pool). Available upgrade versions query per cluster component. Upgrade status, progress, and history per cluster component. Org-wide upgrade visibility for Tenant Admins. Fleet-wide z-stream target management, rollout triggering, pausing, and resuming, and per-cluster rollout status for Cloud Provider Admins. |
-| CLI | Upgrade lifecycle commands: list available versions, initiate upgrade, cancel pending upgrade, view upgrade status, view upgrade history. Cloud Provider Admin: set fleet-wide z-stream target, trigger, pause, and resume rollout, force EOL upgrade on a specific cluster. |
-| UI | Upgrade lifecycle actions and history in the cluster detail view. Available versions and risk display before upgrade initiation. Cloud Provider Admin: fleet-wide z-stream target selection, rollout triggering, pause, resume, and cross-cluster upgrade status monitoring. |
-
-**E2E testing:** E2E coverage for upgrade initiation, status tracking, upgrade history, and pending upgrade cancellation in osac-test-infra.
-
-**Documentation:** User guides for upgrade initiation and monitoring (Tenant User), z-stream upgrade visibility (Tenant Admin), and fleet-wide z-stream management (Cloud Provider Admin).
-
-**Interfaces:** Fulfillment API, CLI, and UI console.
+- **OSAC-1269 (ClusterVersion API):** A version is available for upgrade only if an allowed (not blocked) ClusterVersion exists for it
 
 ---
 
 ## Provenance
 
 Authored: respond @ prd 0.6.3 - 68284c8, workspace main @ 43c34a8
-Final: revise @ prd 0.6.3 - 6ec8c11, workspace main @ d22bfa1
+Final: revise @ prd 0.7.1 - b8b3f86, workspace main @ 8f899d5
 
 > Context changed between respond and revise.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.3","ai_workflows":"6ec8c11","source_repo":"d22bfa1","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise","revise","revise","revise","revise","revise","revise","revise","revise","revise"],"authoring_modes":["skill"],"context_changed":true} -->
+> This document's phase history does not include an initial /draft — structure was not verified against the template from origin.
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"8f899d5","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["respond","revise","revise","revise","revise","revise","revise","revise","revise","revise","revise","manual-edit","revise"],"authoring_modes":["manual","skill"],"context_changed":true,"origin_untracked":true} -->

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -18,10 +18,10 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 - Tenant Users and Tenant Admins can view available upgrade versions for a cluster's control plane and node pools; for both components, versions are sourced from the cluster's own Cincinnati evaluation (only directly reachable versions are surfaced) and filtered by the cluster's update channel
 - Available node pool versions are additionally capped at the current control plane version; a node pool cannot be upgraded past the version of its control plane
 - Tenant Users and Tenant Admins can initiate a control plane y-stream upgrade to any directly reachable version, one hop at a time
-- Tenant Users and Tenant Admins can initiate a node pool upgrade (y-stream or z-stream)
+- Tenant Users and Tenant Admins can initiate a node pool upgrade (y-stream or z-stream), one hop at a time
 - When the platform identifies risks for a target version, those risks are presented to the user before the upgrade can be initiated; the user must explicitly acknowledge the risks to proceed
-- After initiating an upgrade, a short cancellation window allows the user to cancel before the upgrade begins; once the window closes, the upgrade cannot be stopped
-- Only one active upgrade per cluster component (control plane or node pool) is permitted at a time
+- After initiating an upgrade, a cancellation window of a few minutes allows the user to cancel before the upgrade begins; once the window closes, the upgrade cannot be stopped
+- Only one active upgrade per cluster component (control plane or node pool) is permitted at a time; control plane and node pool upgrades are independent and may proceed concurrently
 
 **Upgrade tracking and visibility:**
 - Each upgrade is tracked as a discrete record per cluster component, with a stable lifecycle: pending (within cancellation window), running, succeeded, or failed
@@ -31,11 +31,13 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
   |-------|-------------|
   | Target version | The OpenShift version the upgrade is moving to |
   | Upgrade type | Control plane or node pool |
+  | Node pool identifier | The name of the node pool being upgraded; present only for node pool upgrade records |
   | State | Current lifecycle state (pending, running, succeeded, failed) with a human-readable description |
   | Creation timestamp | When the upgrade was initiated |
   | Last update timestamp | When the state last changed |
 
 - Upgrade status and progress are visible through conditions on each upgrade record
+- Control plane and node pool upgrade records are independent; if a node pool upgrade fails after the control plane upgrade has already succeeded, the tenant can initiate a new node pool upgrade to retry independently
 - Past upgrades per cluster component are available as a history, recording version transitions and their outcomes; history is tied to the cluster's lifetime and is removed when the cluster is deleted
 - Tenant Users and Tenant Admins receive a warning condition on a node pool when it approaches the N-2 minor version skew limit relative to the control plane, so they can initiate a node pool upgrade before the node pool falls out of the supported range
 
@@ -43,15 +45,16 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 - The Cloud Provider Admin selects the fleet-wide z-stream target version for control plane upgrades and applies it across all clusters via progressive rollout; available z-stream versions are sourced from the cluster's own Cincinnati evaluation, the same mechanism used for tenant-visible upgrade versions
 - Z-stream upgrades are triggered on-demand by the Cloud Provider Admin; the regular cadence targets critical CVE remediation within FedRAMP-aligned timelines (High CVEs: 30 days, Medium: 90 days)
 - If a z-stream rollout causes a significant regression, the Cloud Provider Admin can pause the rollout and roll back affected control planes
-- Tenants cannot select or initiate z-stream control plane upgrades; these are applied automatically by the platform
+- Tenants cannot select or initiate z-stream control plane upgrades; these are applied by the Cloud Provider Admin
+- If the fleet-wide z-stream target version is not reachable from a cluster's current Cincinnati graph, the cluster is flagged as an error in the rollout status and no upgrade is initiated for that cluster
 - Tenant Users and Tenant Admins are notified via resource status conditions when the platform applies a z-stream upgrade to their cluster
-- The Cloud Provider Admin can force a control plane y-stream upgrade for a specific cluster at end-of-life; if the forced upgrade fails, the cluster enters a limited-support state (SLA no longer applies, but support remains available)
+- The Cloud Provider Admin can force a control plane y-stream upgrade for a specific cluster at end-of-life; node pools remain at their current version during the forced upgrade and continue to serve workloads — if the current node pool version is approaching the N-2 minor version skew limit relative to the forced target, a warning condition surfaces on the node pool; if the forced upgrade fails, the cluster enters a limited-support state (SLA no longer applies, but support remains available); a status condition on the cluster signals the limited-support state to tenants
 
 **User-facing API surfaces:**
 
 | Surface | Change |
 |---------|--------|
-| Fulfillment API (gRPC and REST) | New upgrade sub-resource per cluster component (control plane and node pool) with full CRUD and status. Available upgrade versions endpoint per cluster component. |
+| Fulfillment API (gRPC and REST) | New upgrade sub-resource per cluster component (control plane and node pool) with full CRUD and status. Available upgrade versions endpoint per cluster component. Org-scoped endpoint for Tenant Admins to list upgrade records across all clusters in their organization. |
 | CLI | Upgrade lifecycle commands: list available versions, initiate upgrade, cancel pending upgrade, view upgrade status, view upgrade history. |
 | UI | Upgrade lifecycle actions and history in the cluster detail view. Available versions and risk display before upgrade initiation. Cloud Provider Admin: fleet-wide z-stream target selection and upgrade status monitoring. |
 
@@ -64,9 +67,10 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 ## Out of Scope
 
 - SNO and traditional (non-HCP) control plane node upgrades
+- Fully automatic z-stream control plane upgrades triggered by version availability; unlike ROSA's auto-upgrade mechanism, z-stream upgrades in this version are on-demand operations initiated explicitly by the Cloud Provider Admin
 - Tenant-initiated upgrade rollback — clusters cannot be rolled back by tenants; rollback is a platform-level operation reserved for Cloud Provider Admins
 - Maintenance windows and upgrade exclusion windows; scheduled upgrades and maintenance windows are both future work
-- One-off scheduled upgrades; upgrades execute immediately upon initiation
+- One-off scheduled upgrades; upgrades are initiated on-demand and begin after the cancellation window expires
 - Tenant admin version allowlist; version availability is determined by the cluster's Cincinnati evaluation
 - Channel selection; channel is set at cluster creation (OSAC-1269)
 - Push notification infrastructure (email, webhook, or external alerting)
@@ -91,7 +95,7 @@ flowchart TD
     D --> E
     E --> F[Cancellation window opens]
     F --> G{User cancels\nwithin window?}
-    G -- Yes --> H[Upgrade record: cancelled]
+    G -- Yes --> H[Pending upgrade record deleted]
     G -- No --> I[Upgrade begins]
     I --> J{Outcome}
     J -- Succeeded --> K[Upgrade record: succeeded]
@@ -124,20 +128,15 @@ flowchart TD
 - As a Cloud Provider Admin, I want to monitor control plane upgrade status across all clusters, so that I can detect stalled or failed upgrades and intervene.
 - As a Cloud Provider Admin, I want to force a control plane y-stream upgrade for a specific cluster approaching end-of-life, so that the platform can maintain supportability independently of tenant scheduling.
 
+### Cloud Infrastructure Admin
+
+No active role in this feature; all platform-level upgrade operations are covered by the Cloud Provider Admin stories above.
+
 ## Dependencies
 
 - **OSAC-1269** (Managed Cluster Versions): must be complete before OSAC-1415 ships; provides cluster channel assignment at creation time, which determines the Cincinnati update graph used by this feature.
 - **Cincinnati / OpenShift Update Service**: source of available upgrade versions and per-version risk data, read from each cluster's own evaluation. In disconnected environments, the OpenShift Update Service Operator must be pre-configured as a prerequisite.
 - **HCP (HostedCluster + NodePool)**: source of upgrade state, conditions, and history; the design will confirm the specific HyperShift API surface used.
-
-## Open Questions
-
-### Q1: Cancelled as a lifecycle state
-
-ROSA includes `cancelled` as a transient lifecycle state — when a user cancels a pending upgrade, the record transitions to `cancelled` before being removed. Should OSAC follow this pattern (cancelled as a transient state before record removal), or should cancellation simply delete the pending record with no intermediate state?
-
-**Owner:** CaaS team
-**Impact:** Upgrade record lifecycle definition; API behavior on cancellation.
 
 ---
 
@@ -148,4 +147,4 @@ Final: revise @ prd 0.6.1 - 96de078, workspace main @ 7b4fff2
 
 > Context changed between draft and revise.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.1","ai_workflows":"96de078","source_repo":"7b4fff2","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise","revise","revise","revise","revise","revise","revise","revise"],"authoring_modes":["skill"],"context_changed":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.6.1","ai_workflows":"96de078","source_repo":"7b4fff2","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise","revise","revise","revise","revise","revise","revise","revise","revise"],"authoring_modes":["skill"],"context_changed":true} -->

--- a/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
+++ b/enhancements/OSAC-1415-cluster-upgrade-caas/prd.md
@@ -8,7 +8,7 @@
 
 ## Problem Statement
 
-OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion — but provides no managed path for upgrading a cluster's OpenShift version. Clusters are provisioned via Hosted Control Planes (HCP), where the control plane and node pools are independent upgrade targets with distinct ownership and ordering constraints; today neither has first-class support in the OSAC API. Tenants who need a newer version have no way to upgrade their cluster at all — they cannot access the underlying HCP infrastructure directly, and OSAC exposes no upgrade capability in its place. As clusters age, the gap widens: end-of-life (EOL) versions lose Red Hat support coverage and security patches, but OSAC has no mechanism to surface upgrade readiness, track version transitions, or apply platform-wide patches.
+OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion — but provides no managed path for upgrading a cluster's OpenShift version. Clusters are provisioned via Hosted Control Planes (HCP), where the control plane and node pools are each an independent upgrade targets with distinct ownership and ordering constraints; today neither has first-class support in the OSAC API. Tenants who need a newer version have no way to upgrade their cluster at all — they cannot access the underlying HCP infrastructure directly, and OSAC exposes no upgrade capability in its place. As clusters age, the gap widens: end-of-life (EOL) versions lose Red Hat support coverage and security patches, but OSAC has no mechanism to surface upgrade readiness or track version transitions, leaving tenants without the information or tools needed to keep their clusters on supported versions.
 
 ## In Scope
 
@@ -16,68 +16,69 @@ OSAC CaaS manages the full cluster lifecycle — creation, scaling, and deletion
 - Upgrade version discovery and restrictions
 - Upgrade initiation, monitoring
 - Cancellation of pending upgrades
-- Tenant-initiated y-stream (minor version, e.g., 4.15 → 4.16) control plane upgrades
-- Platform-forced end-of-life (EOL) y-stream control plane upgrades
-- Platform-initiated z-stream (patch version, e.g., 4.15.10 → 4.15.11) control plane upgrades
-- Tenant-initiated node pool upgrades
-- Console (UI) support for version selection, risk review, status monitoring, and cancellation (Tenant User, Tenant Admin), and fleet-wide z-stream rollout management (Cloud Provider Admin)
-- User documentation for upgrade initiation, monitoring, and fleet-wide rollout management
+- Tenant-initiated control plane upgrades, as HCP supports upgrading the control plane independently of the node pools
+- Tenant-initiated node pool upgrades, as HCP supports upgrading a node pool independently of the control plane or other node pools
+- Console (UI) support for version selection, risk review, status monitoring, and cancellation (Tenant User, Tenant Admin)
+- User documentation for upgrade initiation and monitoring
 
 ## Out of Scope
 
 - SNO and traditional (non-HCP) cluster upgrades
 - Upgrade rollback or version downgrade
-- Tenant-initiated z-stream control plane upgrades
+- Platform-initiated control plane upgrades — deferred to a future version
 - Platform-initiated node pool upgrades
-- Cancellation of running upgrades
+- Cancellation of running upgrades, as OpenShift does not support it
 - Switching upgrade channels — a cluster remains on the channel it was created with
+- Multi-hop upgrades — an upgrade that requires multiple hops can be done as a sequence of one-hop upgrades
 
 ## User Stories
 
-### Tenant User / Tenant Admin / Cloud Provider Admin
-
-- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to select an upgrade version for a cluster component that is directly reachable (one hop) and allowed by the platform, so that I can initiate a valid upgrade.
-- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to review any risks associated with a target upgrade version before initiating an upgrade, so that I can make an informed upgrade decision.
-- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to acknowledge the risks associated with an upgrade version and proceed, or decline and keep the current version, so that the cluster remains operational and supported.
-- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want a brief cancellation window during which the upgrade remains pending after I initiate it, so that I can cancel the upgrade, correct a mistake, and re-initiate if needed.
-- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to monitor the status of an upgrade — its current state (pending, running, succeeded, or failed), the source and target versions, and when each state transition happened, so that I can take an appropriate action in a timely manner.
-- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to see when a cluster has entered limited support state due to a failed forced EOL upgrade, so that I understand the impact on the cluster's support status.
-
 ### Tenant User
 
-- As a Tenant User, I want to initiate a node pool version upgrade, so that my cluster remains operational and supported.
-- As a Tenant User, I want to initiate a control plane y-stream upgrade, so that my cluster remains operational and supported.
-- As a Tenant User, I want the same target version applied uniformly across all node sets within a node pool when I upgrade it, so that all node sets in that pool remain aligned.
-- As a Tenant User, I want a node pool upgrade marked as failed if any node set fails to upgrade, so that I can investigate and remediate the problem.
-- As a Tenant User, I want to see failure details per node set when a node pool upgrade fails, so that I can identify and address the problem.
-- As a Tenant User, I want the node pool version capped at the control plane version of the same cluster, so that the cluster remains operational and supported.
-- As a Tenant User, if a control plane upgrade is in progress, I want the node pool version cap to remain at the control plane's current version until the upgrade succeeds, so that the node pool version always remains correctly capped, even if the control plane upgrade fails.
-- As a Tenant User, I want to be informed when a node pool is approaching the N-2 y-stream (minor) version skew limit relative to the control plane, so that I can initiate a node pool upgrade before it falls out of the supported range.
-- As a Tenant User, I want to view the upgrade history for my cluster (control plane and node pool), so that I can see which version transitions have occurred and their outcomes.
-- As a Tenant User, I want to know when the platform applies a control plane upgrade to my cluster, so that I am aware of platform-managed changes to my cluster's version.
-- As a Tenant User, I want to be informed whenever my cluster's control plane and node pool versions diverge — even within the supported skew range — so that I can decide when to initiate a node pool upgrade and keep versions aligned.
-- As a Tenant User, I want my cluster's control plane and node pool to be upgraded concurrently, so that I can minimize the total upgrade duration.
-- As a Tenant User, I want only one upgrade at a time to be active for a given cluster component (control plane or node pool), so that I can avoid conflicts and race conditions.
+- As a Tenant User, I want to initiate a version upgrade for any node pool in my cluster, so that my cluster remains operational and supported.
+- As a Tenant User, I want to initiate a control plane version upgrade, so that my cluster remains operational and supported.
+- As a Tenant User, I want to select an upgrade version for a cluster component that is directly reachable (one hop) and allowed by the platform, so that I can initiate a valid upgrade.
+- As a Tenant User, I want all my upgrades to be restricted only to versions allowed by the platform as per OSAC-1269 (i.e., not blocked), so that the platform runs only approved and supported versions.
+- As a Tenant User, I want to review any risks associated with a target upgrade version before initiating an upgrade, so that I can make an informed upgrade decision.
+- As a Tenant User, I want to acknowledge the risks associated with an upgrade version and proceed, or decline and keep the current version, so that the cluster remains operational and supported.
+- As a Tenant User, I want a brief cancellation window during which the upgrade remains pending after I initiate it, so that I can cancel the upgrade, correct a mistake, and re-initiate if needed.
+- As a Tenant User, I want to monitor the status of an upgrade — its current state (pending, running, succeeded, or failed), the source and target versions, and when each state transition happened, so that I can take an appropriate action in a timely manner.
+- As a Tenant User, I want each node pool's version capped at the control plane version of the same cluster, so that the cluster remains operational and supported. This is an HCP requirement.
+- As a Tenant User, I want to be able to upgrade my cluster's control plane and node pools in parallel, which is supported by HCP, so that I can minimize the total upgrade duration.
+- As a Tenant User, I want only one upgrade at a time to be active for a given cluster component (control plane or individual node pool), so that I can avoid conflicts and race conditions.
+- As a Tenant User, if a control plane upgrade is in progress, I want the node pool version cap to remain at the control plane's target version to meet the HCP requirements, so that the cluster remains operational and supported.
+- As a Tenant User, I want to be informed when a node pool is approaching the maximum supported version skew of N-3 relative to the control plane (according to the HCP restrictions), so that I can initiate a node pool upgrade before it falls out of the supported range.
+- As a Tenant User, I want to view the upgrade history for my cluster (control plane and node pools), so that I can see which version transitions have occurred and their outcomes.
+- As a Tenant User, I want to be informed whenever any of my cluster's node pools diverge from the control plane version — even within the supported skew range — so that I can decide when to initiate a node pool upgrade and keep versions aligned.
+- As a Tenant User, I want to see when a cluster has entered limited support state due to EOL, so that I understand the impact on the cluster's support status.
 
 ### Tenant Admin
 
 - As a Tenant Admin, I want to act as the Tenant User on any cluster within my organization, so that I can manage the version lifecycle on behalf of my organization.
-- As a Tenant Admin, I want to see which clusters across my organization have diverged control plane and node pool versions needing a node pool upgrade, so that I can coordinate upgrades across my fleet without checking each cluster individually.
+- As a Tenant Admin, I want to see which clusters across my organization have node pools that diverge from the control plane version, so that I can coordinate upgrades across my fleet without checking each cluster individually.
 
 ### Cloud Provider Admin
 
-- As a Cloud Provider Admin, I want all upgrades to target only versions allowed by the platform as per OSAC-1269 (i.e., not blocked), so that the platform runs only approved and supported versions.
-- As a Cloud Provider Admin, I want all control plane y-stream upgrades capped at the target y-stream's current fleet-wide z-stream version, so that all z-stream versions remain aligned and managed by the platform.
-- As a Cloud Provider Admin, I want to select a target z-stream version for a given y-stream version cohort and initiate a progressive rollout, so that all clusters running that y-stream version that can be directly upgraded are brought to a consistent z-stream level without requiring tenant action.
-- As a Cloud Provider Admin, I want to pause a z-stream rollout that is causing regressions, so that I can stop further clusters from being upgraded while I assess the impact.
-- As a Cloud Provider Admin, I want to resume a paused z-stream rollout once the regression is resolved, so that clusters not yet upgraded at the time of pause continue receiving the upgrade.
-- As a Cloud Provider Admin, I want to monitor the progress of a z-stream rollout across all targeted clusters, so that I can detect clusters with stalled or failed upgrades and intervene.
-- As a Cloud Provider Admin, I want to know which clusters in a z-stream rollout will be excluded because the target version is not directly reachable from their current version, so that I can assess the cause and plan remediation.
-- As a Cloud Provider Admin, I want to force a control plane y-stream upgrade for a specific cluster approaching EOL, so that the platform can maintain supportability independently of tenant scheduling.
+No active role in this feature; all platform-level upgrade operations are out of scope in this version.
 
 ### Cloud Infrastructure Admin
 
-No active role in this feature; all platform-level upgrade operations are covered by the Cloud Provider Admin stories above.
+No active role in this feature; all platform-level upgrade operations are out of scope in this version.
+
+## Assumptions
+
+This PRD assumes the following OpenShift and HCP capabilities, verified against the
+[OCP 4.22 Hosted Control Planes documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/hosted_control_planes/hcp-updating):
+
+1. **Independent control plane and node pool upgrades.** HCP decouples the control plane from node pools, allowing each to be upgraded separately.
+2. **Concurrent control plane and node pool upgrades.** HCP does not prevent a node pool upgrade from running while a control plane upgrade is in progress, provided the version skew policy is satisfied.
+3. **Node pool version ceiling.** HCP enforces that a node pool version (including patch level) must not exceed the control plane version.
+4. **Version skew between control plane and node pools.** The maximum supported skew for all currently offered OCP version is up to N-3 minor versions behind the hosted cluster version.
+5. **Upgrade version discovery via upgrade graph.** A cluster connected to the OpenShift upgrade graph can discover the set of directly reachable (one-hop) target versions.
+6. **Conditional updates with risk metadata.** The OpenShift upgrade graph provides risk descriptions and matching rules for conditional updates. HCP surfaces this information but does not gate upgrades on it.
+7. **Irreversible control-plane upgrades.** OpenShift does not support control-plane or whole-cluster version rollback or downgrade once an upgrade has started; a failed upgrade requires Red Hat support intervention. HCP does support rolling a node pool back to a control-plane-compatible version.
+8. **No native cancellation of running upgrades.** Once an upgrade begins execution, it cannot be stopped.
+9. **OSAC node sets map 1:1 to HCP NodePools.** Each OSAC node set corresponds to a separate HCP node pool. A "node pool upgrade" in OSAC terms means upgrading the selected node pool associated with the cluster.
 
 ## Dependencies
 


### PR DESCRIPTION
## PRD: Cluster Upgrade — CaaS

**Jira:** [OSAC-1415](https://redhat.atlassian.net/browse/OSAC-1415)

### Summary

This PRD defines requirements for managed OpenShift cluster upgrade support in OSAC CaaS. Clusters are provisioned via Hosted Control Planes (HCP), where the control plane and node pools are independent upgrade targets. Tenants initiate upgrades one hop at a time with risk acknowledgment and a post-initiation cancellation window. Each upgrade is tracked per cluster component with a stable lifecycle.

### Requesting Review On

- Requirements completeness and accuracy
- Scope (goals and non-goals)
- User stories — are all personas and capabilities correctly represented?

### How to Review

- Comment inline on specific sections
- Approve when the PRD accurately reflects the agreed requirements

> **Note:** This replaces #124, which accumulated too many review rounds to follow comments in context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added product requirements for managed upgrades of CaaS-provisioned HCP OpenShift clusters, including supported scopes and exclusions.
  * Documented tenant and administrator workflows, version reachability, platform restrictions, risk acknowledgement, approval rules, and cancellation windows.
  * Defined requirements for upgrade status and history, version ceilings and skew, concurrency, end-of-life visibility, limited-support outcomes, dependencies, and platform assumptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->