### PR TITLE
OSAC-3254: PRD - Expose NIC MAC Addresses in BareMetalInstance Status

### DIFF
--- a/enhancements/OSAC-3254-expose-baremetalinstance-nic-mac-addresses/prd.md
+++ b/enhancements/OSAC-3254-expose-baremetalinstance-nic-mac-addresses/prd.md
@@ -17,7 +17,7 @@ When BMaaS provisions a BareMetalInstance, it assigns a physical host from the i
 
 ## Out of Scope
 
-- IP addresses — assigned via DHCP at runtime and not a property of the inventory
+- IP addresses — covered by BMaaS networking (OSAC-1437)
 - Full hardware specifications such as CPU, RAM, and disk layout (covered by BareMetalInstanceType)
 - CaaS agent correlation workflow that consumes this data (covered by OSAC-2135)
 
@@ -43,8 +43,8 @@ When BMaaS provisions a BareMetalInstance, it assigns a physical host from the i
 
 ## Provenance
 
-Committed: commit @ prd 0.7.1 - b8b3f86, workspace prd/OSAC-3254 @ 112202d (dirty)
+Committed: commit @ prd 0.7.1 - b8b3f86, workspace prd/OSAC-3254 @ c218f89 (dirty)
 
 > Authoring phases not recorded this session (commit-time snapshot only).
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"112202d (dirty)","source_repo_branch":"prd/OSAC-3254","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["commit","commit"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"c218f89 (dirty)","source_repo_branch":"prd/OSAC-3254","commits_behind_main":0,"commits_ahead_main":2,"main_ref":"main","phases":["commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-3254-expose-baremetalinstance-nic-mac-addresses/prd.md
+++ b/enhancements/OSAC-3254-expose-baremetalinstance-nic-mac-addresses/prd.md
@@ -1,4 +1,4 @@
-# Expose NIC MAC Addresses in BareMetalInstance Status
+# Expose NIC MAC Addresses in BareMetalInstance Details
 
 | Field     | Value                                                       |
 |-----------|-------------------------------------------------------------|
@@ -39,8 +39,8 @@ When BMaaS provisions a BareMetalInstance, it assigns a physical host from the i
 
 ## Provenance
 
-Committed: commit @ prd 0.7.1 - b8b3f86, workspace prd/OSAC-3254 @ 1c351b8 (dirty)
+Committed: commit @ prd 0.7.1 - b8b3f86, workspace prd/OSAC-3254 @ 6e12de2 (dirty)
 
 > Authoring phases not recorded this session (commit-time snapshot only).
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"1c351b8 (dirty)","source_repo_branch":"prd/OSAC-3254","commits_behind_main":0,"commits_ahead_main":3,"main_ref":"main","phases":["commit","commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"6e12de2 (dirty)","source_repo_branch":"prd/OSAC-3254","commits_behind_main":0,"commits_ahead_main":4,"main_ref":"main","phases":["commit","commit","commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-3254-expose-baremetalinstance-nic-mac-addresses/prd.md
+++ b/enhancements/OSAC-3254-expose-baremetalinstance-nic-mac-addresses/prd.md
@@ -12,7 +12,7 @@ When BMaaS provisions a BareMetalInstance, it assigns a physical host from the i
 
 ## In Scope
 
-- MAC addresses of all physical network interfaces of the assigned host, sourced from the inventory backend and exposed in BareMetalInstance status once provisioning completes
+- MAC addresses of all physical network interfaces of the assigned host, available in BareMetalInstance details once provisioning completes
 - Read access to this metadata via the BareMetalInstance API (Get, List), OSAC CLI, and OSAC web console, following existing BMaaS tenant authorization boundaries
 
 ## Out of Scope
@@ -23,13 +23,9 @@ When BMaaS provisions a BareMetalInstance, it assigns a physical host from the i
 
 ## User Stories
 
-### CaaS (internal OSAC service)
-
-- As an OSAC service (CaaS), I want to read the MAC addresses of the physical network interfaces of a provisioned BareMetalInstance so that I can match it to the Assisted Installer agent that registered from that host.
-
 ### Tenant User, Tenant Admin, Cloud Provider Admin, Cloud Infrastructure Admin
 
-- As a {persona}, I want to see the MAC addresses of a BareMetalInstance's physical network interfaces via the CLI and API so that I can identify servers and correlate them across systems.
+- As a Tenant User, Tenant Admin, Cloud Provider Admin, or Cloud Infrastructure Admin, I want to see the MAC addresses of a BareMetalInstance's physical network interfaces via the UI, CLI, and API so that I can identify servers and correlate them across systems.
 
 ## Assumptions
 
@@ -43,8 +39,8 @@ When BMaaS provisions a BareMetalInstance, it assigns a physical host from the i
 
 ## Provenance
 
-Committed: commit @ prd 0.7.1 - b8b3f86, workspace prd/OSAC-3254 @ c218f89 (dirty)
+Committed: commit @ prd 0.7.1 - b8b3f86, workspace prd/OSAC-3254 @ 1c351b8 (dirty)
 
 > Authoring phases not recorded this session (commit-time snapshot only).
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"c218f89 (dirty)","source_repo_branch":"prd/OSAC-3254","commits_behind_main":0,"commits_ahead_main":2,"main_ref":"main","phases":["commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"1c351b8 (dirty)","source_repo_branch":"prd/OSAC-3254","commits_behind_main":0,"commits_ahead_main":3,"main_ref":"main","phases":["commit","commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-3254-expose-baremetalinstance-nic-mac-addresses/prd.md
+++ b/enhancements/OSAC-3254-expose-baremetalinstance-nic-mac-addresses/prd.md
@@ -13,14 +13,13 @@ When BMaaS provisions a BareMetalInstance, it assigns a physical host from the i
 ## In Scope
 
 - MAC addresses of all physical network interfaces of the assigned host, sourced from the inventory backend and exposed in BareMetalInstance status once provisioning completes
-- Read access to this metadata via the BareMetalInstance API (Get, List) and OSAC CLI, following existing BMaaS tenant authorization boundaries
+- Read access to this metadata via the BareMetalInstance API (Get, List), OSAC CLI, and OSAC web console, following existing BMaaS tenant authorization boundaries
 
 ## Out of Scope
 
 - IP addresses — assigned via DHCP at runtime and not a property of the inventory
 - Full hardware specifications such as CPU, RAM, and disk layout (covered by BareMetalInstanceType)
 - CaaS agent correlation workflow that consumes this data (covered by OSAC-2135)
-- UI representation in the OSAC web console
 
 ## User Stories
 
@@ -44,8 +43,8 @@ When BMaaS provisions a BareMetalInstance, it assigns a physical host from the i
 
 ## Provenance
 
-Committed: commit @ prd 0.7.1 - b8b3f86, workspace prd/OSAC-3254 @ e49bc0c
+Committed: commit @ prd 0.7.1 - b8b3f86, workspace prd/OSAC-3254 @ 112202d (dirty)
 
 > Authoring phases not recorded this session (commit-time snapshot only).
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"e49bc0c","source_repo_branch":"prd/OSAC-3254","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["commit"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"112202d (dirty)","source_repo_branch":"prd/OSAC-3254","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["commit","commit"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-3254-expose-baremetalinstance-nic-mac-addresses/prd.md
+++ b/enhancements/OSAC-3254-expose-baremetalinstance-nic-mac-addresses/prd.md
@@ -8,7 +8,7 @@
 
 ## Problem Statement
 
-When BMaaS provisions a BareMetalInstance, it assigns a physical host from the inventory. The MAC addresses of that host's network interfaces are not surfaced in the BareMetalInstance status. This blocks Cluster as a Service (CaaS), which provisions bare metal hosts on demand and then waits for an Assisted Installer agent to register from each host. Agents register using the host's MAC address as an identifier, but CaaS has no programmatic way to correlate an agent with the BareMetalInstance that triggered its provisioning. Without this correlation, CaaS cannot automate worker node registration and requires manual intervention per host.
+When BMaaS provisions a BareMetalInstance, it assigns a physical host from the inventory. The MAC addresses of that host's network interfaces are not surfaced in the BareMetalInstance status. This blocks Cluster as a Service (CaaS), which provisions bare-metal hosts on demand and then waits for an Assisted Installer agent to register from each host. Agents register using the host's MAC address as an identifier, but CaaS has no programmatic way to correlate an agent with the BareMetalInstance that triggered its provisioning. Without this correlation, CaaS cannot automate worker node registration and requires manual intervention per host.
 
 ## In Scope
 
@@ -39,8 +39,8 @@ When BMaaS provisions a BareMetalInstance, it assigns a physical host from the i
 
 ## Provenance
 
-Committed: commit @ prd 0.7.1 - b8b3f86, workspace prd/OSAC-3254 @ 6e12de2 (dirty)
+Committed: commit @ prd 0.7.1 - b8b3f86, workspace prd/OSAC-3254 @ b99c819 (dirty)
 
 > Authoring phases not recorded this session (commit-time snapshot only).
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"6e12de2 (dirty)","source_repo_branch":"prd/OSAC-3254","commits_behind_main":0,"commits_ahead_main":4,"main_ref":"main","phases":["commit","commit","commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"b99c819 (dirty)","source_repo_branch":"prd/OSAC-3254","commits_behind_main":0,"commits_ahead_main":5,"main_ref":"main","phases":["commit","commit","commit","commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-3254-expose-baremetalinstance-nic-mac-addresses/prd.md
+++ b/enhancements/OSAC-3254-expose-baremetalinstance-nic-mac-addresses/prd.md
@@ -1,0 +1,51 @@
+# Expose NIC MAC Addresses in BareMetalInstance Status
+
+| Field     | Value                                                       |
+|-----------|-------------------------------------------------------------|
+| Author(s) | Adrien Gentil                                               |
+| Jira      | [OSAC-3254](https://redhat.atlassian.net/browse/OSAC-3254) |
+| Date      | 2026-08-05                                                  |
+
+## Problem Statement
+
+When BMaaS provisions a BareMetalInstance, it assigns a physical host from the inventory. The MAC addresses of that host's network interfaces are not surfaced in the BareMetalInstance status. This blocks Cluster as a Service (CaaS), which provisions bare metal hosts on demand and then waits for an Assisted Installer agent to register from each host. Agents register using the host's MAC address as an identifier, but CaaS has no programmatic way to correlate an agent with the BareMetalInstance that triggered its provisioning. Without this correlation, CaaS cannot automate worker node registration and requires manual intervention per host.
+
+## In Scope
+
+- MAC addresses of all physical network interfaces of the assigned host, sourced from the inventory backend and exposed in BareMetalInstance status once provisioning completes
+- Read access to this metadata via the BareMetalInstance API (Get, List) and OSAC CLI, following existing BMaaS tenant authorization boundaries
+
+## Out of Scope
+
+- IP addresses — assigned via DHCP at runtime and not a property of the inventory
+- Full hardware specifications such as CPU, RAM, and disk layout (covered by BareMetalInstanceType)
+- CaaS agent correlation workflow that consumes this data (covered by OSAC-2135)
+- UI representation in the OSAC web console
+
+## User Stories
+
+### CaaS (internal OSAC service)
+
+- As an OSAC service (CaaS), I want to read the MAC addresses of the physical network interfaces of a provisioned BareMetalInstance so that I can match it to the Assisted Installer agent that registered from that host.
+
+### Tenant User, Tenant Admin, Cloud Provider Admin, Cloud Infrastructure Admin
+
+- As a {persona}, I want to see the MAC addresses of a BareMetalInstance's physical network interfaces via the CLI and API so that I can identify servers and correlate them across systems.
+
+## Assumptions
+
+- The inventory backend provides the MAC addresses of all physical NICs for every host it assigns to a BareMetalInstance. MAC addresses are a stable hardware property and do not change for the lifetime of a BareMetalInstance.
+
+## Dependencies
+
+- **Bare Metal Inventory Service:** Must provide the MAC addresses of all physical NICs for each host at the time that host is assigned to a BareMetalInstance.
+
+---
+
+## Provenance
+
+Committed: commit @ prd 0.7.1 - b8b3f86, workspace prd/OSAC-3254 @ e49bc0c
+
+> Authoring phases not recorded this session (commit-time snapshot only).
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"e49bc0c","source_repo_branch":"prd/OSAC-3254","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["commit"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->


### PR DESCRIPTION
## PRD: Expose NIC MAC Addresses in BareMetalInstance Status

**Jira:** [OSAC-3254](https://redhat.atlassian.net/browse/OSAC-3254)

### Summary

This PRD scopes the requirement to expose the MAC addresses of all physical network interfaces of a provisioned BareMetalInstance in its status field. The primary consumer is CaaS, which needs MAC addresses to correlate a BareMetalInstance with the Assisted Installer agent that registers from the provisioned host. All OSAC personas also benefit from the hardware identification capability via API and CLI.

### Requesting Review On

- Requirements completeness and accuracy
- Scope (goals and non-goals)
- Whether all relevant personas are covered
- Open questions that need resolution

### How to Review

- Comment inline on specific sections
- Approve when the PRD accurately reflects the agreed requirements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added product requirements for exposing physical NIC MAC addresses for assigned BareMetalInstance hosts through the API, CLI, and web console.
  * Documented provisioning correlation use cases, scope, assumptions, exclusions, service dependencies, and data provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->