### PR TITLE
OSAC-1269: update ClusterVersion PRD and design

### DIFF
--- a/enhancements/OSAC-1269-cluster-version-api/design.md
+++ b/enhancements/OSAC-1269-cluster-version-api/design.md
@@ -36,7 +36,7 @@ Introducing managed versions fixes those gaps. It gives admins a place to manage
 
 ### Non-Goals
 
-- Full upgrade orchestration, progress tracking, rollback, or channel-based upgrade selection (including channel metadata). [User]
+- Full upgrade orchestration, progress tracking, rollback, or channel-based upgrade selection (including channel metadata).
 - Automatically import or synchronize versions from ACM `ClusterImageSet` resources in `v0.2`.
 - Extend this design to VM image management; that remains separate work under `ComputeImage`.
 - Hub-projected ClusterVersion CRD, operator lifecycle watches, or AAP-side version resolution.
@@ -50,11 +50,10 @@ OSAC adds a new platform-global `ClusterVersion` resource in the fulfillment-ser
 - the release image URL (`spec.image`)
 - lifecycle state such as active, deprecated, or obsolete
 - whether it is enabled for new cluster creation and whether it is the system default version
-- an optional list of allowed target versions [User]
 
 The fulfillment-service is the sole owner of this data. At cluster creation time, the server validates the selected version. The cluster controller resolves the release image from the ClusterVersion when building the ClusterOrder — the Cluster object itself stores only the `version_name`, not the release image.
 
-The cluster API stops accepting raw `release_image` input and instead uses `version_name` as the selected version identifier. Basic validated version changes — where the caller explicitly sets a new `version_name` and the change is validated against `allowed_upgrades` — are in scope. [User]
+The cluster API stops accepting raw `release_image` input and instead uses `version_name` as the selected version identifier.
 
 ### Workflow Description
 
@@ -111,8 +110,6 @@ On the catalog-item path, `version_name` comes from the catalog item's field def
 | Referenced version is disabled or obsolete | Reject the request. | `InvalidArgument` |
 | No version can be resolved through input or defaults | Reject the request. | `InvalidArgument` |
 | A referenced version is still in use during deletion | Reject the deletion until references are removed. [PRD: FR-11] | `FailedPrecondition` |
-| `version_name` changed to a version not in `allowed_upgrades`, or target is disabled/obsolete | Reject the update. Same admission checks as cluster creation. [User] | `InvalidArgument` |
-| `allowed_upgrades.version_names` references a non-existent or deleted version on create, or a newly added entry references a non-existent, deleted, disabled, or obsolete version on update | Reject the create or update. | `InvalidArgument` |
 | Two concurrent requests try to set different defaults | Allow one winner and reject the other update. | `AlreadyExists` |
 
 ### API Extensions
@@ -172,18 +169,6 @@ message ClusterVersionSpec {
 
   string version = 6;
   // Stable version identifier (e.g., "4.17.0", "4.17.0-rc.1").
-
-  ClusterVersionAllowedUpgrades allowed_upgrades = 7;
-  // Constrains which versions clusters on this version may upgrade to.
-  // Message absent: no path constraint (target must still be enabled and not obsolete).
-  // Message present with empty version_names: no valid targets — version change is rejected.
-  // Message present with version_names: only listed versions are accepted.
-}
-
-message ClusterVersionAllowedUpgrades {
-  repeated string version_names = 1;
-  // ClusterVersion names (metadata.name). Must reference existing, non-deleted ClusterVersions.
-  // When a target version is deleted, it is automatically removed.
 }
 
 enum ClusterVersionState {
@@ -220,9 +205,6 @@ message ClusterVersionStatus {}
     "state": "DEPRECATED",
     "deprecation": {
       "deprecationTimestamp": "2026-06-15T00:00:00Z"
-    },
-    "allowedUpgrades": {
-      "versionNames": ["4-17-1", "4-18-0"]
     }
   },
   "status": {}
@@ -276,19 +258,11 @@ All state transitions are allowed. [PRD: FR-13] Timestamps are system-managed: s
 - If a default version transitions to `OBSOLETE` or is disabled (`enabled=false`), the server clears `is_default` as part of the same change.
 
 **Lifecycle:**
-- Obsolete or disabled versions cannot be used for new clusters or as version-change targets. `enabled` is admission policy, not lifecycle state — changing it does not affect existing clusters.
+- Obsolete or disabled versions cannot be used for new clusters. `enabled` is admission policy, not lifecycle state — changing it does not affect existing clusters.
 
 **References and delete protection:**
 - Versions referenced by active clusters, templates, or catalog item field definitions cannot be deleted. [PRD: FR-11]
 - `ClusterTemplate` create and update validate `spec_defaults.version_name` in the server layer; database triggers are the race-safety backstop.
-
-**Cluster version-change validation:**
-- When `allowed_upgrades` is set on the source version, cluster updates that change `version_name` are validated against the list. The target version must pass the same admission checks as cluster creation (exists, enabled, not obsolete). When `allowed_upgrades` is not set, any version change is allowed but the target must still pass those checks. [User]
-
-**Upgrade target management:**
-- `allowed_upgrades.version_names` entries must reference existing, non-deleted ClusterVersions. On create, the server validates that all entries are also enabled and non-obsolete. On update, only newly added entries are validated against enabled and non-obsolete. A database trigger enforces the existence constraint as a race-safety backstop for concurrent deletions.
-- When a target version is soft-deleted, it is automatically removed from all other versions' `allowed_upgrades` lists within the same transaction. Disabling or marking a version obsolete does not remove it — the entry stays and becomes available again when the target is re-enabled or returned to a non-obsolete state.
-- If deletion cleanup removes all entries, the empty `allowed_upgrades` message is preserved.
 
 #### Database considerations
 
@@ -312,13 +286,7 @@ All state transitions are allowed. [PRD: FR-13] Timestamps are system-managed: s
 - **Inbound (resource → version):** fires before INSERT or UPDATE (only active rows: `WHEN new.deletion_timestamp = 'epoch'`). On INSERT, or when the reference changes on UPDATE, validates that the referenced ClusterVersion exists, is enabled, and is not obsolete using `SELECT ... FOR SHARE` on the referenced row. Raises SQLSTATE `Z0002` (`ErrReference`). Three source tables, same validation logic:
   - `clusters` and `cluster_templates` — scalar field `data->'spec'->>'version_name'`.
   - `cluster_catalog_items` — loops over `data->'field_definitions'`, filters entries with `path = 'version_name'`, and validates each entry's `default` value.
-- **Inbound (version → version via allowed_upgrades):** fires before INSERT or UPDATE on `cluster_versions` (only active rows). On INSERT, or when `allowed_upgrades` changes on UPDATE, loops over `version_names` and validates each entry against an existing, non-deleted ClusterVersion using `SELECT ... FOR SHARE`. Raises SQLSTATE `Z0002` (`ErrReference`).
-
 Inbound triggers use `FOR SHARE` on the referenced row to serialize against concurrent deletes and lifecycle changes, following the established pattern across all existing reference triggers.
-
-*Server-side cleanup (Go layer):*
-
-- **Upgrade target cleanup:** when a ClusterVersion is soft-deleted, the server removes its `metadata.name` from all other active versions' `allowed_upgrades.version_names` arrays within the same transaction. The cleanup UPDATE increments `version` on each affected row to preserve optimistic concurrency. The private server's Delete method runs this after the DAO operation, sharing the same transaction via [`database.TxFromContext(ctx)`](https://github.com/osac-project/fulfillment-service/blob/e5c4482dbbb9e508f7df912b86f7a5a1e5900607/internal/database/database_context.go#L46).
 
 **Performance.** A JSONB index on `data->'spec'->>'version_name'` in the `clusters` table keeps the outbound trigger's reference scan efficient. The trigger also scans `cluster_templates` and `cluster_catalog_items` field definitions; template and catalog item volume is low enough that separate indexes are not warranted.
 
@@ -413,7 +381,7 @@ Not needed for `v0.2`. A single `spec.image` is sufficient for the current `mult
 
 The test strategy focuses on validating the version model in the fulfillment-service:
 
-- **Unit tests:** version validation, default selection, lifecycle-state handling, image resolution, version-change validation, and template default checks.
+- **Unit tests:** version validation, default selection, lifecycle-state handling, image resolution, and template default checks.
 - **Integration tests:** end-to-end flow from version creation through cluster creation and reconciliation, including delete protection, default fallback, and release-image population on the `ClusterOrder`.
 - **E2E tests:** admin version management plus tenant cluster creation using managed versions.
 

--- a/enhancements/OSAC-1269-cluster-version-api/prd.md
+++ b/enhancements/OSAC-1269-cluster-version-api/prd.md
@@ -20,7 +20,7 @@ A managed version catalog provides that missing abstraction. Users select from a
 
 - Users specify an OpenShift version by number (e.g., "4.17.0") instead of a raw OCI release image URL when creating a cluster.
 - Users receive immediate, descriptive feedback when specifying an invalid, obsolete, or deprecated version — before any provisioning begins.
-- Cloud Provider Admins manage available cluster versions through the CLI and UI console.
+- Cloud Provider Admins manage available cluster versions through the CLI and API.
 - Tenant Users can discover and select from available versions when creating a cluster — in the CLI, UI, and API.
 
 ### 2.2 Non-Goals
@@ -46,7 +46,7 @@ A managed version catalog provides that missing abstraction. Users select from a
 
 - **FR-4:** Users specify a version number (e.g., "4.17.0") when creating a cluster. [Clarify: R1.Q2, R1.Q5, R2.Q1, R2.Q4, R3.Q3, R3.Q4]
 
-- **FR-5:** Templates can specify a default version (e.g., "4.17.0"). [Clarify: R2.Q1]
+- **FR-5:** Templates can specify a default version by ClusterVersion name (e.g., "4-17-0"). [Clarify: R2.Q1]
 
 - **FR-6:** A cluster's version and its current lifecycle state are visible when viewing or listing clusters. If the version is deprecated or obsolete, the state is surfaced so users can identify clusters that need attention.
 
@@ -58,7 +58,7 @@ A managed version catalog provides that missing abstraction. Users select from a
 
 - **FR-8:** The CLI supports catalog management (create, update, delete) and cluster creation with a version option replacing the release image option. [Clarify: R1.Q5, R1.Q7]
 
-- **FR-9:** The UI console supports catalog management for admins and version selection in the cluster creation wizard for users.
+- **FR-9:** The UI console supports version selection in the cluster creation wizard and version lifecycle display (state, deprecation) on cluster views. ClusterVersion management (create, delete, lifecycle state transitions) is CLI/API-only in v0.2 — the interaction model is expected to change when versions become system-populated (OSAC-1415).
 
 - **FR-10:** Catalog items reference version instead of release image in their field definitions, following the existing catalog item pattern. [Clarify: R1.Q5]
 
@@ -78,7 +78,7 @@ A managed version catalog provides that missing abstraction. Users select from a
 
 - **NFR-1:** Admins manage the version catalog using the same patterns they already know from other admin-managed resources — consistent commands, access model, lifecycle states (active/deprecated/obsolete), and visibility rules with no new interaction model to learn. [Clarify: R1.Q6, R3.Q1]
 
-- **NFR-2:** Future additions to the version catalog (e.g., upgrade paths, channel metadata, channel-based selection) must not break existing cluster creation workflows. [Clarify: R2.Q2]
+- **NFR-2:** Future additions to the version catalog (e.g., system-populated entries, upgrade graph integration) must not break existing cluster creation workflows. [Clarify: R2.Q2]
 
 ## 4. Acceptance Criteria
 
@@ -87,7 +87,7 @@ A managed version catalog provides that missing abstraction. Users select from a
 - [ ] Admins can create, update, and delete version catalog entries. Deleting a version referenced by an active cluster or template defaults is rejected with a message identifying the referencing resource.
 - [ ] Admins can transition a version between active, deprecated, and obsolete in any direction, even when referenced by active clusters or templates. Listing versions returns active and deprecated entries by default; obsolete versions are hidden unless explicitly filtered. Deprecation and obsolescence timestamps are recorded automatically on each transition.
 - [ ] At most one version is marked as default at any time — setting a new default clears the previous one. An obsolete version cannot be marked as default. When a user omits the version and template defaults do not supply one, the server uses the default version. Templates can specify a default version, and the server resolves it to a release image.
-- [ ] The CLI supports version catalog management and cluster creation with a version option. Catalog items can reference version in their field definitions. The UI console supports catalog management for admins and version selection in the cluster creation wizard.
+- [ ] The CLI supports ClusterVersion management and cluster creation with a version option. Catalog items can reference version in their field definitions. The UI console supports version selection in the cluster creation wizard and displays version lifecycle state on cluster views.
 
 ## 5. Assumptions
 
@@ -97,7 +97,7 @@ A managed version catalog provides that missing abstraction. Users select from a
 ## 6. Dependencies
 
 - **OSAC-1531 (Default Catalog Items)** — Default version catalog entries should ship alongside default catalog items. Version catalog population is a prerequisite for catalog items that reference version-based clusters.
-- **OSAC-1415 (Cluster Upgrade)** — The version catalog is designed as an extension point. OSAC-1415 is expected to add upgrade capabilities and channel-based version selection. This PRD does not constrain OSAC-1415's design. [Clarify: R2.Q2]
+- **OSAC-1415 (Cluster Upgrade)** — The version catalog is designed as an extension point. OSAC-1415 is expected to add upgrade capabilities, including upgrade graph integration and system-populated version entries. This PRD does not constrain OSAC-1415's design. [Clarify: R2.Q2]
 
 ## 7. Risks
 
@@ -125,7 +125,7 @@ This feature applies to **CaaS** (Cluster as a Service) only. VMaaS has an analo
 
 | Persona | Interaction |
 |---------|-------------|
-| Cloud Provider Admin | Creates version entries by providing version number, release image URL, and lifecycle state. Manages the catalog via CLI, API, and UI. Sets the default version. |
+| Cloud Provider Admin | Creates ClusterVersion entries by providing version number, release image URL, and lifecycle state. Manages ClusterVersions via CLI and API. Sets the default version. |
 | Tenant User | Browses available versions (version number, state — no release image URLs). Selects a version when creating a cluster via CLI, UI wizard, or catalog items. |
 | Cloud Infrastructure Admin | Not affected. |
 | Tenant Admin | Same as Tenant User. May also reference versions when authoring org-specific catalog items. |
@@ -140,7 +140,7 @@ Version resolution occurs during cluster creation: the fulfillment-service valid
 |---------|--------|
 | Fulfillment API (gRPC/REST) | New version catalog resource. Cluster creation uses version instead of release image URL. Template defaults updated. Deletion protection when referenced. |
 | OSAC CRDs | No change. |
-| UI Console | Version catalog management for admins. Version selection in the cluster creation wizard. |
+| UI Console | Version selection in the cluster creation wizard. Version lifecycle display on cluster views. |
 | Catalog Items | Support version selection. |
 
 ### Milestone Scoping


### PR DESCRIPTION
## Summary
- Remove allowed_upgrades, update UI scope, and align with future upgrade graph direction ([OSAC-1415](https://redhat.atlassian.net/browse/OSAC-1415)).

## Test plan
- [ ] Review PRD and design for consistency
- [ ] Verify no leftover allowed_upgrades references

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ClusterVersion management in v0.2 is now available through the CLI and API.
  * The UI continues to support version selection and lifecycle status display.
  * Disabled or obsolete versions are restricted only when creating new clusters.

* **Changes**
  * Removed upgrade-target selection and version-change validation from the v0.2 scope.
  * Updated product requirements and acceptance criteria to reflect the revised workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->