### PR TITLE
OSAC-2135: Design — CaaS Bare-Metal Worker Node Provisioning

### DIFF
--- a/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
+++ b/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
@@ -1,0 +1,535 @@
+---
+title: caas-bare-metal-worker-provisioning
+authors:
+  - rpiccoli@redhat.com
+creation-date: 2026-08-06
+last-updated: 2026-08-07
+tracking-link:
+  - https://redhat.atlassian.net/browse/OSAC-2135
+prd:
+  - "prd.md"
+see-also:
+  - "/enhancements/OSAC-2540-disk-image"
+  - "/enhancements/OSAC-1201-baremetal-instance-types"
+replaces:
+  - N/A
+superseded-by:
+  - N/A
+---
+
+# CaaS Bare-Metal Worker Node Provisioning
+
+## Summary
+
+This design adds on-demand bare-metal worker node provisioning to CaaS by having the osac-operator ClusterOrder controller create BareMetalInstances via the fulfillment-service private gRPC API. Each instance references a pre-registered RHCOS DiskImage and carries cluster-specific discovery ignition as `user_data`, causing the host to register as an assisted-service Agent and join the HyperShift-managed cluster as a worker node. The existing BareMetalPool-based static pre-boot pool is removed. See [PRD](prd.md) for detailed requirements.
+
+## Motivation
+
+CaaS currently provisions bare-metal worker nodes through a static pre-boot pool: a cron job maintains hosts running the Assisted Installer ISO via BareMetalPool resources. This wastes capacity on idle hosts, is difficult to right-size, and couples cluster provisioning to a fragile pool management process. When the pool is exhausted, cluster scale-up fails silently until an administrator intervenes.
+
+The new approach eliminates the pool by provisioning workers on-demand. When a ClusterOrder specifies bare-metal resource classes, the controller creates individual BareMetalInstances through the BMaaS private API, each configured with a cluster-specific discovery ignition. This gives CaaS per-instance control over image and boot configuration while keeping all infrastructure details hidden from tenants. The PoC (OSAC-2817) validated this flow end-to-end: BMI provisioning took approximately 6 minutes, the agent registered successfully, and the worker joined the HyperShift cluster.
+
+### Goals
+
+- Reuse the existing ClusterOrder controller reconciliation pattern and the private gRPC API for BMI lifecycle management.
+- Keep all CaaS-managed bare-metal infrastructure (BMIs, InfraEnvs, Agents) invisible to tenant-facing APIs and UIs.
+- Support both initial provisioning and manual scale-up/scale-down through the same controller logic.
+- Ensure host cleanup on scale-down and cluster deletion flows through BMaaS's existing deprovision pipeline (disk wipe, network reset).
+- Remove the BareMetalPool-based static pre-boot pool workflow entirely — no coexistence period.
+- Require no changes to the tenant-facing Cluster API or CLI experience.
+
+### Non-Goals
+
+- Autoscaling based on workload utilization (deferred to a future CaaS autoscaling feature).
+- VM-based worker nodes (deferred to VMaaS integration).
+- Static IP or NMStateConfig support for worker nodes (deferred; not validated by the PoC).
+- Network boot acceleration or caching strategies `[Jira: OSAC-2134]`.
+
+## Proposal
+
+The ClusterOrder controller in osac-operator gains a new reconciliation phase for bare-metal worker management. When a ClusterOrder's `nodeRequests` reference bare-metal resource classes, the controller:
+
+1. Creates a cluster-specific `InfraEnv` CR on the hub cluster to generate discovery ignition.
+2. Creates `BareMetalInstance` objects via the fulfillment-service private API, passing the RHCOS qcow2 image URL and the InfraEnv's discovery ignition as `user_data`.
+3. Correlates registered Agents to BMIs via MAC address and labels them for NodePool selection.
+
+No new CRDs are introduced. The design extends the ClusterOrder CRD status with a `workers` field to track CaaS-managed worker resources. BareMetalInstances created by CaaS are hidden from tenant APIs via a well-known metadata label.
+
+**Dependencies (unresolved — block implementation):**
+
+| Dependency | Jira | Impact if not delivered |
+|-----------|------|----------------------|
+| MAC address in BareMetalInstance status | [OSAC-2308](https://redhat.atlassian.net/browse/OSAC-2308), [OSAC-3254](https://redhat.atlassian.net/browse/OSAC-3254) | Agent-to-BMI correlation impossible; entire feature blocked |
+| DiskImage resource + BMI DiskImage integration | [OSAC-2540](https://redhat.atlassian.net/browse/OSAC-2540), [OSAC-1270](https://redhat.atlassian.net/browse/OSAC-1270) | Controller cannot resolve RHCOS boot image; BMI creation blocked |
+
+The existing BareMetalPool-based static pre-boot pool is removed as part of this work. The `cluster_infra` AAP step that creates BareMetalPool CRs and the scheduled `osac-import-agents` AAP job that discovers and imports hosts are no longer used by CaaS. Any remaining BareMetalPool resources are drained and cleaned up during rollout. The BareMetalPool CRD itself is retained (it serves BMaaS standalone use cases) but CaaS no longer creates or references BareMetalPool resources.
+
+### Workflow Description
+
+**Actors:** Cloud Infrastructure Admin (registers RHCOS DiskImages per OCP version), Tenant User (creates/scales clusters), osac-operator controller (orchestrates), fulfillment-service (BMI lifecycle), assisted-service (agent discovery), HyperShift (cluster management).
+
+#### Provisioning Flow
+
+Starting state: a Tenant User creates a Cluster with `node_sets` referencing a bare-metal resource class (e.g., `bare-metal-standard`). The fulfillment-service Cluster controller creates a ClusterOrder CR on the hub cluster.
+
+```mermaid
+sequenceDiagram
+    participant T as Tenant User
+    participant FS as fulfillment-service
+    participant CO as ClusterOrder Controller
+    participant AAP as AAP Provisioning
+    participant BMaaS as BMaaS (Private API)
+    participant AS as assisted-service
+    participant HCP as HyperShift
+
+    T->>FS: Create Cluster (node_sets with BM resource class)
+    FS->>CO: Create ClusterOrder CR
+
+    CO->>AAP: Trigger cluster provisioning job
+    AAP->>HCP: Create HostedCluster + NodePool
+    HCP-->>CO: ClusterDeployment exists
+
+    CO->>CO: Create InfraEnv CR (refs ClusterDeployment)
+    AS-->>CO: InfraEnv ready (discovery ignition available)
+
+    loop For each requested bare-metal worker
+        CO->>BMaaS: Create BareMetalInstance (qcow2 + ignition)
+        BMaaS-->>CO: BMI provisioned, MAC in status
+    end
+
+    loop Agent registration
+        AS-->>CO: Agent registered (MAC in inventory)
+        CO->>CO: Correlate Agent to BMI via MAC
+        CO->>AS: Label Agent for NodePool
+    end
+
+    HCP-->>CO: Workers joined, NodePool scaled
+    CO->>FS: Signal Cluster (state=Ready)
+```
+
+The diagram shows the end-to-end provisioning flow. The controller waits for each phase to complete before proceeding: AAP provisions the HostedCluster, the InfraEnv generates ignition, BMIs provision hosts, and agents register and join the cluster. The controller updates ClusterOrder status conditions at each phase transition.
+
+**Step-by-step:**
+
+1. The ClusterOrder controller detects `nodeRequests` with bare-metal resource classes by checking the resource class against BareMetalInstanceType definitions.
+2. After AAP creates the HostedCluster and the ClusterDeployment CR exists, the controller creates an `InfraEnv` CR in the cluster's namespace. The InfraEnv references the ClusterDeployment, the pull secret, and the SSH public key from the ClusterOrder spec.
+3. The controller polls the InfraEnv status until `status.bootArtifacts.discoveryIgnitionURL` is populated, then fetches the discovery ignition content from that URL.
+4. For each bare-metal worker requested, the controller calls `BareMetalInstances.Create` on the private API with: `spec.catalog_item` resolved from the resource class, `spec.image` set to the resolved RHCOS DiskImage ID (see RHCOS DiskImage Resolution), `spec.user_data` set to the discovery ignition, `spec.network_attachments` from the ClusterOrder's network attachment configuration, and `metadata.labels["osac.openshift.io/managed-by"] = "caas"`.
+5. The controller updates ClusterOrder status with the BMI IDs in `workers[]`.
+6. BMaaS allocates a host, writes the qcow2 to disk via Ironic, and boots with the discovery ignition. The host registers as an Agent with assisted-service.
+7. The controller watches Agent CRs in the cluster namespace. When a new Agent appears, the controller matches its inventory MAC address against BMI status MAC addresses (`status.host.mac_address`, dependency OSAC-2308/OSAC-3254).
+8. Once correlated, the controller sets the Agent's `clusterDeploymentName` to the cluster's ClusterDeployment and applies the `agentBareMetal` role label so the NodePool's `agentLabelSelector` selects it. This requires the osac-operator to modify `agent-install.openshift.io/v1beta1` Agent resources — a cross-API-group coupling. This is unavoidable: the assisted-service Agent API does not provide an auto-bind mechanism for late-binding agents, so an external controller must set `clusterDeploymentName` and apply labels. The osac-operator's RBAC must include `patch` on `agents` in the `agent-install.openshift.io` API group.
+9. HyperShift installs the Agent as a worker node. The controller monitors NodePool `.status.replicas` to confirm convergence.
+
+#### Scale-Up
+
+A Tenant User increases `node_sets[].size` for a bare-metal node set. The fulfillment-service updates the Cluster object, the Cluster controller updates the ClusterOrder's `nodeRequests`, and the controller detects the delta between desired and current worker count.
+
+**Step-by-step:**
+
+1. The controller computes `desired - current` where `current` counts workers in any phase except `Deleting`. Workers in `Failed` phase count toward `current` — they are not automatically retried.
+2. The controller re-reads the InfraEnv's `status.bootArtifacts.discoveryIgnitionURL` to fetch fresh ignition. The InfraEnv persists from initial provisioning; if it was deleted (e.g., manual cleanup), the `ensureInfraEnv` phase recreates it.
+3. The controller resolves the RHCOS DiskImage from the NodePool's current release image (not the ClusterOrder's original). This ensures workers added after a cluster upgrade use a compatible boot image.
+4. For each new worker, the controller follows provisioning steps 4-9 from the initial flow.
+5. Partial success is reported: if 3 of 5 new workers succeed and 2 fail, the ClusterOrder status shows 3 additional `Ready` workers and 2 `Failed`. The tenant sees the cluster with the successfully added workers; the failed slots are visible via ClusterOrder conditions and events.
+
+#### Scale-Down
+
+```mermaid
+sequenceDiagram
+    participant T as Tenant User
+    participant CO as ClusterOrder Controller
+    participant HCP as HyperShift / CAPI
+    participant AS as assisted-service
+    participant BMaaS as BMaaS (Private API)
+
+    T->>CO: Decrease node count
+    CO->>HCP: Decrease NodePool replicas
+
+    HCP->>HCP: CAPI selects Machine, drains node
+    HCP->>AS: AgentMachine unbinds Agent
+    AS-->>CO: Agent enters *-unbound state
+
+    CO->>CO: Match unbound Agent to BMI via MAC
+    CO->>BMaaS: Delete BareMetalInstance
+    BMaaS->>BMaaS: Host cleanup (disk wipe, network reset)
+    CO->>CO: Remove BMI from status.workers
+```
+
+This diagram shows the scale-down flow. CAPI handles node drain and agent unbinding automatically. The controller reacts to the agent reaching an unbound state and then cleans up the BMI.
+
+**Step-by-step:**
+
+1. The controller computes the excess worker count (current minus desired).
+2. The controller decreases NodePool `.spec.replicas` by the excess count.
+3. CAPI's MachineDeployment controller (used by HyperShift's default Replace upgrade type) manages MachineSets, which select Machines for deletion. CaaS does not control the selection order.
+4. CAPI drains each selected node, then the AgentMachine controller unbinds the Agent (clears `ClusterDeploymentName`, removes labels and ignition refs).
+5. Because BMH resources exist, the Agent enters `UnbindingPendingUserAction`. The BMH agent controller triggers Ironic deprovision (clears `bmh.Spec.Image`, removes the `detached` annotation).
+6. The controller watches for Agents transitioning to any `*-unbound` terminal state (`discovering-unbound`, `known-unbound`, `disconnected-unbound`, `insufficient-unbound`, `disabled-unbound`).
+7. The controller matches the unbound Agent back to a BMI via MAC address.
+8. The controller calls `BareMetalInstances.Delete` on the private API. BMaaS handles full host cleanup (disk wipe, network reset) before returning the host to inventory. CaaS does not independently verify cleanup completion — this is a trust boundary between CaaS and BMaaS. If BMaaS cleanup fails, the host must not be reallocated; this guarantee is BMaaS's responsibility.
+9. The controller removes the entry from `status.workers`.
+
+#### Cluster Deletion
+
+On ClusterOrder deletion, the controller runs the scale-down flow for all remaining workers (steps 2-9) before allowing the AAP deprovision job to destroy the HostedCluster. The InfraEnv CR is cleaned up automatically by Kubernetes garbage collection via its ownerReference to the ClusterOrder — no explicit deletion is needed. The ClusterOrder's finalizer prevents premature deletion, ensuring all BMIs are cleaned up before the ClusterOrder (and its owned InfraEnv) are removed.
+
+### API Extensions
+
+**Modified CRDs:**
+
+- `ClusterOrder` (osac-operator): new `workers` status field for tracking CaaS-managed worker resources. No spec changes — `nodeRequests[].resourceClass` already carries the information needed to identify bare-metal node sets.
+
+**New CRs created at runtime (not new CRD definitions):**
+
+- `InfraEnv` (agent-install.openshift.io/v1beta1): one per cluster, created by the controller in the cluster's namespace. Owned by the ClusterOrder via an owner reference for garbage collection.
+
+**Modified behavior of existing resources:**
+
+- `BareMetalInstance` (fulfillment-service): CaaS-created BMIs carry `metadata.labels["osac.openshift.io/managed-by"] = "caas"`. The public `BareMetalInstances.List` API adds an implicit filter excluding BMIs with this label, so they do not appear in tenant listings. The private API returns all BMIs regardless. This change affects the fulfillment-service public server (`baremetal_instances_server.go`), which must inject the exclusion filter.
+
+**Operational impact:** If the osac-operator is down, no new bare-metal workers are provisioned and scale-up/scale-down operations stall. Existing workers continue running — HyperShift manages the cluster independently. On restart, the controller reconciles current state and resumes any pending operations.
+
+## UX Alignment
+
+This section does not apply. No UI changes are required — CaaS-managed BMIs are hidden from tenant-facing views.
+
+### Implementation Details/Notes/Constraints
+
+#### ClusterOrder CRD Status Extensions
+
+```go
+type ClusterOrderStatus struct {
+    // ... existing fields ...
+
+    // Workers references CaaS-managed worker resources (BareMetalInstance or ComputeInstance).
+    // +kubebuilder:validation:Optional
+    Workers []corev1.ObjectReference `json:"workers,omitempty"`
+}
+```
+
+Each `corev1.ObjectReference` entry contains `Kind` (e.g., `BareMetalInstance` or `ComputeInstance`), `Namespace`, `Name`, and `APIVersion`, identifying the worker CR on the hub cluster. The controller resolves the fulfillment-service ID from the CR's `osac.openshift.io/baremetalinstance-uuid` label (or the equivalent ComputeInstance label) when it needs to call the private API. Worker lifecycle state (agent correlation, phase tracking) is managed in-memory by the controller and rebuilt from live CR and Agent state on restart — it is not persisted in the ClusterOrder status.
+
+Example: a 5-worker cluster where 3 workers are ready and 2 failed:
+
+```yaml
+status:
+  phase: Progressing
+  conditions:
+    - type: WorkersFailed
+      status: "True"
+      reason: ProvisioningFailed
+      message: "2 of 5 bare-metal workers failed: bm-cluster-a-worker-2 (AgentRegistrationTimeout), bm-cluster-a-worker-4 (BMI provisioning error)"
+    - type: InfraEnvReady
+      status: "True"
+  workers:
+    - kind: BareMetalInstance
+      namespace: osac-orders
+      name: bm-cluster-a-worker-0
+      apiVersion: osac.openshift.io/v1alpha1
+    - kind: BareMetalInstance
+      namespace: osac-orders
+      name: bm-cluster-a-worker-1
+      apiVersion: osac.openshift.io/v1alpha1
+    - kind: BareMetalInstance
+      namespace: osac-orders
+      name: bm-cluster-a-worker-2
+      apiVersion: osac.openshift.io/v1alpha1
+    - kind: BareMetalInstance
+      namespace: osac-orders
+      name: bm-cluster-a-worker-3
+      apiVersion: osac.openshift.io/v1alpha1
+    - kind: BareMetalInstance
+      namespace: osac-orders
+      name: bm-cluster-a-worker-4
+      apiVersion: osac.openshift.io/v1alpha1
+```
+
+The `workers[]` list always contains all worker references regardless of their individual state. The `WorkersFailed` condition provides the summary — which workers failed and why. The ClusterOrder remains in `Progressing` phase (not `Failed`) because 3 workers are operational. The operator inspects individual BMIs via the private API to diagnose failures.
+
+The controller tracks worker lifecycle internally through phases: `Provisioning` → `WaitingForAgent` → `Binding` → `Ready` (and `Unbinding` → `Deleting` for scale-down). `Failed` is reachable from any active phase and is terminal — the controller does not automatically retry failed workers. Failures are reported via ClusterOrder conditions and Kubernetes events.
+
+#### InfraEnv Creation
+
+The controller creates one InfraEnv per ClusterOrder. The InfraEnv spec:
+
+```yaml
+apiVersion: agent-install.openshift.io/v1beta1
+kind: InfraEnv
+metadata:
+  name: <cluster-order-name>-infraenv
+  namespace: <cluster-namespace>
+  ownerReferences:
+    - apiVersion: osac.openshift.io/v1alpha1
+      kind: ClusterOrder
+      name: <cluster-order-name>
+spec:
+  clusterRef:
+    name: <cluster-deployment-name>
+    namespace: <cluster-namespace>
+  pullSecretRef:
+    name: <pull-secret-name>
+  sshAuthorizedKey: <from ClusterOrder spec>
+```
+
+One InfraEnv per cluster prevents cross-tenant agent races. If two clusters shared an InfraEnv, an agent from cluster A could be mistakenly assigned to cluster B during concurrent scale operations.
+
+#### RHCOS DiskImage Resolution
+
+The controller resolves the RHCOS boot image via a pre-registered DiskImage resource (dependency: OSAC-2540 DiskImage, OSAC-1270 BMI DiskImage integration). The Cloud Infrastructure Admin registers RHCOS qcow2 images as provider-global DiskImages with guest OS family (`linux`) and architecture (`amd64`), and applies a CaaS-specific label `osac.openshift.io/ocp-version: "4.22"` to enable version-based lookup. This label is a CaaS convention — the DiskImage resource itself (OSAC-2540) has no OCP version field, since version-based lookup is a CaaS-specific need. If richer metadata is needed (e.g., multiple image variants per version, automated registration), a dedicated `ClusterDiskImage` resource could wrap DiskImage with CaaS-specific fields. Labeling is sufficient for this design.
+
+The controller reads `NodePool.spec.release.image`, extracts the OCP major.minor version (e.g., `4.22` from `ocp-release:4.22.5-x86_64`), and resolves the matching DiskImage by querying for provider-global DiskImages with the `osac.openshift.io/ocp-version` label matching the target version and the correct architecture.
+
+Using the NodePool's current release image rather than the ClusterOrder's original ensures scale-up works correctly after cluster upgrades. A cluster created at OCP 4.18 and later upgraded to 4.22 would use a 4.22 boot image for new workers. Using the original 4.18 image could cause agent compatibility issues — the assisted-installer agent in an older RHCOS may not be compatible with a newer cluster's API or ignition format.
+
+The boot image is ephemeral — it exists only to run the discovery agent. The assisted-installer writes the correct RHCOS version (pinned to the release image) to disk during installation. Any Z stream within the same minor version is acceptable for the boot image.
+
+If no matching DiskImage is found for the target OCP version, the controller sets the ClusterOrder condition `RHCOSImageNotFound` and does not proceed with BMI creation. The Cloud Infrastructure Admin must register the missing DiskImage before provisioning can continue.
+
+If the underlying OCI artifact referenced by the DiskImage is unreachable or the image download fails at Ironic, the BMI enters `Failed` phase. The failure is reported via ClusterOrder conditions.
+
+#### BMI Creation via Private API
+
+For each worker, the controller calls `BareMetalInstances.Create` on the private API. The existing `BareMetalInstanceSpec` proto already has the required fields. The only proto change is a new `source_type` value (`"disk_image"`) on `BareMetalInstanceImage`:
+
+```protobuf
+// Existing fields in osac.private.v1.BareMetalInstanceSpec used by CaaS
+// (field numbers omitted for clarity — see baremetal_instance_type.proto for canonical numbering):
+message BareMetalInstanceSpec {
+  string catalog_item = ...;                                // resolved from nodeRequest.resourceClass → BareMetalInstanceCatalogItem
+  optional BareMetalInstanceImage image = ...;              // RHCOS DiskImage reference (see DiskImage Resolution)
+  optional string user_data = ...;                          // discovery ignition fetched from InfraEnv (max 64KB)
+  repeated BareMetalNetworkAttachment network_attachments = ...;
+  // ... other existing fields (ssh_public_key, run_strategy, template_parameters, etc.) omitted
+}
+
+message BareMetalInstanceImage {
+  string source_type = ...;  // existing value "registry"; this design proposes adding "disk_image" for DiskImage references
+  string source_ref = ...;   // DiskImage ID resolved for target OCP version + architecture
+}
+```
+
+The controller sets the following metadata fields on the created BMI:
+
+- `name`: `"<cluster-order-name>-worker-<index>"`
+- `labels["osac.openshift.io/managed-by"]`: `"caas"` — visibility filter key
+- `labels["osac.openshift.io/cluster-order"]`: `"<order-id>"` — links BMI to parent ClusterOrder
+- `annotations["osac.openshift.io/owner-reference"]`: `"ClusterOrder/<order-id>"`
+
+#### Visibility Filtering
+
+The public `BareMetalInstances.List` implementation adds an implicit CEL filter clause: `!has(this.metadata.labels["osac.openshift.io/managed-by"])` (or equivalent SQL-level filtering). This ensures CaaS-managed BMIs never appear in tenant API responses. Cloud Provider Admins access CaaS BMIs via the private API or by explicitly filtering with `this.metadata.labels["osac.openshift.io/managed-by"] == "caas"`.
+
+The `BareMetalInstances.Get`, `Update`, and `Delete` methods on the public API also reject requests for CaaS-managed BMIs with `NotFound`, preventing tenants from interacting with infrastructure they should not see. The `NotFound` response is indistinguishable from a genuinely non-existent BMI — a tenant cannot determine whether a given ID refers to a CaaS-managed instance or simply does not exist, preventing information disclosure about hidden infrastructure.
+
+Cloud Provider Admins who need to debug CaaS-managed workers (ssh, console, restart — per PRD user story) use the private API, which returns all BMIs regardless of the `managed-by` label.
+
+The public API rejects `Create` and `Update` requests that set `osac.openshift.io/managed-by` to a reserved value (`caas`). This prevents tenants from hiding their own resources by self-applying the label, which would break audit trail integrity.
+
+#### MAC Address Correlation
+
+Agent-to-BMI matching uses MAC addresses. When a BMI reaches `Running` state, its status includes the allocated host's MAC address (exact field path TBD — depends on OSAC-2308/OSAC-3254, which add inventory metadata to BareMetalInstance status; the field does not exist in the current proto). When an Agent registers, its inventory includes NIC MAC addresses at `status.inventory.interfaces[].macAddress`. The controller matches by finding the Agent whose inventory contains a MAC matching a BMI's status MAC.
+
+The controller maintains an in-memory index of pending (uncorrelated) BMIs and their MACs. On each Agent watch event, it checks for a match. If no match is found within a configurable timeout (default: 30 minutes), the controller sets the worker phase to `Failed` with reason `AgentRegistrationTimeout`.
+
+#### Minimum MCE Version
+
+The MGMT-24903 fix (persistent-boot day-2 installs) is merged to assisted-service master ([PR #10717](https://github.com/openshift/assisted-service/pull/10717), 2026-07-29) and assisted-installer-agent master ([PR #1568](https://github.com/openshift/assisted-installer-agent/pull/1568), 2026-07-30). The fix is not yet in a tagged release (post-v2.55.0). The design requires a MCE version shipping these commits. Without them, workers fail to install because `osImageURL` is stripped from the ignition config. The controller does not implement a workaround — the deployment prerequisite documentation must specify the minimum MCE version.
+
+#### Controller Reconciliation Structure
+
+The bare-metal worker management integrates into the existing ClusterOrder controller as a new reconciliation phase, invoked after the AAP provisioning job creates the HostedCluster:
+
+1. **ensureInfraEnv** — list InfraEnvs owned by this ClusterOrder (via ownerReference); create one if none exists; wait for ignition readiness.
+2. **reconcileWorkers** — compare desired count (from `nodeRequests`) with current `workers` count. Create or delete BMIs as needed.
+3. **correlateAgents** — watch Agents, match to BMIs via MAC, label for NodePool.
+4. **reconcileNodePoolReplicas** — set NodePool replicas to match the number of correlated agents.
+
+Each phase is idempotent. The controller re-enters from the top on each reconciliation cycle and progresses through completed phases without repeating side effects (BMI creation is guarded by checking `status.workers` for existing entries).
+
+All four phases are handled within the ClusterOrder controller rather than split across separate controllers because they share sequential dependencies and ClusterOrder status state. The InfraEnv must exist before BMIs can be created, BMIs must be provisioned before agents can be correlated, and agents must be correlated before NodePool replicas can be set. Splitting these into independent controllers would require coordination mechanisms (shared status fields, cross-controller watches) that add complexity without benefit — the ClusterOrder is the single natural owner of the full bare-metal worker lifecycle.
+
+### Security Considerations
+
+CaaS-managed BMIs are created in the tenant's context via the private API. The private API bypasses tenant-scoped OPA policies because it operates with system-level credentials. The BMIs carry the tenant's `metadata.tenant` field for attribution but are not visible to the tenant through the public API (label-based filtering).
+
+The discovery ignition passed as `user_data` contains the InfraEnv's pull secret and cluster endpoint information. The `user_data` field is immutable (enforced by the proto `IMMUTABLE` field behavior annotation). The ignition is scoped to a single cluster's InfraEnv — it cannot be used to register agents against a different cluster.
+
+No changes to authentication or authorization flows are required. The existing OPA policies enforce tenant isolation for all public API access. The osac-operator authenticates to the private API using a token file mounted from a Kubernetes Secret (`OSAC_FULFILLMENT_TOKEN_FILE`), following the same pattern used by the existing feedback controllers for Signal RPCs.
+
+Tenants interact only through the fulfillment-service API. They do not have K8s API access to the hub cluster — ClusterOrder, InfraEnv, and Agent CRs are not tenant-readable. The `Workers` references in ClusterOrder status are visible only to platform operators with hub cluster access.
+
+The `user_data` field (which carries discovery ignition containing pull secrets) is not encrypted at application level in PostgreSQL. This is a platform-wide gap affecting all resources with `user_data`, not specific to CaaS. Infrastructure-level encryption (LUKS on PVs) is expected but not enforced by the fulfillment-service.
+
+The private API token (`OSAC_FULFILLMENT_TOKEN_FILE`) authenticates as `service-account-osac-controller`, an admin service account with unrestricted access to all API methods across all tenants. This is an existing platform-wide credential used by all osac-operator controllers (feedback, compute instance, networking). This design does not widen its scope — it adds BMI Create/Delete to a token that already has full admin access.
+
+### Failure Handling and Recovery
+
+| Failure Mode | What Happens | Recovery | Tenant Observes |
+|---|---|---|---|
+| InfraEnv creation fails | Controller retries on next reconciliation cycle (controller-runtime requeue) | Automatic retry with exponential backoff | ClusterOrder stuck in `Progressing` with condition `InfraEnvNotReady` |
+| InfraEnv ignition not generated | Controller polls InfraEnv status with 30s requeue | Automatic; investigate assisted-service if persistent | Same as above |
+| BMI creation fails (private API error) | Worker phase set to `Failed` | No automatic retry. Failure reported via ClusterOrder condition `WorkersFailed` | ClusterOrder condition `WorkersFailed` with message |
+| BMI provisioning fails (host allocation or Ironic error) | BMI enters `Failed` phase, worker phase set to `Failed` | No automatic retry. Failure reported via ClusterOrder condition `WorkersFailed` and event | ClusterOrder shows degraded worker count |
+| Agent does not register within timeout | Worker phase set to `Failed`, reason `AgentRegistrationTimeout` | No automatic retry. Operator investigates (check InfraEnv, image URL, BMI status) | ClusterOrder condition indicates degraded workers |
+| MAC correlation finds no match | Agent remains uncorrelated | Controller logs a warning and continues watching. If all BMIs are correlated and extra agents exist, they are ignored | No direct tenant impact |
+| Agent binding to NodePool fails | Agent not installed as worker | assisted-service reports failure in Agent conditions; controller reflects in worker phase | ClusterOrder shows degraded worker count |
+| Scale-down: Agent unbinding times out | Agent stuck in `unbinding-pending-user-action` longer than 30 minutes | Controller logs warning, sets worker phase to `Failed`. Manual intervention required to investigate Ironic deprovision failure | Node count mismatch visible in ClusterOrder status |
+| BMI deletion fails | BMI stuck in `Deleting` (e.g., AAP deprovision job fails with `blockDeletionOnFailure: true`) | Controller retries delete periodically. Alerting notifies operators | Scale-down appears incomplete in ClusterOrder status |
+| Controller restart mid-reconciliation | Controller resumes from current state on restart | Idempotent reconciliation logic rebuilds in-memory state from CRD status and re-queries BMI/Agent state | Temporary stall, no data loss |
+
+### RBAC / Tenancy
+
+No new RBAC roles are introduced. The osac-operator's service account already has permissions to create CRs in cluster namespaces and call the private API.
+
+CaaS-managed BMIs carry `metadata.tenant` (set by the private API from the ClusterOrder's tenant context) and `metadata.labels["osac.openshift.io/managed-by"] = "caas"`. The tenant isolation metadata is present but the BMIs are not visible to the tenant — the public API filters them out. The `osac.openshift.io/cluster-order` label links BMIs to their parent ClusterOrder, enabling Cloud Provider Admin queries across clusters.
+
+Tenant-owned BMaaS workflows are unaffected. A tenant creating their own BareMetalInstance through the public API sees only their own instances, as before.
+
+### Observability and Monitoring
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `osac_clusterorder_workers_desired` | Gauge | `tenant`, `worker_type` | Total desired workers across all ClusterOrders for the tenant |
+| `osac_clusterorder_workers_ready` | Gauge | `tenant`, `worker_type` | Total workers in `Ready` phase |
+| `osac_clusterorder_workers_failed` | Gauge | `tenant`, `worker_type` | Total workers in `Failed` phase |
+| `osac_clusterorder_worker_provisioning_duration_seconds` | Histogram | `tenant`, `worker_type` | Time from worker creation to NodePool join |
+| `osac_clusterorder_worker_agent_correlation_duration_seconds` | Histogram | `tenant`, `worker_type` | Time from worker `Running` to Agent MAC match (bare_metal only) |
+
+Per-ClusterOrder metrics would create unbounded label cardinality at scale. Metrics are aggregated by `tenant` (bounded). Per-ClusterOrder detail is available via the ClusterOrder status fields and Kubernetes events, which are the appropriate layer for per-instance diagnostics.
+
+**Kubernetes Events:**
+
+| Event | Type | Reason | When |
+|---|---|---|---|
+| InfraEnv created | Normal | `InfraEnvCreated` | Controller creates the InfraEnv CR |
+| Worker created | Normal | `WorkerCreated` | Controller creates a worker resource via private API |
+| Agent correlated | Normal | `AgentCorrelated` | MAC match found between Agent and worker resource |
+| Worker joined | Normal | `WorkerReady` | Worker installed as cluster node |
+| Agent registration timeout | Warning | `AgentRegistrationTimeout` | No Agent registered within the timeout window |
+| Worker provisioning failed | Warning | `WorkerFailed` | Worker resource entered `Failed` phase |
+| Worker deleted | Normal | `WorkerDeleted` | Controller deleted a worker resource during scale-down |
+
+### Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| MAC address dependency (OSAC-2308/OSAC-3254) not delivered before this feature | Agent-to-BMI correlation impossible; entire feature blocked | Feature gated on this dependency. No partial implementation without MAC correlation. |
+| DiskImage dependency (OSAC-2540/OSAC-1270) not delivered before this feature | Controller cannot resolve RHCOS boot image via DiskImage; BMI creation blocked | Feature gated on this dependency. Cloud Infrastructure Admin must register RHCOS DiskImages before CaaS bare-metal provisioning is enabled. |
+| RHCOS DiskImage not registered for target OCP version | Controller cannot resolve boot image; BMI creation blocked with `RHCOSImageNotFound` condition | Cloud Infrastructure Admin must register DiskImages for each supported OCP version before enabling CaaS provisioning. Alert on `RHCOSImageNotFound` condition. |
+| Ironic deprovision failure leaves hosts in limbo during scale-down | Hosts are not cleaned up; potential data leakage if reassigned | Controller sets a 30-minute timeout for unbinding. Operators alerted via `WorkerFailed` event. Manual intervention documented in support procedures. |
+| Discovery ignition exceeds `bareMetalInstanceUserDataMaxBytes` (64KB) | BMI creation rejected | PoC measured 15KB. The controller emits a `DiscoveryIgnitionSizeWarning` event when the fetched ignition exceeds 48KB (75% of the 64KB limit), giving operators advance notice before BMI creation starts failing. |
+| Concurrent scale operations on multiple clusters exhaust host inventory | Multiple ClusterOrders compete for limited hosts; some fail | BMI creation fails, worker enters `Failed` phase. ClusterOrder status reflects partial provisioning. Inventory sizing is the admin's responsibility. |
+
+### Drawbacks
+
+This design tightly couples the osac-operator to the fulfillment-service private API for BMI lifecycle management. The controller becomes a gRPC client of the fulfillment-service, adding a synchronous dependency in the reconciliation path. If the fulfillment-service is unavailable, worker provisioning and deprovisioning stall. The alternative — creating BMI CRs directly on the hub cluster — would avoid this dependency but lose the audit trail and visibility filtering that the fulfillment-service provides. The coupling is justified because the private API is the canonical path for all BMI operations, and the fulfillment-service is a core dependency that the osac-operator already communicates with for Signal RPCs and other operations.
+
+The MAC-based Agent correlation is inherently racy: if two BMIs in different clusters boot on the same VLAN and an Agent's MAC matches a BMI from a different cluster, the correlation is wrong. The one-InfraEnv-per-cluster design prevents this for Agents (each Agent is scoped to its InfraEnv's ClusterDeployment), but the MAC lookup must still be scoped to Agents in the correct namespace.
+
+## Alternatives (Not Implemented)
+
+### BareMetalPool-Based Provisioning (Current Approach)
+
+Create a BareMetalPool per ClusterOrder and let the bare-metal-fulfillment-operator manage BMI creation. **Rejected** because BareMetalPool groups BMIs with a shared profile — CaaS needs per-instance ignition (each cluster has a different InfraEnv). The Pool abstraction does not support per-BMI `image` and `user_data` configuration. The PoC validated direct BMI creation; adding a pooling abstraction that does not fit the use case adds complexity without benefit.
+
+### Direct CR Creation on Hub Cluster
+
+Have the controller (or AAP role) create BareMetalInstance CRs directly on the hub cluster, bypassing the fulfillment-service. This is what the current `cluster_infra` AAP step does with BareMetalPool CRs. **Rejected** because: (a) BMIs would not appear in the fulfillment-service database, breaking audit and observability; (b) the label-based visibility filtering requires fulfillment-service cooperation; (c) the private API is the canonical path for BMI lifecycle, and the PRD explicitly requires it.
+
+### AAP-Orchestrated BMI Creation
+
+Replace the controller-based flow with a new AAP role that calls the private API and manages the agent correlation loop. **Rejected** because AAP jobs are one-shot — they do not naturally handle the asynchronous agent registration and correlation flow. The controller's watch-based reconciliation model is the correct abstraction for reacting to Agent CR state changes over time. Scale-up and scale-down events also need reactive handling that controllers provide.
+
+## Test Plan
+
+### Unit Tests
+
+- ClusterOrder controller: `reconcileWorkers` creates the correct number of BMIs when desired count exceeds current count.
+- ClusterOrder controller: `reconcileWorkers` calls `BareMetalInstances.Delete` for excess BMIs when desired count is less than current count.
+- ClusterOrder controller: `correlateAgents` matches an Agent to a BMI when their MAC addresses match.
+- ClusterOrder controller: `correlateAgents` does not match Agents from a different namespace.
+- ClusterOrder controller: `ensureInfraEnv` creates an InfraEnv with the correct ClusterDeployment reference and owner reference.
+- ClusterOrder controller: worker phase transitions correctly through `Provisioning` → `WaitingForAgent` → `Binding` → `Ready`.
+- ClusterOrder controller: worker phase transitions to `Failed` after agent registration timeout.
+- ClusterOrder controller: reconciliation is idempotent — re-running with the same state produces no new API calls.
+- Visibility filtering: public `BareMetalInstances.List` excludes BMIs with `osac.openshift.io/managed-by` label.
+- Visibility filtering: public `BareMetalInstances.Get` returns `NotFound` for CaaS-managed BMIs.
+
+### Integration Tests
+
+- Create a ClusterOrder with bare-metal node requests in a kind cluster. Verify InfraEnv CR is created with correct spec. Verify BMI creation calls reach the fulfillment-service (mocked private API). Verify ClusterOrder status reflects `workers` entries.
+- Simulate Agent registration by creating Agent CRs with matching MAC addresses. Verify correlation and labeling.
+- Simulate scale-down by decreasing `nodeRequests`. Verify NodePool replicas decrease and BMI delete is called for the excess workers.
+- Verify ClusterOrder deletion cleans up all BMIs and the InfraEnv before removing the finalizer.
+
+### E2E Tests
+
+- Full provisioning flow: create a Cluster with a bare-metal node set via the fulfillment-service public API. Verify workers join and ClusterOrder reaches `Ready`. (Requires a test environment with BMaaS hosts and assisted-service.)
+- Scale-up: increase node count on an existing cluster. Verify new workers are provisioned and join.
+- Scale-down: decrease node count. Verify workers are drained, agents unbound, BMIs deleted.
+- Cluster deletion: delete a cluster with bare-metal workers. Verify all BMIs are cleaned up.
+- Visibility: verify `osac list baremetalinstances` as a tenant user does not return CaaS-managed instances.
+- Pool removal: verify no BareMetalPool CRs are created during CaaS cluster provisioning. Verify the `cluster_infra` AAP step no longer references BareMetalPool.
+
+Note: full E2E tests require a BMaaS-capable test environment with physical or simulated bare-metal hosts. Initial E2E coverage may be limited to API-level verification with mocked BMaaS responses.
+
+## Graduation Criteria
+
+N/A. OSAC is in active development and has not been released to customers.
+
+## Upgrade / Downgrade Strategy
+
+The BareMetalPool-based pre-boot pool is removed immediately — there is no coexistence period. On upgrade:
+
+1. The `cluster_infra` AAP step that creates BareMetalPool CRs is removed from the CaaS provisioning workflow.
+2. The scheduled `osac-import-agents` AAP job is no longer needed for CaaS (it may be retained for standalone BMaaS use cases).
+3. Existing BareMetalPool resources created by CaaS are drained: idle hosts are released back to inventory, and the BareMetalPool CRs are deleted.
+4. Existing clusters with workers provisioned via the old pool flow continue running — their workers are already installed and do not depend on the pool. However, scale-up on these clusters uses the new on-demand BMI flow going forward.
+5. Clusters mid-provisioning during the upgrade (AAP job in progress using the old `cluster_infra` step) must complete or fail before the upgrade. The upgrade procedure must drain the AAP job queue — no new CaaS provisioning jobs are accepted while the old step is being removed. Any in-flight job that references the deleted `cluster_infra` step will fail; the operator must re-trigger provisioning using the new flow after the upgrade completes.
+
+Downgrade requires:
+1. Scale down all bare-metal workers on affected clusters (the controller manages cleanup).
+2. Delete any InfraEnv CRs created by the controller.
+3. Re-deploy the `cluster_infra` AAP step and scheduled `osac-import-agents` job for BareMetalPool management.
+4. Revert the osac-operator to the previous version.
+
+The ClusterOrder CRD gains a new status field (`workers`). On downgrade, the older controller ignores this field. No data migration is needed because the field is status-only (the controller rebuilds it from live state on startup).
+
+## Version Skew Strategy
+
+The osac-operator (controller) and fulfillment-service (private API) must be upgraded together or the operator first. The controller calls `BareMetalInstances.Create` with existing fields (`image`, `user_data`). The only proto change is a new `source_type` value (`"disk_image"`) on `BareMetalInstanceImage`. If the fulfillment-service is at an older version that does not recognize this value, BMI creation may fail with a validation error — the fulfillment-service must be upgraded first or at the same time as the operator.
+
+The visibility filtering (label-based exclusion in public `List`) requires the fulfillment-service to be upgraded. If the operator is upgraded first, CaaS-managed BMIs are created with the label but remain visible in tenant listings until the fulfillment-service is updated. This is a cosmetic issue during the upgrade window, not a functional failure.
+
+## Support Procedures
+
+**Detecting failures:**
+- ClusterOrder stuck in `Progressing` with condition `WorkersFailed`: check `status.workers[]` for the referenced BMI names, then inspect each via the private API (`osac get baremetalinstances <name> --private`) for provisioning job errors and state.
+- Alert: `osac_clusterorder_workers_failed > 0` sustained for 15 minutes.
+- Agent registration timeout: check InfraEnv status for ignition generation errors. Verify RHCOS image URL is reachable from Ironic. Check BMI status for host allocation failures.
+- Scale-down stall: Agent stuck in `unbinding-pending-user-action` — investigate Ironic deprovision status via `oc get bmh` in the cluster namespace. Check Ironic logs for deprovision errors.
+
+**Disabling the feature:**
+- Set the cluster template to exclude bare-metal resource classes. Existing clusters with bare-metal workers continue running — the controller does not deprovision workers unless instructed (scale-down or delete).
+- To force-remove CaaS BMIs: delete them via the private API and remove the corresponding entries from `status.workers[]` on the ClusterOrder. The workers are removed from the cluster but hosts must be manually cleaned.
+
+**Recovery:**
+- The controller is designed for idempotent reconciliation. Restarting the osac-operator pod causes the controller to rebuild state from the ClusterOrder status, re-query BMI and Agent CRs, and resume any pending operations. No manual consistency repair is needed.
+
+## Infrastructure Needed
+
+No new infrastructure. The feature uses existing components: osac-operator deployment, fulfillment-service private API, assisted-service, HyperShift, and BMaaS hosts.
+
+Documentation updates required:
+- Cloud Infrastructure Admin guide: DiskImage registration procedure for RHCOS qcow2 images per OCP version.
+- Installation prerequisites: minimum MCE version requirement (assisted-service 5.0.0+ for MGMT-24903 fix).
+- Migration guide: BareMetalPool removal procedure, AAP job queue drain during upgrade, post-upgrade re-trigger of mid-provisioning clusters.
+
+---
+
+## Provenance
+
+Authored: draft @ design 0.7.1 - b8b3f86, workspace fix/containerfile-podman-wrapper @ 38af260
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"design","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"38af260","source_repo_branch":"fix/containerfile-podman-wrapper","commits_behind_main":0,"commits_ahead_main":324,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
+++ b/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
@@ -131,7 +131,7 @@ A Tenant User increases `node_sets[].size` for a bare-metal node set. The fulfil
 
 1. The controller computes `desired - current` where `current` is `status.currentWorkers` (workers in active phases: `Provisioning`, `WaitingForAgent`, `Binding`, `Ready`). Workers in `Failed` phase do not count toward capacity — new workers are created to fill the gap once their retry backoff expires.
 2. The controller re-reads the InfraEnv's `status.bootArtifacts.discoveryIgnitionURL` to fetch fresh ignition. The InfraEnv persists from initial provisioning; if it was deleted (e.g., manual cleanup), the `ensureInfraEnv` phase recreates it.
-3. The controller resolves the RHCOS DiskImage using the cluster's current ClusterVersion (see RHCOS DiskImage Resolution). Note: until cluster upgrades are implemented, this is always the creation-time version. Once upgrades land, the Cluster's ClusterVersion reference will be updated by the upgrade flow, and this step will automatically resolve the upgraded version's DiskImage — this is why the design reads the current reference rather than caching the creation-time version.
+3. The controller resolves the RHCOS DiskImage from the cluster's current ClusterVersion's `disk_image` reference (see RHCOS DiskImage Resolution).
 4. For each new worker, the controller follows provisioning steps 4-9 from the initial flow (the ignition content is re-fetched in step 2 above).
 5. Partial success is reported: if 3 of 5 new workers succeed and 2 fail, the ClusterOrder status shows 3 additional `Ready` workers and 2 `Failed`. The tenant sees the cluster with the successfully added workers; the failed slots are visible via ClusterOrder conditions and events.
 
@@ -150,7 +150,7 @@ sequenceDiagram
 
     HCP->>HCP: CAPI selects Machine, drains node
     HCP->>AS: AgentMachine unbinds Agent
-    AS-->>CO: Agent enters unbinding-pending-user-action
+    AS-->>CO: Agent reaches unbound/terminal state
 
     CO->>CO: Match unbound Agent to BMI via MAC
     CO->>BMaaS: Delete BareMetalInstance
@@ -164,16 +164,16 @@ This diagram shows the scale-down flow. CAPI handles node drain and agent unbind
 
 1. The controller computes the excess worker count (current minus desired).
 2. The controller removes `Failed` workers first — deletes their dead BMIs and removes their `status.workers` entries. If more removals are needed after clearing all failed slots, the controller decreases NodePool `.spec.replicas` by the remaining excess.
-3. CAPI's MachineDeployment controller manages MachineSets, which select Machines for deletion. CaaS does not control the selection order.
-4. CAPI drains each selected node, then the AgentMachine controller unbinds the Agent (clears `ClusterDeploymentName`). Since workers are post-installation, the Agent transitions to `unbinding-pending-user-action` and remains there — CAPA considers its job done at this point.
+3. CAPI's MachineDeployment controller manages MachineSets, which select Machines for deletion. CaaS delegates Machine selection order to CAPI's default behavior (random) — no preference for newest-first or oldest-first. This is a deliberate design choice: bare-metal workers are fungible, and controlling selection order would require CAPI-level configuration (e.g., `MachineDeployment.spec.strategy`) that is not needed for this use case.
+4. CAPI drains each selected node, then the AgentMachine controller unbinds the Agent (clears `ClusterDeploymentName`). With the assisted image service disabled (see deployment prerequisites), reclaim is not attempted and the Agent transitions directly to `unbinding-pending-user-action`. CAPA removes its hook/finalizer at this point.
 5. The controller watches for Agents entering `unbinding-pending-user-action` and matches them back to BMIs via MAC address.
-6. The controller deletes the Agent CR. CAPA does not delete the Agent — it only clears `ClusterDeploymentName` and removes its own hook/finalizer. Without a BMH to drive the Agent back to discovery, the Agent CR would remain in `unbinding-pending-user-action` indefinitely. CaaS owns this cleanup.
+6. The controller deletes the Agent CR. CAPA does not delete the Agent — it only clears `ClusterDeploymentName` and removes its own hook/finalizer. CaaS owns the Agent CR cleanup because the host will be deprovisioned by BMaaS.
 7. The controller calls `BareMetalInstances.Delete` on the private API. BMaaS handles full host cleanup before returning the host to inventory. CaaS does not independently verify cleanup completion — this is a trust boundary between CaaS and BMaaS. If BMaaS cleanup fails, the host must not be reallocated; this guarantee is BMaaS's responsibility.
 8. The controller retains the worker entry in `status.workers` in `Deleting` phase until the BMI deletion is confirmed. This prevents orphaned hosts — if `Delete` succeeds but cleanup stalls, the controller still has the reference to retry or alert.
 
 #### Cluster Deletion
 
-On ClusterOrder deletion, the controller runs the scale-down flow for all remaining workers (steps 2-8) before allowing the AAP deprovision job to destroy the HostedCluster. The InfraEnv CR is cleaned up automatically by Kubernetes garbage collection via its ownerReference to the ClusterOrder — no explicit deletion is needed. The ClusterOrder's finalizer prevents premature deletion, ensuring all BMIs are cleaned up before the ClusterOrder (and its owned InfraEnv) are removed.
+On ClusterOrder deletion, the worker reconciler does not need to explicitly orchestrate scale-down. Deleting the HostedCluster cascades through HyperShift (deletes all NodePools) → CAPI (drains nodes, deletes Machines) → CAPA (unbinds Agents). The worker reconciler reacts to Agents becoming unbound and cleans up BMIs and Agent CRs through the normal scale-down watch (steps 5-8). The ClusterOrder's finalizer holds until all `status.workers[]` entries are cleaned up. The InfraEnv CR is garbage collected via its ownerReference to the ClusterOrder.
 
 ### API Extensions
 
@@ -357,25 +357,34 @@ The discovery ignition is architecture-neutral (the `assisted-installer-agent` i
 
 #### RHCOS DiskImage Resolution
 
-The controller resolves the RHCOS boot image via a pre-registered DiskImage resource (dependency: OSAC-2540 DiskImage, OSAC-1270 BMI DiskImage integration). The controller reads `ClusterVersion.spec.version` (a structured semver field, e.g., `"4.22.0"`), extracts the major.minor version, and resolves the worker architecture from the node set's HostType. It then queries for provider-global DiskImages matching both the `osac.openshift.io/ocp-version` label and the resolved architecture.
+The controller resolves the RHCOS boot image via a `DiskImageReference` on the `ClusterVersion` resource (dependency: OSAC-2540 DiskImage, OSAC-1270 BMI DiskImage integration, OSAC-1330 type-safe references). The private `ClusterVersionSpec` gains a new field:
 
-The `osac.openshift.io/ocp-version` label is a CaaS convention — the DiskImage resource itself (OSAC-2540) has no OCP version field, since version-based lookup is a CaaS-specific need. The controller reads the cluster's **current** ClusterVersion reference, not the creation-time version. After a cluster upgrade (e.g., 4.20 → 4.22), the Cluster's ClusterVersion reference is updated by the upgrade flow, and subsequent scale-up operations resolve the 4.22 DiskImage.
+```protobuf
+message ClusterVersionSpec {
+    // ... existing fields (image, version, enabled, is_default, state, deprecation) ...
+    DiskImageReference disk_image = 7;
+}
+```
+
+The controller reads the cluster's current ClusterVersion, follows the `disk_image` reference to get the DiskImage ID, and passes it as `spec.image.source_ref` on the BMI. No label-based lookup, no ambiguity — each ClusterVersion references exactly one DiskImage. The typed reference (per OSAC-1330) provides reference validation at ClusterVersion creation time and deletion protection (the DiskImage cannot be deleted while referenced by an active ClusterVersion).
+
+The controller reads the cluster's **current** ClusterVersion reference, not the creation-time version. Note: until cluster upgrades are implemented, this is always the creation-time version. Once upgrades land, the Cluster's ClusterVersion reference will be updated by the upgrade flow — this is the most reasonable assumption but should be treated as a dependency since cluster upgrades are still at the PRD stage.
 
 The boot image is ephemeral — it exists only to run the discovery agent. The assisted-installer writes the correct RHCOS version (pinned to the release image) to disk during installation. Any Z stream within the same minor version is acceptable for the boot image.
 
-If no matching DiskImage is found for the target OCP version, the controller sets the ClusterOrder condition `RHCOSImageNotFound` and does not proceed with BMI creation. If multiple DiskImages match the same version and architecture, the controller sets `RHCOSImageAmbiguous` and does not proceed — the Cloud Infrastructure Admin must ensure exactly one DiskImage exists per OCP version + architecture combination.
+If the `disk_image` reference is not set on the ClusterVersion, the controller sets the ClusterOrder condition `RHCOSImageNotFound` and does not proceed with BMI creation. If the underlying image is unreachable or the download fails during provisioning, the BMI enters `Failed` phase. The failure is reported via ClusterOrder conditions.
 
-If the underlying image referenced by the DiskImage is unreachable or the download fails during provisioning, the BMI enters `Failed` phase. The failure is reported via ClusterOrder conditions.
-
-**Current limitation — manual DiskImage registration:** In this version, the Cloud Infrastructure Admin must manually register RHCOS images as provider-global DiskImages. For each supported OCP version:
+**Current limitation — manual DiskImage registration and linking:** In this version, the Cloud Infrastructure Admin must manually register RHCOS images and link them to ClusterVersions. For each supported OCP version:
 
 1. Download the RHCOS qcow2 image for the target OCP version and architecture
 2. Repackage the qcow2 as an OCI artifact
 3. Push the OCI artifact to a container registry accessible to BMaaS
 4. Register a DiskImage via the fulfillment-service API with `source_ref` pointing to the pushed OCI artifact
-5. Apply the `osac.openshift.io/ocp-version` label with the major.minor version (e.g., `"4.22"`)
+5. Update the ClusterVersion to set the `disk_image` reference to the registered DiskImage (e.g., `osac update clusterversion 4.22.0 --disk-image <disk-image-id>`)
 
-**Future automation path:** The DiskImage-based resolution stays the same — the controller always resolves DiskImages by version label. What changes is how DiskImages are populated. The OCP release image (`ClusterVersion.spec.image`) contains the RHCOS image reference as a component (`rhel-coreos`). A future utility could introspect registered ClusterVersions, extract the RHCOS image reference from each release payload, and automatically create the DiskImage with the extracted reference as `source_ref` and the correct version label. This removes the manual coupling — no need to separately download a qcow2, repackage it as OCI, and register it with the right version label. Adding a new ClusterVersion would automatically produce the matching DiskImage.
+The CLI must support setting the `disk_image` reference on ClusterVersion — this requires extending the `osac create/update clusterversion` commands with a `--disk-image` flag.
+
+**Future automation path:** The OCP release image (`ClusterVersion.spec.image`) contains the RHCOS image reference as a component (`rhel-coreos`). A future utility could introspect registered ClusterVersions, extract the RHCOS image reference from each release payload, and automatically create the DiskImage and set the `disk_image` reference on the ClusterVersion. This removes the manual coupling — adding a new ClusterVersion would automatically produce and link the matching DiskImage. Note: directly using the RHCOS OCI image from the release payload as the DiskImage `source_ref` is not possible today because OCP BMO does not support this image format (planned for OCP 5.1). Until then, the qcow2 repackaging step remains necessary.
 
 #### BMI Creation via Private API
 
@@ -410,7 +419,18 @@ The controller sets the following metadata fields on the created BMI:
 
 `BareMetalInstances.Create` requires a `spec.catalog_item` reference (`BareMetalInstanceCatalogItem`). The current `resourceClass` on `ClusterOrder.nodeRequests[]` carries a HostType name (e.g., `"fc430"`), which does not map directly to a CatalogItem — the resolution chain is HostType → Template → CatalogItem, and it is ambiguous (multiple Templates can reference the same HostType, multiple CatalogItems can reference the same Template).
 
-To avoid this ambiguity, the ClusterTemplate must carry the CatalogItem reference for CaaS node sets. This is a small addition to the ClusterTemplate metadata (`meta/osac.yaml`): a `catalog_item` field per node request entry, set by the Cloud Infrastructure Admin when defining the template. The controller reads the CatalogItem reference from the template parameters rather than reverse-looking it up from the HostType.
+To avoid this ambiguity, the ClusterTemplate must carry the CatalogItem reference for CaaS node sets. This is a small addition to the ClusterTemplate metadata (`meta/osac.yaml`): a `catalog_item` field per node request entry, set by the Cloud Infrastructure Admin when defining the template:
+
+```yaml
+# ocp-small/meta/osac.yaml
+title: OpenShift Small Cluster
+default_node_request:
+  - resourceClass: fc430
+    catalogItem: bm-standard      # new field — BareMetalInstanceCatalogItem name
+    numberOfNodes: 2
+```
+
+The controller reads the CatalogItem reference from the template parameters rather than reverse-looking it up from the HostType. The `catalogItem` field is passed through to the ClusterOrder as a template parameter (alongside the existing `resourceClass`), making it available to the `BareMetalWorkerReconciler` without changes to the `NodeRequest` CRD type.
 
 Changing `resourceClass` itself to reference a CatalogItem instead of a HostType is a broader change that affects the entire stack (fulfillment-service, osac-operator, AAP roles, bare-metal-fulfillment-operator) and is out of scope for this design.
 
@@ -437,9 +457,15 @@ The correlation algorithm requires a unique match across three dimensions before
 
 If zero candidates match, the controller continues watching. If multiple candidates match (should not happen — MACs are unique per host), the controller logs an error and does not bind, preventing ambiguous correlation. If no match is found within a configurable timeout (default: 30 minutes), the controller sets the worker phase to `Failed` with reason `AgentRegistrationTimeout`.
 
+After the first successful MAC match, the controller labels the Agent with `osac.openshift.io/worker-name` pointing to the worker slot name (e.g., `bm-cluster-a-worker-0`). Subsequent reconciliations and scale-down lookups use this label instead of re-doing MAC correlation — the same pattern CAPA uses with the `agentMachineRef` label.
+
 #### Minimum MCE Version
 
 The MGMT-24903 fix (persistent-boot day-2 installs) is merged to assisted-service master ([PR #10717](https://github.com/openshift/assisted-service/pull/10717), 2026-07-29) and assisted-installer-agent master ([PR #1568](https://github.com/openshift/assisted-installer-agent/pull/1568), 2026-07-30). The fix ships in MCE 5.0. Without it, workers fail to install because `osImageURL` is stripped from the ignition config. The controller does not implement a workaround — MCE >= 5.0 is a deployment prerequisite.
+
+#### Assisted Image Service
+
+The assisted image service must be **disabled** for CaaS deployments. CaaS does not use ISO-based discovery — hosts boot from a RHCOS DiskImage with inline ignition, not from an assisted-service ISO. If the image service is deployed, assisted-service will attempt to reclaim Agents during scale-down (rebooting the host back into the discovery ISO), which conflicts with CaaS's flow where BMaaS owns host lifecycle and the controller deletes the BMI directly. Disabling the image service ensures Agents transition directly to `unbinding-pending-user-action` on unbind, allowing CaaS to clean up the Agent CR and the BMI without interference.
 
 #### Controller Reconciliation Structure
 
@@ -527,7 +553,7 @@ Per-ClusterOrder metrics would create unbounded label cardinality at scale. Metr
 |---|---|---|
 | MAC address dependency (OSAC-2308/OSAC-3254) not delivered before this feature | Agent-to-BMI correlation impossible; entire feature blocked | Feature gated on this dependency. No partial implementation without MAC correlation. |
 | DiskImage dependency (OSAC-2540/OSAC-1270) not delivered before this feature | Controller cannot resolve RHCOS boot image via DiskImage; BMI creation blocked | Feature gated on this dependency. Cloud Infrastructure Admin must register RHCOS DiskImages before CaaS bare-metal provisioning is enabled. |
-| RHCOS DiskImage not registered for target OCP version | Controller cannot resolve boot image; BMI creation blocked with `RHCOSImageNotFound` condition | Cloud Infrastructure Admin must register DiskImages for each supported OCP version before enabling CaaS provisioning. Alert on `RHCOSImageNotFound` condition. |
+| RHCOS DiskImage not linked to ClusterVersion | Controller cannot resolve boot image; BMI creation blocked with `RHCOSImageNotFound` condition | Cloud Infrastructure Admin must register DiskImages and link them to ClusterVersions via `--disk-image` before enabling CaaS provisioning. Reference validation catches this at ClusterVersion creation time. |
 | BMaaS deprovision failure leaves hosts in limbo during scale-down | Hosts are not cleaned up; potential data leakage if reassigned | Controller sets a 30-minute timeout for unbinding. Operators alerted via `WorkerFailed` event. Manual intervention documented in support procedures. |
 | Discovery ignition exceeds `bareMetalInstanceUserDataMaxBytes` (64KB) | BMI creation rejected | PoC measured 15KB. The controller emits a `DiscoveryIgnitionSizeWarning` event when the fetched ignition exceeds 48KB (75% of the 64KB limit), giving operators advance notice before BMI creation starts failing. |
 | Concurrent scale operations on multiple clusters exhaust host inventory | Multiple ClusterOrders compete for limited hosts; some fail | BMI creation fails, worker enters `Failed` phase. ClusterOrder status reflects partial provisioning. Inventory sizing is the admin's responsibility. |
@@ -635,8 +661,8 @@ CaaS-managed BMIs are assigned to the builtin `system` tenant, which already exi
 No new infrastructure. The feature uses existing components: osac-operator deployment, fulfillment-service private API, assisted-service, HyperShift, and BMaaS hosts.
 
 Documentation updates required:
-- Cloud Infrastructure Admin guide: DiskImage registration procedure for RHCOS qcow2 images per OCP version.
-- Installation prerequisites: minimum MCE version requirement (assisted-service 5.0.0+ for MGMT-24903 fix).
+- Cloud Infrastructure Admin guide: DiskImage registration procedure and ClusterVersion linking.
+- Installation prerequisites: minimum MCE version requirement (assisted-service 5.0.0+ for MGMT-24903 fix), assisted image service must be disabled.
 - Migration guide: BareMetalPool removal procedure, AAP job queue drain during upgrade, post-upgrade re-trigger of mid-provisioning clusters.
 
 ---

--- a/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
+++ b/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
@@ -22,7 +22,7 @@ superseded-by:
 
 ## Summary
 
-This design adds on-demand bare-metal worker node provisioning to CaaS by having the osac-operator ClusterOrder controller create BareMetalInstances via the fulfillment-service private gRPC API. Each instance references a pre-registered RHCOS DiskImage and carries discovery ignition inline from the shared platform-level InfraEnv, causing the host to register as an assisted-service Agent and join the HyperShift-managed cluster as a worker node. The existing BareMetalPool-based static pre-boot pool is removed. See [PRD](prd.md) for detailed requirements.
+This design adds on-demand bare-metal worker node provisioning to CaaS by having the osac-operator ClusterOrder controller create BareMetalInstances via the fulfillment-service private gRPC API. Each instance references a pre-registered RHCOS DiskImage and carries discovery ignition inline from a cluster-specific InfraEnv, causing the host to register as an assisted-service Agent and join the HyperShift-managed cluster as a worker node. The existing BareMetalPool-based static pre-boot pool is removed. See [PRD](prd.md) for detailed requirements.
 
 ## Motivation
 
@@ -35,7 +35,7 @@ The new approach eliminates the pool by provisioning workers on-demand. When a C
 - Reuse the existing ClusterOrder controller reconciliation pattern and the private gRPC API for BMI lifecycle management.
 - Keep all CaaS-managed bare-metal infrastructure (BMIs, InfraEnvs, Agents) invisible to tenant-facing APIs and UIs.
 - Support both initial provisioning and manual scale-up/scale-down through the same controller logic.
-- Ensure host cleanup on scale-down and cluster deletion flows through BMaaS's existing deprovision pipeline (disk wipe, network reset).
+- Ensure host cleanup on scale-down and cluster deletion flows through BMaaS's existing deprovision pipeline via `BareMetalInstances.Delete`.
 - Remove the BareMetalPool-based static pre-boot pool workflow entirely — no coexistence period.
 - Require no changes to the tenant-facing Cluster API or CLI experience.
 
@@ -50,9 +50,9 @@ The new approach eliminates the pool by provisioning workers on-demand. When a C
 
 The ClusterOrder controller in osac-operator gains a new reconciliation phase for bare-metal worker management. When a ClusterOrder's `nodeRequests` reference bare-metal resource classes, the controller:
 
-1. Ensures a shared `InfraEnv` CR exists on the hub cluster to generate discovery ignition (one per platform, not per cluster).
+1. Creates a cluster-specific `InfraEnv` CR on the hub cluster to generate discovery ignition.
 2. Fetches discovery ignition from the InfraEnv and creates `BareMetalInstance` objects with the ignition passed inline as `user_data`, referencing the RHCOS DiskImage.
-3. Correlates registered Agents to BMIs via MAC address, binds them to the cluster's ClusterDeployment, and labels them for NodePool selection.
+3. Correlates registered Agents to BMIs via MAC address and labels them for NodePool selection.
 
 No new CRDs are introduced. The design extends the ClusterOrder CRD status with a `workers` field to track CaaS-managed worker resources. BareMetalInstances created by CaaS are assigned to the builtin `system` tenant, making them invisible to tenant APIs via the existing tenancy logic.
 
@@ -91,7 +91,7 @@ sequenceDiagram
     AAP->>HCP: Create HostedCluster + NodePool
     HCP-->>CO: ClusterDeployment exists
 
-    CO->>CO: Verify shared InfraEnv exists
+    CO->>CO: Create InfraEnv CR (late binding, no clusterRef)
     AS-->>CO: InfraEnv ready (discovery ignition available)
 
     loop For each requested bare-metal worker
@@ -113,14 +113,14 @@ The diagram shows the end-to-end provisioning flow. The controller waits for eac
 
 **Step-by-step:**
 
-1. The ClusterOrder controller detects `nodeRequests` with bare-metal resource classes by checking the resource class against BareMetalInstanceType definitions.
-2. After AAP creates the HostedCluster and the ClusterDeployment CR exists, the controller ensures the shared platform-level `InfraEnv` CR exists (see InfraEnv Creation). The InfraEnv has no `clusterRef` — agents register as unbound and the controller explicitly binds them to the correct cluster in step 8.
-3. The controller reads the InfraEnv's `status.bootArtifacts.discoveryIgnitionURL` and fetches the discovery ignition content. The ignition is architecture-neutral (the `assisted-installer-agent` image is a multi-arch manifest), so the same InfraEnv serves hosts of any architecture.
+1. The ClusterOrder controller identifies bare-metal node sets from `nodeRequests[]`. The `resourceClass` maps to a HostType; bare-metal HostTypes are distinguished by having physical network interfaces defined (per HostType proto convention).
+2. After AAP creates the HostedCluster and the ClusterDeployment CR exists, the controller creates a cluster-specific `InfraEnv` CR (see InfraEnv Creation). The InfraEnv uses late binding (no `clusterRef`) — agents register as unbound and the controller explicitly binds them in step 8.
+3. The controller polls the InfraEnv status until `status.bootArtifacts.discoveryIgnitionURL` is populated, then fetches the discovery ignition content. The ignition is architecture-neutral (the `assisted-installer-agent` image is a multi-arch manifest).
 4. For each bare-metal worker requested, the controller calls `BareMetalInstances.Create` on the private API with: `spec.catalog_item` resolved from the resource class, `spec.image` set to the resolved RHCOS DiskImage ID (see RHCOS DiskImage Resolution), `spec.user_data` set to the fetched ignition content inline (the `user_data` field accepts raw first-boot data up to 64KB; the PoC measured 15KB), `spec.network_attachments` built from the Cluster's `ClusterNetworkAttachment` (subnet + security groups) and the node set's HostType (fabric interface), and `metadata.tenant = "system"` (see System Tenant Isolation). The network attachment mapping is a pass-through: the controller reads the Cluster's `ClusterNetworkAttachment` for the subnet and security group references, resolves the fabric interface name from the node set's HostType definition (first interface with role `fabric`), and constructs a `BareMetalNetworkAttachment` with `primary: true`. BMaaS handles the physical networking — moving the host to the tenant subnet VLAN and assigning an IP via fabric DHCP — as part of BMI provisioning (dependency: OSAC-1437). If the host fails to join the tenant network, the agent will not register on the expected subnet, and the existing `AgentRegistrationTimeout` handles this failure mode. API and ingress VIPs are provisioned by the existing AAP template (MetalLB LoadBalancer Services) and are not managed by this controller.
 5. The controller updates ClusterOrder status with the BMI references in `workers[]`.
-6. BMaaS allocates a host, writes the qcow2 to disk via Ironic, and boots with the discovery ignition. The host registers as an Agent with assisted-service.
+6. BMaaS allocates a host, provisions it with the DiskImage and discovery ignition, and boots it. The host registers as an Agent with assisted-service.
 7. The controller watches Agent CRs in the cluster namespace. When a new Agent appears, the controller matches its inventory MAC address against BMI status MAC addresses (`status.host.mac_address`, dependency OSAC-2308/OSAC-3254).
-8. Once correlated, the controller sets the Agent's `clusterDeploymentName` to the cluster's ClusterDeployment and applies the `agentBareMetal` role label so the NodePool's `agentLabelSelector` selects it. This requires the osac-operator to modify `agent-install.openshift.io/v1beta1` Agent resources — a cross-API-group coupling. This is unavoidable: the assisted-service Agent API does not provide an auto-bind mechanism for late-binding agents, so an external controller must set `clusterDeploymentName` and apply labels. The osac-operator's RBAC must include `patch` on `agents` in the `agent-install.openshift.io` API group.
+8. Once correlated, the controller sets the Agent's `clusterDeploymentName` to the cluster's ClusterDeployment and applies the `agentBareMetal` role label so the NodePool's `agentLabelSelector` selects it. Late binding (explicit `clusterDeploymentName` setting) gives the controller full control over the Agent lifecycle — on scale-down, CAPA clears `clusterDeploymentName`, triggering the unbind flow that CaaS reacts to. The osac-operator's RBAC must include `patch` on `agents` in the `agent-install.openshift.io` API group.
 9. HyperShift installs the Agent as a worker node. The controller monitors NodePool `.status.replicas` to confirm convergence.
 
 #### Scale-Up
@@ -130,8 +130,8 @@ A Tenant User increases `node_sets[].size` for a bare-metal node set. The fulfil
 **Step-by-step:**
 
 1. The controller computes `desired - current` where `current` is `status.currentWorkers` (workers in active phases: `Provisioning`, `WaitingForAgent`, `Binding`, `Ready`). Workers in `Failed` phase do not count toward capacity — new workers are created to fill the gap once their retry backoff expires.
-2. The controller re-reads the shared InfraEnv's `status.bootArtifacts.discoveryIgnitionURL` to fetch fresh ignition.
-3. The controller resolves the RHCOS DiskImage from the NodePool's current release image (not the ClusterOrder's original). This ensures workers added after a cluster upgrade use a compatible boot image.
+2. The controller re-reads the InfraEnv's `status.bootArtifacts.discoveryIgnitionURL` to fetch fresh ignition. The InfraEnv persists from initial provisioning; if it was deleted (e.g., manual cleanup), the `ensureInfraEnv` phase recreates it.
+3. The controller resolves the RHCOS DiskImage using the cluster's current ClusterVersion (see RHCOS DiskImage Resolution). Note: until cluster upgrades are implemented, this is always the creation-time version. Once upgrades land, the Cluster's ClusterVersion reference will be updated by the upgrade flow, and this step will automatically resolve the upgraded version's DiskImage — this is why the design reads the current reference rather than caching the creation-time version.
 4. For each new worker, the controller follows provisioning steps 4-9 from the initial flow (the ignition content is re-fetched in step 2 above).
 5. Partial success is reported: if 3 of 5 new workers succeed and 2 fail, the ClusterOrder status shows 3 additional `Ready` workers and 2 `Failed`. The tenant sees the cluster with the successfully added workers; the failed slots are visible via ClusterOrder conditions and events.
 
@@ -150,11 +150,11 @@ sequenceDiagram
 
     HCP->>HCP: CAPI selects Machine, drains node
     HCP->>AS: AgentMachine unbinds Agent
-    AS-->>CO: Agent enters *-unbound state
+    AS-->>CO: Agent enters unbinding-pending-user-action
 
     CO->>CO: Match unbound Agent to BMI via MAC
     CO->>BMaaS: Delete BareMetalInstance
-    BMaaS->>BMaaS: Host cleanup (disk wipe, network reset)
+    BMaaS->>BMaaS: Host cleanup
     CO->>CO: Remove worker from status.workers (after BMI CR gone)
 ```
 
@@ -164,17 +164,15 @@ This diagram shows the scale-down flow. CAPI handles node drain and agent unbind
 
 1. The controller computes the excess worker count (current minus desired).
 2. The controller removes `Failed` workers first — deletes their dead BMIs and removes their `status.workers` entries. If more removals are needed after clearing all failed slots, the controller decreases NodePool `.spec.replicas` by the remaining excess.
-3. CAPI's MachineDeployment controller (used by HyperShift's default Replace upgrade type) manages MachineSets, which select Machines for deletion. CaaS does not control the selection order.
-4. CAPI drains each selected node, then the AgentMachine controller unbinds the Agent (clears `ClusterDeploymentName`, removes labels and ignition refs).
-5. Because BMH resources exist, the Agent enters `UnbindingPendingUserAction`. The BMH agent controller triggers Ironic deprovision (clears `bmh.Spec.Image`, removes the `detached` annotation).
-6. The controller watches for Agents transitioning to any `*-unbound` terminal state (`discovering-unbound`, `known-unbound`, `disconnected-unbound`, `insufficient-unbound`, `disabled-unbound`).
-7. The controller matches the unbound Agent back to a BMI via MAC address.
-8. The controller calls `BareMetalInstances.Delete` on the private API. BMaaS handles full host cleanup (disk wipe, network reset) before returning the host to inventory. CaaS does not independently verify cleanup completion — this is a trust boundary between CaaS and BMaaS. If BMaaS cleanup fails, the host must not be reallocated; this guarantee is BMaaS's responsibility.
-9. The controller retains the worker entry in `status.workers` until the BMI CR no longer exists on the hub cluster (confirming terminal deletion). This prevents orphaned hosts — if `Delete` succeeds but cleanup stalls, the controller still has the reference to retry or alert.
+3. CAPI's MachineDeployment controller manages MachineSets, which select Machines for deletion. CaaS does not control the selection order.
+4. CAPI drains each selected node, then the AgentMachine controller unbinds the Agent (clears `ClusterDeploymentName`). Since workers are post-installation, the Agent transitions to `unbinding-pending-user-action` and remains there — CAPA considers its job done at this point.
+5. The controller watches for Agents entering `unbinding-pending-user-action` and matches them back to BMIs via MAC address.
+6. The controller calls `BareMetalInstances.Delete` on the private API. BMaaS handles full host cleanup before returning the host to inventory. CaaS does not independently verify cleanup completion — this is a trust boundary between CaaS and BMaaS. If BMaaS cleanup fails, the host must not be reallocated; this guarantee is BMaaS's responsibility.
+7. The controller retains the worker entry in `status.workers` in `Deleting` phase until the BMI deletion is confirmed. This prevents orphaned hosts — if `Delete` succeeds but cleanup stalls, the controller still has the reference to retry or alert.
 
 #### Cluster Deletion
 
-On ClusterOrder deletion, the controller runs the scale-down flow for all remaining workers (steps 2-9) before allowing the AAP deprovision job to destroy the HostedCluster. The shared InfraEnv is not deleted — it is a platform-level resource that persists across cluster lifecycles. The ClusterOrder's finalizer prevents premature deletion, ensuring all BMIs are cleaned up before the ClusterOrder is removed.
+On ClusterOrder deletion, the controller runs the scale-down flow for all remaining workers (steps 2-7) before allowing the AAP deprovision job to destroy the HostedCluster. The InfraEnv CR is cleaned up automatically by Kubernetes garbage collection via its ownerReference to the ClusterOrder — no explicit deletion is needed. The ClusterOrder's finalizer prevents premature deletion, ensuring all BMIs are cleaned up before the ClusterOrder (and its owned InfraEnv) are removed.
 
 ### API Extensions
 
@@ -182,9 +180,9 @@ On ClusterOrder deletion, the controller runs the scale-down flow for all remain
 
 - `ClusterOrder` (osac-operator): new `workers` status field for tracking CaaS-managed worker resources. No spec changes — `nodeRequests[].resourceClass` already carries the information needed to identify bare-metal node sets.
 
-**Existing CRs used (not new CRD definitions):**
+**New CRs created at runtime (not new CRD definitions):**
 
-- `InfraEnv` (agent-install.openshift.io/v1beta1): a shared platform-level InfraEnv in the `hardware-inventory` namespace. The controller verifies it exists but does not create or own it — it is a deployment prerequisite managed by the Cloud Provider Admin (the same InfraEnv already used by the existing agent import flow).
+- `InfraEnv` (agent-install.openshift.io/v1beta1): one per cluster, created by the controller in the cluster's namespace. Owned by the ClusterOrder via an owner reference for garbage collection.
 
 **Modified behavior of existing resources:**
 
@@ -192,7 +190,7 @@ On ClusterOrder deletion, the controller runs the scale-down flow for all remain
 
 **Tenant-visible status:** The PRD requires tenant-visible failure conditions. ClusterOrder conditions (`WorkersFailed`, `InfraEnvReady`, `RHCOSImageNotFound`) live on the hub cluster, which tenants cannot access. The existing feedback controller syncs ClusterOrder status to the public Cluster API via the `Signal` RPC. This design extends the feedback controller to translate worker conditions into the tenant-visible Cluster status:
 
-- `WorkersFailed=True` on ClusterOrder → `WORKER_PROVISIONING_FAILED` condition on the public Cluster, with a tenant-safe message (e.g., "2 of 5 worker nodes failed to provision") that omits infrastructure details (no BMI names, MACs, or Ironic errors)
+- `WorkersFailed=True` on ClusterOrder → `WORKER_PROVISIONING_FAILED` condition on the public Cluster, with a tenant-safe message (e.g., "2 of 5 worker nodes failed to provision") that omits infrastructure details (no BMI names, MACs, or backend errors)
 - Workers in `Failed` with high attempt count → Cluster condition message includes the attempt count and next retry time, so tenants know retries are ongoing
 - All other conditions (`InfraEnvReady=False`, `RHCOSImageNotFound`) → mapped to a generic `WORKER_PROVISIONING_BLOCKED` condition on the Cluster, indicating the cluster cannot provision workers due to an infrastructure issue requiring Cloud Infrastructure Admin intervention
 
@@ -316,7 +314,7 @@ The controller tracks worker lifecycle through phases: `Provisioning` → `Waiti
 
 | Failure type | Examples | Backoff | Rationale |
 |---|---|---|---|
-| Transient infrastructure | BMaaS API timeout, Ironic temporary error, host allocation contention | Short exponential: 30s, 60s, 120s, capped at 5m | Likely to resolve quickly; fresh host allocation may succeed immediately |
+| Transient infrastructure | BMaaS API timeout, backend provisioning error, host allocation contention | Short exponential: 30s, 60s, 120s, capped at 5m | Likely to resolve quickly; fresh host allocation may succeed immediately |
 | Resource availability | No hosts available for the requested BareMetalInstanceType | Long exponential: 5m, 15m, 30m, capped at 30m | Inventory needs time to free up; aggressive retry wastes API calls |
 | Agent registration timeout | Host booted but agent did not register within 30m | Long exponential: 5m, 15m, 30m, capped at 30m | Root cause (bad image URL, broken InfraEnv, network) is unlikely to self-resolve; gives operator time to investigate before next attempt burns another host |
 
@@ -330,38 +328,53 @@ This satisfies the PRD requirement: "CaaS automatically handles provisioning ret
 
 #### InfraEnv Creation
 
-The controller ensures a single shared InfraEnv exists at the platform level, rather than creating one per cluster. The InfraEnv spec:
+The controller creates one InfraEnv per ClusterOrder. The InfraEnv spec:
 
 ```yaml
 apiVersion: agent-install.openshift.io/v1beta1
 kind: InfraEnv
 metadata:
-  name: infraenv
-  namespace: hardware-inventory
+  name: <cluster-order-name>-infraenv
+  namespace: <cluster-namespace>
+  ownerReferences:
+    - apiVersion: osac.openshift.io/v1alpha1
+      kind: ClusterOrder
+      name: <cluster-order-name>
 spec:
   pullSecretRef:
-    name: pull-secret
+    name: <pull-secret-name>
+  sshAuthorizedKey: <from ClusterOrder spec>
 ```
 
-The InfraEnv has no `clusterRef` and no `sshAuthorizedKey` — it generates unbound discovery ignition that is not scoped to any cluster. Agent-to-cluster binding happens explicitly in the correlation phase (step 9), where the controller sets `clusterDeploymentName` on each Agent after MAC-based matching.
+The InfraEnv uses **late binding** — no `clusterRef`. Agents register as unbound and the controller explicitly binds them by setting `clusterDeploymentName` after MAC correlation. This gives the controller full control over the Agent binding lifecycle: on scale-down, CAPA clears `clusterDeploymentName`, the Agent enters `unbinding-pending-user-action`, and the controller reacts by deleting the BMI. CAPI handles node drain and Node object deletion independently — the pre-terminate hook clears as soon as the Agent reaches `unbinding-pending-user-action`, so node removal does not depend on the host rebooting into discovery.
 
-**Why a shared InfraEnv:** The discovery ignition is architecture-neutral (`assisted-installer-agent` is a multi-arch manifest) and does not vary by cluster or tenant. The `cpuArchitecture` field on InfraEnv only affects ISO/kernel/rootfs URLs in `status.bootArtifacts`, not the ignition content — and this design uses the ignition-only flow, not ISO download. The InfraEnv's pull secret is a platform-level credential (Cloud Provider Admin's registry credentials for pulling the discovery agent image), separate from the per-cluster pull secret used for OCP release images. The existing OSAC deployment already uses a single `infraenv` in the `hardware-inventory` namespace with a platform-level `pull-secret`.
+One InfraEnv per cluster provides pull secret isolation (each cluster's InfraEnv carries the cluster-specific pull secret) and supports future static networking (per-host NMStateConfig is InfraEnv-scoped). Agent-to-cluster isolation is enforced by the MAC correlation algorithm (see MAC Address Correlation), which scopes matching to BMIs owned by the current ClusterOrder.
 
-Agent-to-cluster isolation is enforced by the MAC correlation algorithm (see MAC Address Correlation), which scopes matching to the ClusterOrder's owned BMIs. Cross-tenant agent misassignment is not possible because each BMI carries the `osac.openshift.io/cluster-order` ownership label, and the controller only binds Agents whose MAC matches a BMI owned by the current ClusterOrder.
+The discovery ignition is architecture-neutral (the `assisted-installer-agent` image is a multi-arch manifest) — the `cpuArchitecture` field on InfraEnv only affects ISO/kernel/rootfs URLs in `status.bootArtifacts`, not the ignition content, and this design uses the ignition-only flow.
+
+**Future optimization — shared InfraEnv for agent pooling:** A single platform-level InfraEnv could enable pre-booting hosts ahead of cluster requests, reducing provisioning latency. This design uses per-cluster InfraEnvs to keep the flow simple and maintain pull secret isolation. Agent pooling can be revisited as a future CaaS optimization.
 
 #### RHCOS DiskImage Resolution
 
-The controller resolves the RHCOS boot image via a pre-registered DiskImage resource (dependency: OSAC-2540 DiskImage, OSAC-1270 BMI DiskImage integration). The Cloud Infrastructure Admin registers RHCOS qcow2 images as provider-global DiskImages with guest OS family (`linux`) and architecture (`amd64`), and applies a CaaS-specific label `osac.openshift.io/ocp-version: "4.22"` to enable version-based lookup. This label is a CaaS convention — the DiskImage resource itself (OSAC-2540) has no OCP version field, since version-based lookup is a CaaS-specific need. If richer metadata is needed (e.g., multiple image variants per version, automated registration), a dedicated `ClusterDiskImage` resource could wrap DiskImage with CaaS-specific fields. Labeling is sufficient for this design.
+The controller resolves the RHCOS boot image via a pre-registered DiskImage resource (dependency: OSAC-2540 DiskImage, OSAC-1270 BMI DiskImage integration). The controller reads `ClusterVersion.spec.version` (a structured semver field, e.g., `"4.22.0"`), extracts the major.minor version, and resolves the worker architecture from the node set's HostType. It then queries for provider-global DiskImages matching both the `osac.openshift.io/ocp-version` label and the resolved architecture.
 
-The controller reads `NodePool.spec.release.image`, extracts the OCP major.minor version (e.g., `4.22` from `ocp-release:4.22.5-x86_64`), and resolves the worker architecture from the node set's `BareMetalInstanceType` (which defines the HostType and its CPU architecture). It then queries for provider-global DiskImages matching both the `osac.openshift.io/ocp-version` label and the resolved architecture. This design targets `amd64` only; other architectures require Cloud Infrastructure Admin to register the corresponding RHCOS DiskImages.
-
-Using the NodePool's current release image rather than the ClusterOrder's original ensures scale-up works correctly after cluster upgrades. A cluster created at OCP 4.18 and later upgraded to 4.22 would use a 4.22 boot image for new workers. Using the original 4.18 image could cause agent compatibility issues — the assisted-installer agent in an older RHCOS may not be compatible with a newer cluster's API or ignition format.
+The `osac.openshift.io/ocp-version` label is a CaaS convention — the DiskImage resource itself (OSAC-2540) has no OCP version field, since version-based lookup is a CaaS-specific need. The controller reads the cluster's **current** ClusterVersion reference, not the creation-time version. After a cluster upgrade (e.g., 4.20 → 4.22), the Cluster's ClusterVersion reference is updated by the upgrade flow, and subsequent scale-up operations resolve the 4.22 DiskImage.
 
 The boot image is ephemeral — it exists only to run the discovery agent. The assisted-installer writes the correct RHCOS version (pinned to the release image) to disk during installation. Any Z stream within the same minor version is acceptable for the boot image.
 
 If no matching DiskImage is found for the target OCP version, the controller sets the ClusterOrder condition `RHCOSImageNotFound` and does not proceed with BMI creation. If multiple DiskImages match the same version and architecture, the controller sets `RHCOSImageAmbiguous` and does not proceed — the Cloud Infrastructure Admin must ensure exactly one DiskImage exists per OCP version + architecture combination.
 
-If the underlying OCI artifact referenced by the DiskImage is unreachable or the image download fails at Ironic, the BMI enters `Failed` phase. The failure is reported via ClusterOrder conditions.
+If the underlying image referenced by the DiskImage is unreachable or the download fails during provisioning, the BMI enters `Failed` phase. The failure is reported via ClusterOrder conditions.
+
+**Current limitation — manual DiskImage registration:** In this version, the Cloud Infrastructure Admin must manually register RHCOS images as provider-global DiskImages. For each supported OCP version:
+
+1. Download the RHCOS qcow2 image for the target OCP version and architecture
+2. Repackage the qcow2 as an OCI artifact
+3. Push the OCI artifact to a container registry accessible to BMaaS
+4. Register a DiskImage via the fulfillment-service API with `source_ref` pointing to the pushed OCI artifact
+5. Apply the `osac.openshift.io/ocp-version` label with the major.minor version (e.g., `"4.22"`)
+
+**Future automation path:** The DiskImage-based resolution stays the same — the controller always resolves DiskImages by version label. What changes is how DiskImages are populated. The OCP release image (`ClusterVersion.spec.image`) contains the RHCOS image reference as a component (`rhel-coreos`). A future utility could introspect registered ClusterVersions, extract the RHCOS image reference from each release payload, and automatically create the DiskImage with the extracted reference as `source_ref` and the correct version label. This removes the manual coupling — no need to separately download a qcow2, repackage it as OCI, and register it with the right version label. Adding a new ClusterVersion would automatically produce the matching DiskImage.
 
 #### BMI Creation via Private API
 
@@ -423,7 +436,7 @@ The MGMT-24903 fix (persistent-boot day-2 installs) is merged to assisted-servic
 
 The bare-metal worker management integrates into the existing ClusterOrder controller as a new reconciliation phase, invoked after the AAP provisioning job creates the HostedCluster:
 
-1. **ensureInfraEnv** — verify the shared platform-level InfraEnv exists and has generated ignition; fail with `InfraEnvReady=False` if not.
+1. **ensureInfraEnv** — list InfraEnvs owned by this ClusterOrder (via ownerReference); create one if none exists; wait for ignition readiness.
 2. **reconcileWorkers** — compare desired count (from `nodeRequests`) with current `workers` count. Create or delete BMIs as needed.
 3. **correlateAgents** — watch Agents, match to BMIs via MAC, label for NodePool.
 4. **reconcileNodePoolReplicas** — set NodePool replicas to match the number of correlated agents.
@@ -438,7 +451,7 @@ All four phases are handled within the ClusterOrder controller rather than split
 
 CaaS-managed BMIs are created under the builtin `system` tenant via the private API. The `system` tenant is excluded from `DetermineVisibleTenants`, so these BMIs are invisible to all regular users without any additional filtering. The private API bypasses tenant-scoped OPA policies because it operates with system-level credentials. Ownership is traceable via the `osac.openshift.io/owner-reference` annotation linking each BMI to its parent ClusterOrder (which belongs to the real tenant).
 
-The discovery ignition contains the InfraEnv's pull secret and the assisted-service endpoint URL (both platform-level, not cluster-specific). It is passed inline as `user_data` on each BMI (max 64KB; PoC measured 15KB). The `user_data` field is immutable (enforced by the proto `IMMUTABLE` field behavior annotation). The ignition comes from the shared platform-level InfraEnv and is not cluster-scoped — agent-to-cluster binding is enforced by the MAC correlation algorithm, not by the ignition content.
+The discovery ignition contains the InfraEnv's pull secret and the assisted-service endpoint URL. It is passed inline as `user_data` on each BMI (max 64KB; PoC measured 15KB). The `user_data` field is immutable (enforced by the proto `IMMUTABLE` field behavior annotation). The InfraEnv uses late binding (no `clusterRef`) — agents register as unbound and are explicitly bound by the controller after MAC correlation. Agent-to-cluster isolation is enforced by the MAC correlation scoping, not by the ignition content.
 
 No changes to authentication or authorization flows are required. The existing OPA policies enforce tenant isolation for all public API access. The osac-operator authenticates to the private API using a token file mounted from a Kubernetes Secret (`OSAC_FULFILLMENT_TOKEN_FILE`), following the same pattern used by the existing feedback controllers for Signal RPCs.
 
@@ -450,14 +463,14 @@ The private API token (`OSAC_FULFILLMENT_TOKEN_FILE`) authenticates as `service-
 
 | Failure Mode | What Happens | Recovery | Tenant Observes |
 |---|---|---|---|
-| Shared InfraEnv missing or not ready | Controller sets `InfraEnvReady=False`, requeues | Cloud Provider Admin must ensure InfraEnv exists in `hardware-inventory` namespace | Cluster stuck in `PROGRESSING` with `WORKER_PROVISIONING_BLOCKED` condition |
+| InfraEnv creation fails | Controller retries on next reconciliation cycle (controller-runtime requeue) | Automatic retry with exponential backoff | Cluster stuck in `PROGRESSING` with `WORKER_PROVISIONING_BLOCKED` condition |
 | InfraEnv ignition not generated | Controller polls InfraEnv status with 30s requeue | Automatic; investigate assisted-service if persistent | Same as above |
 | BMI creation fails (private API error) | Worker phase set to `Failed`, `attemptCount` incremented | Controller deletes the failed BMI and retries with escalating backoff (capped at 5m). Retries indefinitely | Cluster shows `WORKER_PROVISIONING_FAILED` with attempt count |
-| BMI provisioning fails (host allocation or Ironic error) | BMI enters `Failed` phase, worker phase set to `Failed` | Controller deletes the failed BMI and retries with escalating backoff. Each attempt allocates a fresh host | Cluster shows degraded worker count during retries |
+| BMI provisioning fails (host allocation or backend error) | BMI enters `Failed` phase, worker phase set to `Failed` | Controller deletes the failed BMI and retries with escalating backoff. Each attempt allocates a fresh host | Cluster shows degraded worker count during retries |
 | Agent does not register within timeout | Worker phase set to `Failed`, reason `AgentRegistrationTimeout` | Controller deletes the timed-out BMI and retries with escalating backoff (capped at 30m) | Cluster shows `WORKER_PROVISIONING_FAILED` |
 | MAC correlation finds no match | Agent remains uncorrelated | Controller logs a warning and continues watching. If all BMIs are correlated and extra agents exist, they are ignored | No direct tenant impact |
 | Agent binding to NodePool fails | Agent not installed as worker | assisted-service reports failure in Agent conditions; controller reflects in worker phase | Cluster shows degraded worker count |
-| Scale-down: Agent unbinding times out | Agent stuck in `unbinding-pending-user-action` longer than 30 minutes | Worker remains in `Unbinding` phase with `lastFailureReason: AgentUnbindingTimeout`. Controller retries periodically. Manual intervention required to investigate Ironic deprovision failure. No replacement is triggered | Node count mismatch visible in Cluster status |
+| Scale-down: Agent unbinding times out | Agent stuck in unbound state longer than 30 minutes | Worker remains in `Unbinding` phase with `lastFailureReason: AgentUnbindingTimeout`. Controller retries periodically. Manual intervention required. No replacement is triggered | Node count mismatch visible in Cluster status |
 | BMI deletion fails | BMI stuck in `Deleting` (e.g., AAP deprovision job fails with `blockDeletionOnFailure: true`) | Controller retries delete periodically. Alerting notifies operators | Scale-down appears incomplete in Cluster status |
 | Controller restart mid-reconciliation | Controller resumes from current state on restart | Idempotent reconciliation logic rebuilds in-memory state from CRD status and re-queries BMI/Agent state | Temporary stall, no data loss |
 
@@ -485,7 +498,7 @@ Per-ClusterOrder metrics would create unbounded label cardinality at scale. Metr
 
 | Event | Type | Reason | When |
 |---|---|---|---|
-| InfraEnv verified | Normal | `InfraEnvReady` | Shared InfraEnv found and ignition available |
+| InfraEnv created | Normal | `InfraEnvCreated` | Controller creates the InfraEnv CR |
 | Worker created | Normal | `WorkerCreated` | Controller creates a worker resource via private API |
 | Agent correlated | Normal | `AgentCorrelated` | MAC match found between Agent and worker resource |
 | Worker joined | Normal | `WorkerReady` | Worker installed as cluster node |
@@ -501,7 +514,7 @@ Per-ClusterOrder metrics would create unbounded label cardinality at scale. Metr
 | MAC address dependency (OSAC-2308/OSAC-3254) not delivered before this feature | Agent-to-BMI correlation impossible; entire feature blocked | Feature gated on this dependency. No partial implementation without MAC correlation. |
 | DiskImage dependency (OSAC-2540/OSAC-1270) not delivered before this feature | Controller cannot resolve RHCOS boot image via DiskImage; BMI creation blocked | Feature gated on this dependency. Cloud Infrastructure Admin must register RHCOS DiskImages before CaaS bare-metal provisioning is enabled. |
 | RHCOS DiskImage not registered for target OCP version | Controller cannot resolve boot image; BMI creation blocked with `RHCOSImageNotFound` condition | Cloud Infrastructure Admin must register DiskImages for each supported OCP version before enabling CaaS provisioning. Alert on `RHCOSImageNotFound` condition. |
-| Ironic deprovision failure leaves hosts in limbo during scale-down | Hosts are not cleaned up; potential data leakage if reassigned | Controller sets a 30-minute timeout for unbinding. Operators alerted via `WorkerFailed` event. Manual intervention documented in support procedures. |
+| BMaaS deprovision failure leaves hosts in limbo during scale-down | Hosts are not cleaned up; potential data leakage if reassigned | Controller sets a 30-minute timeout for unbinding. Operators alerted via `WorkerFailed` event. Manual intervention documented in support procedures. |
 | Discovery ignition exceeds `bareMetalInstanceUserDataMaxBytes` (64KB) | BMI creation rejected | PoC measured 15KB. The controller emits a `DiscoveryIgnitionSizeWarning` event when the fetched ignition exceeds 48KB (75% of the 64KB limit), giving operators advance notice before BMI creation starts failing. |
 | Concurrent scale operations on multiple clusters exhaust host inventory | Multiple ClusterOrders compete for limited hosts; some fail | BMI creation fails, worker enters `Failed` phase. ClusterOrder status reflects partial provisioning. Inventory sizing is the admin's responsibility. |
 
@@ -509,7 +522,7 @@ Per-ClusterOrder metrics would create unbounded label cardinality at scale. Metr
 
 This design tightly couples the osac-operator to the fulfillment-service private API for BMI lifecycle management. The controller becomes a gRPC client of the fulfillment-service, adding a synchronous dependency in the reconciliation path. If the fulfillment-service is unavailable, worker provisioning and deprovisioning stall. The alternative — creating BMI CRs directly on the hub cluster — would avoid this dependency but lose the audit trail and system tenant isolation that the fulfillment-service provides. The coupling is justified because the private API is the canonical path for all BMI operations, and the fulfillment-service is a core dependency that the osac-operator already communicates with for Signal RPCs and other operations.
 
-The shared InfraEnv means Agents are not auto-scoped to a cluster, so MAC-based correlation could theoretically match an Agent to a BMI from a different cluster if two BMIs on the same VLAN share a MAC. The three-dimension scoping (namespace, ownership label, MAC match) described in the MAC Address Correlation section prevents this — each controller only considers BMIs owned by its own ClusterOrder, making cross-cluster misassignment impossible even with shared infrastructure.
+The per-cluster InfraEnv provides pull secret isolation. Late binding (no `clusterRef`) means agents register as unbound and the controller explicitly binds them after MAC correlation. MAC-based correlation is needed both for Agent-to-BMI mapping (scale-down cleanup, failure tracking) and for cluster binding (`clusterDeploymentName` setting).
 
 ## Alternatives (Not Implemented)
 
@@ -533,7 +546,7 @@ Replace the controller-based flow with a new AAP role that calls the private API
 - ClusterOrder controller: `reconcileWorkers` calls `BareMetalInstances.Delete` for excess BMIs when desired count is less than current count.
 - ClusterOrder controller: `correlateAgents` matches an Agent to a BMI when their MAC addresses match.
 - ClusterOrder controller: `correlateAgents` does not match Agents from a different namespace.
-- ClusterOrder controller: `ensureInfraEnv` verifies the shared platform-level InfraEnv exists and has generated ignition.
+- ClusterOrder controller: `ensureInfraEnv` creates an InfraEnv with late binding (no `clusterRef`) and correct owner reference.
 - ClusterOrder controller: worker phase transitions correctly through `Provisioning` → `WaitingForAgent` → `Binding` → `Ready`.
 - ClusterOrder controller: worker phase transitions to `Failed` after agent registration timeout.
 - ClusterOrder controller: reconciliation is idempotent — re-running with the same state produces no new API calls.
@@ -543,10 +556,10 @@ Replace the controller-based flow with a new AAP role that calls the private API
 
 ### Integration Tests
 
-- Create a ClusterOrder with bare-metal node requests in a kind cluster with a pre-existing shared InfraEnv. Verify BMI creation calls reach the fulfillment-service (mocked private API). Verify ClusterOrder status reflects `workers` entries.
+- Create a ClusterOrder with bare-metal node requests in a kind cluster. Verify InfraEnv CR is created with correct spec. Verify BMI creation calls reach the fulfillment-service (mocked private API). Verify ClusterOrder status reflects `workers` entries.
 - Simulate Agent registration by creating Agent CRs with matching MAC addresses. Verify correlation and labeling.
 - Simulate scale-down by decreasing `nodeRequests`. Verify NodePool replicas decrease and BMI delete is called for the excess workers.
-- Verify ClusterOrder deletion cleans up all BMIs before removing the finalizer (shared InfraEnv is not deleted).
+- Verify ClusterOrder deletion cleans up all BMIs and the InfraEnv before removing the finalizer.
 
 ### E2E Tests
 
@@ -575,8 +588,9 @@ The BareMetalPool-based pre-boot pool is removed immediately — there is no coe
 
 Downgrade requires:
 1. Scale down all bare-metal workers on affected clusters (the controller manages cleanup).
-2. Re-deploy the `cluster_infra` AAP step and scheduled `osac-import-agents` job for BareMetalPool management.
-3. Revert the osac-operator to the previous version.
+2. Delete any InfraEnv CRs created by the controller.
+3. Re-deploy the `cluster_infra` AAP step and scheduled `osac-import-agents` job for BareMetalPool management.
+4. Revert the osac-operator to the previous version.
 
 The ClusterOrder CRD gains a new status field (`workers`). On downgrade, the older controller ignores this field. No data migration is needed because the field is status-only (the controller rebuilds it from live state on startup).
 
@@ -591,8 +605,8 @@ CaaS-managed BMIs are assigned to the builtin `system` tenant, which already exi
 **Detecting failures:**
 - ClusterOrder stuck in `Progressing` with condition `WorkersFailed`: check `status.workers[]` for the referenced BMI names, then inspect each via the private API (`osac get baremetalinstances <name> --private`) for provisioning job errors and state.
 - Alert: `osac_clusterorder_workers_failed > 0` sustained for 15 minutes.
-- Agent registration timeout: check InfraEnv status for ignition generation errors. Verify RHCOS image URL is reachable from Ironic. Check BMI status for host allocation failures.
-- Scale-down stall: Agent stuck in `unbinding-pending-user-action` — investigate Ironic deprovision status via `oc get bmh` in the cluster namespace. Check Ironic logs for deprovision errors.
+- Agent registration timeout: check InfraEnv status for ignition generation errors. Verify DiskImage is reachable. Check BMI status for host allocation failures.
+- Scale-down stall: Agent stuck in unbound state — check BMI status via the private API for deprovision errors. Investigate the BMaaS backend if the BMI remains in `Deleting`.
 
 **Disabling the feature:**
 - Set the cluster template to exclude bare-metal resource classes. Existing clusters with bare-metal workers continue running — the controller does not deprovision workers unless instructed (scale-down or delete).

--- a/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
+++ b/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
@@ -128,7 +128,7 @@ This design replaces `HostType` with `BareMetalInstanceType` and the static agen
      --description "Standard bare-metal node: 64-core x86_64, 512 GiB RAM, 100GbE fabric"
    ```
 
-   Cloud Infrastructure Admins must also label inventory hosts to match — via the backend's native mechanism (Metal3 BareMetalHost labels, OpenStack Ironic node metadata). OSAC does not validate label consistency at type-creation time.
+   Cloud Infrastructure Admins must also label inventory hosts to match — via whatever host-labeling mechanism the BMaaS backend exposes. This is a BMaaS/backend concern; CaaS does not assume a specific backend and OSAC does not validate label consistency at type-creation time.
 
 4. **Ensure the assisted image service is disabled** (deployment prerequisite — see Assisted Image Service section).
 
@@ -285,7 +285,7 @@ This diagram shows the scale-down flow. CAPI handles node drain and agent unbind
 
 #### Cluster Deletion
 
-On ClusterOrder deletion, the worker reconciler does not need to explicitly orchestrate scale-down. Deleting the HostedCluster cascades through HyperShift (deletes all NodePools) → CAPI (drains nodes, deletes Machines) → CAPA (unbinds Agents). The worker reconciler reacts to Agents entering `unbinding-pending-user-action` and cleans up Agent CRs and BMIs through the normal scale-down watch (steps 5-8). The ClusterOrder's finalizer holds until all `status.workers[]` entries are cleaned up. The InfraEnv CR is garbage collected via its ownerReference to the ClusterOrder.
+On ClusterOrder deletion, deleting the HostedCluster cascades through HyperShift (deletes all NodePools) → CAPI (drains nodes, deletes Machines) → CAPA (unbinds Agents), which cleans up the Kubernetes-side objects and the Agent CRs. The cascade does **not** delete the BMIs — the fulfillment-service BareMetalInstances are unknown to HyperShift. The ClusterOrder finalizer therefore actively deletes every BMI listed in `status.workers[]` via `BareMetalInstances.Delete`, rather than reacting to per-Agent unbind events as the scale-down flow does. The finalizer holds until all `status.workers[]` entries are confirmed deleted. The InfraEnv CR is garbage collected via its ownerReference to the ClusterOrder.
 
 ### API Extensions
 
@@ -559,7 +559,9 @@ message BareMetalInstanceImage {
 }
 ```
 
-The system-owned catalog item is a deployment prerequisite — created during OSAC installation with unlocked parameters so the CaaS controller can set image, user_data, and network_attachments freely. The `BareMetalInstanceType` referenced in the `ClusterNodeSet` determines which host hardware profile is allocated by BMaaS.
+The system-owned catalog item is created automatically, not by an admin. Because CaaS bare-metal provisioning is only usable once (a) CaaS is deployed, (b) a BMaaS backend is integrated, and (c) at least one `BareMetalInstanceType` is registered, the catalog item is seeded by the same automation that enables the CaaS-on-bare-metal integration — not by the base OSAC install (which may run without BMaaS). Concretely, the osac-installer creates it as a `system`-tenant `BareMetalInstanceCatalogItem` with all provisioning parameters unlocked when the bare-metal integration is enabled; the CaaS controller then reconciles against it (creating it if missing) so a fresh deployment is self-healing rather than dependent on install ordering. The item carries unlocked parameters so the controller can set image, user_data, and network_attachments freely. The `BareMetalInstanceType` referenced in the `ClusterNodeSet` — not this catalog item — determines which host hardware profile BMaaS allocates.
+
+Open item: whether the seed lives in the installer chart or is reconciled entirely by the controller is an implementation choice; either way the contract is that no human creates this item, and it does not exist until a `BareMetalInstanceType` is available to reference.
 
 **gRPC call behavior:** This controller is the first in osac-operator to call `Create` and `Delete` on the fulfillment-service private API (existing controllers only call `Signal`). All gRPC calls use a context deadline of 30 seconds. On persistent failure (3 consecutive errors), the controller sets a `FulfillmentServiceUnavailable` condition on the ClusterOrder and backs off to 5-minute requeue intervals. The controller-runtime requeue provides the retry loop; the deadline prevents a hung fulfillment-service from blocking the controller goroutine.
 

--- a/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
+++ b/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
@@ -3,7 +3,7 @@ title: caas-bare-metal-worker-provisioning
 authors:
   - rpiccoli@redhat.com
 creation-date: 2026-08-06
-last-updated: 2026-08-07
+last-updated: 2026-08-14
 tracking-link:
   - https://redhat.atlassian.net/browse/OSAC-2135
 prd:
@@ -12,6 +12,8 @@ see-also:
   - "/enhancements/OSAC-2540-disk-image"
   - "/enhancements/OSAC-1201-baremetal-instance-types"
   - "/enhancements/OSAC-1330-type-safe-resource-references"
+  - "/enhancements/OSAC-1436-caas-networking"
+  - "/enhancements/OSAC-1589-vm-worker-caas"
 replaces:
   - N/A
 superseded-by:
@@ -50,6 +52,8 @@ The new approach eliminates the pool by provisioning workers on-demand. When a C
 
 A new `BareMetalWorkerReconciler` in osac-operator watches `ClusterOrder` CRs for bare-metal worker management. When a ClusterOrder's `nodeRequests` reference bare-metal resource classes, the controller:
 
+> **Terminology note:** `node_sets` (proto, on `ClusterSpec`) maps to `nodeRequests` (CRD, on `ClusterOrderSpec`) via the fulfillment-service Cluster controller. The `BareMetalWorkerReconciler` reads `nodeRequests` from the ClusterOrder CRD.
+
 1. Creates a cluster-specific `InfraEnv` CR on the hub cluster to generate discovery ignition.
 2. Fetches discovery ignition from the InfraEnv and creates `BareMetalInstance` objects with the ignition passed inline as `user_data`, referencing the RHCOS DiskImage.
 3. Correlates registered Agents to BMIs via MAC address and labels them for NodePool selection.
@@ -62,23 +66,119 @@ No new CRDs are introduced. The design extends the ClusterOrder CRD status with 
 |-----------|------|----------------------|
 | MAC address in BareMetalInstance status | [OSAC-2308](https://redhat.atlassian.net/browse/OSAC-2308), [OSAC-3254](https://redhat.atlassian.net/browse/OSAC-3254) | Agent-to-BMI correlation impossible; entire feature blocked |
 | DiskImage resource + BMI DiskImage integration | [OSAC-2540](https://redhat.atlassian.net/browse/OSAC-2540), [OSAC-1270](https://redhat.atlassian.net/browse/OSAC-1270) | Controller cannot resolve RHCOS boot image; BMI creation blocked |
+| Type-safe resource references | [OSAC-1330](https://redhat.atlassian.net/browse/OSAC-1330) | `DiskImageReference` on `ClusterVersionSpec` requires the typed reference pattern; without it, `disk_image` is a plain string with no reference validation or deletion protection |
 | BMaaS networking for subnet attachment | [OSAC-1437](https://redhat.atlassian.net/browse/OSAC-1437) | BMI creation requires `network_attachments`; without BMaaS subnet support, workers cannot be moved to the tenant subnet and will not receive DHCP-assigned IPs on the correct network |
 
 The existing BareMetalPool-based static pre-boot pool is removed as part of this work. The `cluster_infra` AAP step that creates BareMetalPool CRs and the scheduled `osac-import-agents` AAP job that discovers and imports hosts are no longer used by CaaS. Any remaining BareMetalPool resources are drained and cleaned up during rollout. The BareMetalPool CRD itself is retained (it serves BMaaS standalone use cases) but CaaS no longer creates or references BareMetalPool resources.
 
 ### Workflow Description
 
-**Actors:** Cloud Infrastructure Admin (registers RHCOS DiskImages per OCP version), Tenant User (creates/scales clusters), osac-operator controller (orchestrates), fulfillment-service (BMI lifecycle), assisted-service (agent discovery), HyperShift (cluster management).
+#### Changes Overview
+
+This design replaces `HostType` with `BareMetalInstanceType` and the static agent pool with on-demand BMI provisioning. The key changes per component:
+
+| Component | Before | After |
+|---|---|---|
+| **ClusterNodeSet (proto)** | `host_type: HostTypeReference` | `baremetal_instance_type: BareMetalInstanceTypeReference` |
+| **NodeRequest (CRD)** | `ResourceClass string` (opaque) | `BareMetalInstanceType string` (explicit) |
+| **ClusterCatalogItem** | `host_type: "acme_1tb"` in template YAML | `baremetalInstanceType: "bm-standard"` in template YAML |
+| **ClusterVersionSpec (proto)** | No DiskImage reference | `disk_image: DiskImageReference` (owned by this design) |
+| **BMI Create call** | No `instance_type` field | `instance_type = 20` set by controller |
+| **Interface resolution** | HostType.interfaces[].role=fabric | BareMetalInstanceType.network_ports[].role=fabric |
+| **Network attachment source** | Cluster proto via private API callback | ClusterOrder CRD `networkAttachments[0]` (ClusterNetworkAttachment) |
+| **Host selection** | HostType → Template → CatalogItem reverse lookup | BareMetalInstanceType.host_label_selector (direct, OSAC-1201) |
+| **Worker provisioning** | Static pre-boot pool + cron job + parking network | On-demand BMI creation via private API |
+| **Boot image** | Assisted image service ISO | RHCOS DiskImage (OCI artifact) linked to ClusterVersion |
+| **HostType resource** | Shared BM/VM concept, no hardware specs | Deprecated and decommissioned |
+
+#### Setup Flow (by persona)
+
+**Cloud Infrastructure Admin** — one-time platform setup:
+
+1. **Register RHCOS DiskImages** for each supported OCP version. CaaS boots bare-metal hosts with a RHCOS qcow2 image containing discovery ignition — unlike the old pool model which used ISOs from the assisted image service. Each DiskImage is an OCI artifact registered in the fulfillment-service (dependency: OSAC-2540, OSAC-1270).
+
+   ```bash
+   osac-admin create diskimage rhcos-4.18 \
+     --source-ref quay.io/osac/rhcos:4.18.0 \
+     --guest-os-family linux --architecture x86_64
+   ```
+
+2. **Link each DiskImage to its ClusterVersion** via the `disk_image` reference (this design adds `DiskImageReference` to `ClusterVersionSpec`). This is how the controller resolves which boot image to use — it reads the Cluster's ClusterVersion, follows the reference, and passes the DiskImage ID to the BMI Create call. Without this link, the controller sets `RHCOSImageNotFound` and does not create BMIs.
+
+   ```bash
+   osac-admin update clusterversion 4.18.0 --disk-image rhcos-4.18
+   ```
+
+3. **Register BareMetalInstanceTypes** defining available hardware profiles. This replaces `HostType`, which was opaque (no CPU/memory specs, no inventory matching). `BareMetalInstanceType` (OSAC-1201) carries full hardware specs AND a `host_label_selector` for direct inventory matching — no reverse lookup needed. The `network_ports` field is critical for CaaS: the controller reads it to resolve the fabric interface for each BMI's network attachment.
+
+   ```bash
+   # BEFORE — HostType (opaque, no hardware specs, no inventory matching)
+   osac-admin create hosttype acme_1tb \
+     --title "Acme 1TB Server" \
+     --interface name=data-0,role=fabric \
+     --interface name=mgmt-0,role=management
+
+   # AFTER — BareMetalInstanceType (rich hardware specs + inventory matching)
+   osac-admin create baremetalinstancetype bm-standard \
+     --hardware-cpu-cores 64 --hardware-cpu-arch x86_64 \
+     --hardware-memory-gb 512 \
+     --hardware-network-port name=data-0,role=fabric,type=Ethernet,speed=100Gbps \
+     --hardware-network-port name=mgmt-0,role=management,type=Ethernet,speed=1Gbps \
+     --host-label-selector profile=bm-standard \
+     --description "Standard bare-metal node: 64-core x86_64, 512 GiB RAM, 100GbE fabric"
+   ```
+
+   Cloud Infrastructure Admins must also label inventory hosts to match — via the backend's native mechanism (Metal3 BareMetalHost labels, OpenStack Ironic node metadata). OSAC does not validate label consistency at type-creation time.
+
+4. **Ensure the assisted image service is disabled** (deployment prerequisite — see Assisted Image Service section).
+
+**Cloud Provider Admin** — catalog and template configuration:
+
+1. Creates `ClusterVersion` entries (OCP version + release image pullspec), or they are seeded during installation.
+
+2. Creates `ClusterCatalogItem` (cluster templates) referencing `BareMetalInstanceType` instead of `HostType`:
+
+   ```yaml
+   # BEFORE — ocp-small/meta/osac.yaml (HostType reference)
+   default_node_request:
+     - resourceClass: acme_1tb          # opaque string → HostType name
+       numberOfNodes: 2
+
+   # AFTER — ocp-small/meta/osac.yaml (BareMetalInstanceType reference)
+   default_node_request:
+     - baremetalInstanceType: bm-standard  # explicit BareMetalInstanceType name
+       numberOfNodes: 2
+   ```
+
+   This flows through to the proto as `ClusterNodeSet.baremetal_instance_type` (replacing `ClusterNodeSet.host_type`) and to the CRD as `NodeRequest.BareMetalInstanceType` (replacing `NodeRequest.ResourceClass`).
+
+3. Creates the system-owned `BareMetalInstanceCatalogItem` — a pass-through with unlocked parameters so the CaaS controller can set image, user_data, and network_attachments freely (one-time deployment prerequisite):
+
+   ```bash
+   osac-admin create baremetalinstancecatalogitem caas-system-bmi --unlocked
+   ```
+
+4. Publishes templates to make them available to tenants.
+
+**Tenant User** — cluster lifecycle (unchanged before and after):
+
+```bash
+# Same CLI, same UX — before and after
+osac create cluster my-cluster --template ocp-small
+```
+
+The tenant never interacts with BareMetalInstanceTypes, DiskImages, InfraEnvs, or Agents — all CaaS-managed infrastructure is invisible via system tenant isolation. The template populates `node_sets` with the default `BareMetalInstanceType` and size.
 
 #### Provisioning Flow
 
-Starting state: a Tenant User creates a Cluster with `node_sets` referencing a bare-metal resource class (e.g., `bare-metal-standard`). The fulfillment-service Cluster controller creates a ClusterOrder CR on the hub cluster.
+Starting state: a Tenant User creates a Cluster selecting a template (e.g., `ocp-small`). The template populates `node_sets` with `baremetal_instance_type` references. The fulfillment-service Cluster controller creates a ClusterOrder CR on the hub cluster.
 
 ```mermaid
 sequenceDiagram
     participant T as Tenant User
     participant FS as fulfillment-service
     participant CO as ClusterOrder Controller
+    participant BMW as BareMetalWorkerReconciler
     participant AAP as AAP Provisioning
     participant BMaaS as BMaaS (Private API)
     participant AS as assisted-service
@@ -89,23 +189,23 @@ sequenceDiagram
 
     CO->>AAP: Trigger cluster provisioning job
     AAP->>HCP: Create HostedCluster + NodePool
-    HCP-->>CO: ClusterDeployment exists
+    HCP-->>BMW: ClusterDeployment exists
 
-    CO->>CO: Create InfraEnv CR (late binding, no clusterRef)
-    AS-->>CO: InfraEnv ready (discovery ignition available)
+    BMW->>BMW: Create InfraEnv CR (late binding, no clusterRef)
+    AS-->>BMW: InfraEnv ready (discovery ignition available)
 
     loop For each requested bare-metal worker
-        CO->>BMaaS: Create BareMetalInstance (qcow2 + ignition)
-        BMaaS-->>CO: BMI provisioned, MAC in status
+        BMW->>BMaaS: Create BareMetalInstance (qcow2 + ignition)
+        BMaaS-->>BMW: BMI provisioned, MAC in status
     end
 
     loop Agent registration
-        AS-->>CO: Agent registered (MAC in inventory)
-        CO->>CO: Correlate Agent to BMI via MAC
-        CO->>AS: Label Agent for NodePool
+        AS-->>BMW: Agent registered (MAC in inventory)
+        BMW->>BMW: Correlate Agent to BMI via MAC
+        BMW->>AS: Label Agent for NodePool
     end
 
-    HCP-->>CO: Workers joined, NodePool scaled
+    HCP-->>BMW: Workers joined, NodePool scaled
     CO->>FS: Signal Cluster (state=Ready)
 ```
 
@@ -113,14 +213,25 @@ The diagram shows the end-to-end provisioning flow. The controller waits for eac
 
 **Step-by-step:**
 
-1. The `BareMetalWorkerReconciler` identifies bare-metal node sets from `nodeRequests[]`. The `resourceClass` maps to a HostType; bare-metal HostTypes are distinguished by having physical network interfaces defined (per HostType proto convention).
+1. The `BareMetalWorkerReconciler` identifies bare-metal node sets from the Cluster's `node_sets` — any node set with a `baremetal_instance_type` reference (see ClusterNodeSet Redesign).
 2. After AAP creates the HostedCluster and the ClusterDeployment CR exists, the controller creates a cluster-specific `InfraEnv` CR (see InfraEnv Creation). The InfraEnv uses late binding (no `clusterRef`) — agents register as unbound and the controller explicitly binds them in step 8.
 3. The controller polls the InfraEnv status until `status.bootArtifacts.discoveryIgnitionURL` is populated, then fetches the discovery ignition content. The ignition is architecture-neutral (the `assisted-installer-agent` image is a multi-arch manifest).
-4. For each bare-metal worker requested, the controller calls `BareMetalInstances.Create` on the private API with: `spec.catalog_item` resolved from the ClusterTemplate's CaaS configuration (see Catalog Item Resolution), `spec.image` set to the resolved RHCOS DiskImage ID (see RHCOS DiskImage Resolution), `spec.user_data` set to the fetched ignition content inline (the `user_data` field accepts raw first-boot data up to 64KB; the PoC measured 15KB), `spec.network_attachments` built from the Cluster's `ClusterNetworkAttachment` (subnet + security groups) and the node set's HostType (fabric interface), and `metadata.tenant = "system"` (see System Tenant Isolation). The network attachment mapping is a pass-through: the controller reads the Cluster's `ClusterNetworkAttachment` for the subnet and security group references, resolves the fabric interface name from the node set's HostType definition (first interface with role `fabric`), and constructs a `BareMetalNetworkAttachment` with `primary: true`. BMaaS handles the physical networking — moving the host to the tenant subnet VLAN and assigning an IP via fabric DHCP — as part of BMI provisioning (dependency: OSAC-1437). If the host fails to join the tenant network, the agent will not register on the expected subnet, and the existing `AgentRegistrationTimeout` handles this failure mode. API and ingress VIPs are provisioned by the existing AAP template (MetalLB LoadBalancer Services) and are not managed by this controller.
+4. For each bare-metal worker requested, the controller assembles a `BareMetalInstances.Create` call on the private API from multiple sources:
+
+   | Field | Source | Purpose |
+   |---|---|---|
+   | `instance_type` | `nodeRequests[i].BareMetalInstanceType` | Hardware profile → host_label_selector → inventory match |
+   | `catalog_item` | System-owned pass-through | Required by private API; CaaS overrides all parameters |
+   | `image` | `ClusterVersion.disk_image` → DiskImage ID | RHCOS boot image for discovery agent |
+   | `user_data` | InfraEnv ignition (inline, ~15KB, max 64KB) | Discovery ignition to register with assisted-service |
+   | `network_attachments` | `networkAttachments[0]` + BareMetalInstanceType `network_ports` | Subnet from `ClusterNetworkAttachment`, interface from first `fabric` port, `primary: true` (see Network Attachment Enrichment) |
+   | `tenant` | Always `"system"` | Hides CaaS BMIs from tenant APIs (see System Tenant Isolation) |
+
+   BMaaS handles the physical networking — moving the host to the tenant subnet VLAN and assigning an IP via fabric DHCP — as part of BMI provisioning (dependency: OSAC-1437). If the host fails to join the tenant network, the agent will not register on the expected subnet, and the existing `AgentRegistrationTimeout` handles this failure mode. API and ingress VIPs are provisioned by the existing AAP template (MetalLB LoadBalancer Services) and are not managed by this controller.
 5. The controller updates ClusterOrder status with the BMI references in `workers[]`.
 6. BMaaS allocates a host, provisions it with the DiskImage and discovery ignition, and boots it. The host registers as an Agent with assisted-service.
 7. The controller watches Agent CRs in the cluster namespace. When a new Agent appears, the controller matches its inventory MAC address against BMI status MAC addresses (`status.host.mac_address`, dependency OSAC-2308/OSAC-3254).
-8. Once correlated, the controller sets the Agent's `clusterDeploymentName` to the cluster's ClusterDeployment and applies the `agentBareMetal` role label so the NodePool's `agentLabelSelector` selects it. Late binding (explicit `clusterDeploymentName` setting) gives the controller full control over the Agent lifecycle — on scale-down, CAPA clears `clusterDeploymentName`, triggering the unbind flow that CaaS reacts to. The osac-operator's RBAC must include `patch` on `agents` in the `agent-install.openshift.io` API group.
+8. Once correlated, the controller sets the Agent's `clusterDeploymentName` to the cluster's ClusterDeployment and applies the `agentBareMetal` role label so the NodePool's `agentLabelSelector` selects it. Late binding (explicit `clusterDeploymentName` setting) gives the controller full control over the Agent lifecycle — on scale-down, CAPA clears `clusterDeploymentName`, triggering the unbind flow that CaaS reacts to. The osac-operator's RBAC must include `get`, `list`, `watch`, `patch`, and `delete` on `agents` in the `agent-install.openshift.io` API group (see RBAC / Tenancy).
 9. HyperShift installs the Agent as a worker node. The controller monitors NodePool `.status.replicas` to confirm convergence.
 
 #### Scale-Up
@@ -130,7 +241,7 @@ A Tenant User increases `node_sets[].size` for a bare-metal node set. The fulfil
 **Step-by-step:**
 
 1. The controller computes `desired - current` where `current` is `status.currentWorkers` (workers in active phases: `Provisioning`, `WaitingForAgent`, `Binding`, `Ready`). Workers in `Failed` phase do not count toward capacity — new workers are created to fill the gap once their retry backoff expires.
-2. The controller re-reads the InfraEnv's `status.bootArtifacts.discoveryIgnitionURL` to fetch fresh ignition. The InfraEnv persists from initial provisioning; if it was deleted (e.g., manual cleanup), the `ensureInfraEnv` phase recreates it.
+2. The controller re-reads the InfraEnv's `status.bootArtifacts.discoveryIgnitionURL` to fetch fresh ignition. The InfraEnv persists from initial provisioning; if it was deleted (e.g., manual cleanup), the `ensureInfraEnv` phase recreates it. Note: if the InfraEnv is deleted while hosts are in `WaitingForAgent` phase (already booted with old ignition), those hosts have stale discovery data. The controller treats them as `AgentRegistrationTimeout` failures and deprovisions/reprovisions them with fresh ignition from the recreated InfraEnv.
 3. The controller resolves the RHCOS DiskImage from the cluster's current ClusterVersion's `disk_image` reference (see RHCOS DiskImage Resolution).
 4. For each new worker, the controller follows provisioning steps 4-9 from the initial flow (the ignition content is re-fetched in step 2 above).
 5. Partial success is reported: if 3 of 5 new workers succeed and 2 fail, the ClusterOrder status shows 3 additional `Ready` workers and 2 `Failed`. The tenant sees the cluster with the successfully added workers; the failed slots are visible via ClusterOrder conditions and events.
@@ -140,22 +251,23 @@ A Tenant User increases `node_sets[].size` for a bare-metal node set. The fulfil
 ```mermaid
 sequenceDiagram
     participant T as Tenant User
-    participant CO as ClusterOrder Controller
+    participant BMW as BareMetalWorkerReconciler
     participant HCP as HyperShift / CAPI
     participant AS as assisted-service
     participant BMaaS as BMaaS (Private API)
 
-    T->>CO: Decrease node count
-    CO->>HCP: Decrease NodePool replicas
+    T->>BMW: Decrease node count
+    BMW->>HCP: Decrease NodePool replicas
 
     HCP->>HCP: CAPI selects Machine, drains node
     HCP->>AS: AgentMachine unbinds Agent
-    AS-->>CO: Agent reaches unbound/terminal state
+    AS-->>BMW: Agent enters unbinding-pending-user-action
 
-    CO->>CO: Match unbound Agent to BMI via MAC
-    CO->>BMaaS: Delete BareMetalInstance
+    BMW->>BMW: Match Agent to BMI via MAC
+    BMW->>AS: Delete Agent CR
+    BMW->>BMaaS: Delete BareMetalInstance
     BMaaS->>BMaaS: Host cleanup
-    CO->>CO: Remove worker from status.workers (after BMI CR gone)
+    BMW->>BMW: Remove worker from status.workers (after BMI deletion confirmed)
 ```
 
 This diagram shows the scale-down flow. CAPI handles node drain and agent unbinding automatically. The controller reacts to the agent reaching an unbound state and then cleans up the BMI.
@@ -165,7 +277,7 @@ This diagram shows the scale-down flow. CAPI handles node drain and agent unbind
 1. The controller computes the excess worker count (current minus desired).
 2. The controller removes `Failed` workers first — deletes their dead BMIs and removes their `status.workers` entries. If more removals are needed after clearing all failed slots, the controller decreases NodePool `.spec.replicas` by the remaining excess.
 3. CAPI's MachineDeployment controller manages MachineSets, which select Machines for deletion. CaaS delegates Machine selection order to CAPI's default behavior (random) — no preference for newest-first or oldest-first. This is a deliberate design choice: bare-metal workers are fungible, and controlling selection order would require CAPI-level configuration (e.g., `MachineDeployment.spec.strategy`) that is not needed for this use case.
-4. CAPI drains each selected node, then the AgentMachine controller unbinds the Agent (clears `ClusterDeploymentName`). With the assisted image service disabled (see deployment prerequisites), reclaim is not attempted and the Agent transitions directly to `unbinding-pending-user-action`. CAPA removes its hook/finalizer at this point.
+4. CAPI drains each selected node, then the AgentMachine controller unbinds the Agent (clears `ClusterDeploymentName`). With the assisted image service disabled (see Assisted Image Service), reclaim is not attempted and the Agent transitions directly to `unbinding-pending-user-action`. CAPA removes its hook/finalizer at this point.
 5. The controller watches for Agents entering `unbinding-pending-user-action` and matches them back to BMIs via MAC address.
 6. The controller deletes the Agent CR. CAPA does not delete the Agent — it only clears `ClusterDeploymentName` and removes its own hook/finalizer. CaaS owns the Agent CR cleanup because the host will be deprovisioned by BMaaS.
 7. The controller calls `BareMetalInstances.Delete` on the private API. BMaaS handles full host cleanup before returning the host to inventory. CaaS does not independently verify cleanup completion — this is a trust boundary between CaaS and BMaaS. If BMaaS cleanup fails, the host must not be reallocated; this guarantee is BMaaS's responsibility.
@@ -173,13 +285,13 @@ This diagram shows the scale-down flow. CAPI handles node drain and agent unbind
 
 #### Cluster Deletion
 
-On ClusterOrder deletion, the worker reconciler does not need to explicitly orchestrate scale-down. Deleting the HostedCluster cascades through HyperShift (deletes all NodePools) → CAPI (drains nodes, deletes Machines) → CAPA (unbinds Agents). The worker reconciler reacts to Agents becoming unbound and cleans up BMIs and Agent CRs through the normal scale-down watch (steps 5-8). The ClusterOrder's finalizer holds until all `status.workers[]` entries are cleaned up. The InfraEnv CR is garbage collected via its ownerReference to the ClusterOrder.
+On ClusterOrder deletion, the worker reconciler does not need to explicitly orchestrate scale-down. Deleting the HostedCluster cascades through HyperShift (deletes all NodePools) → CAPI (drains nodes, deletes Machines) → CAPA (unbinds Agents). The worker reconciler reacts to Agents entering `unbinding-pending-user-action` and cleans up Agent CRs and BMIs through the normal scale-down watch (steps 5-8). The ClusterOrder's finalizer holds until all `status.workers[]` entries are cleaned up. The InfraEnv CR is garbage collected via its ownerReference to the ClusterOrder.
 
 ### API Extensions
 
 **Modified CRDs:**
 
-- `ClusterOrder` (osac-operator): new `workers` status field for tracking CaaS-managed worker resources. No spec changes — `nodeRequests[].resourceClass` already carries the information needed to identify bare-metal node sets.
+- `ClusterOrder` (osac-operator): new `workers` status field and aggregate counts (`desiredWorkers`, `currentWorkers`, `readyWorkers`) for tracking CaaS-managed worker resources. The `nodeRequests` element type (`NodeRequest`) is redesigned to carry the `BareMetalInstanceType` reference (see ClusterNodeSet Redesign). The `networkAttachments` field (plural `[]ClusterNetworkAttachment`, defined by OSAC-1436 and OSAC-1589) carries the tenant subnet reference — the `BareMetalWorkerReconciler` reads `networkAttachments[0]` from the ClusterOrder spec to build per-BMI `BareMetalNetworkAttachment` objects (see Network Attachment Enrichment below).
 
 **New CRs created at runtime (not new CRD definitions):**
 
@@ -195,13 +307,34 @@ On ClusterOrder deletion, the worker reconciler does not need to explicitly orch
 - Workers in `Failed` with high attempt count → Cluster condition message includes the attempt count and next retry time, so tenants know retries are ongoing
 - All other conditions (`InfraEnvReady=False`, `RHCOSImageNotFound`) → mapped to a generic `WORKER_PROVISIONING_BLOCKED` condition on the Cluster, indicating the cluster cannot provision workers due to an infrastructure issue requiring Cloud Infrastructure Admin intervention
 
-This ensures tenants see provisioning progress and actionable failure messages without exposure to CaaS internals. The condition names and feedback controller extension must align with OSAC-1604 (status reporting improvements) to avoid overlap — this design defines CaaS-specific worker conditions, while OSAC-1604 defines the general status reporting framework.
+This ensures tenants see provisioning progress and actionable failure messages without exposure to CaaS internals. The condition names and feedback controller extension must align with [OSAC-1604](https://redhat.atlassian.net/browse/OSAC-1604) (status reporting improvements) to avoid overlap — this design defines CaaS-specific worker conditions, while OSAC-1604 defines the general status reporting framework. Coordination tracked via Jira link.
 
 **Operational impact:** If the osac-operator is down, no new bare-metal workers are provisioned and scale-up/scale-down operations stall. Existing workers continue running — HyperShift manages the cluster independently. On restart, the controller reconciles current state and resumes any pending operations.
 
 ## UX Alignment
 
-This section does not apply. No UI changes are required — CaaS-managed BMIs are hidden from tenant-facing views.
+CaaS-managed BMIs are hidden from tenant-facing views — no tenant UI changes are required. However, the BareMetalPool removal and assisted image service disablement affect the **Cloud Infrastructure Admin** installation and configuration flow, which surfaces through Enclave.
+
+### Installer / Enclave Impact
+
+The following `osac-installer` Helm values and Enclave Wizard controls are affected:
+
+| Helm value | Current purpose | Impact |
+|---|---|---|
+| `aap.configAsCode.importAgentsEnabled` | Enables the `osac-import-agents` scheduled AAP job that discovers and imports bare-metal hosts into the pre-boot pool | **Remove or deprecate** — CaaS no longer uses a pre-boot pool; agents are created on-demand via BMI provisioning. BMaaS standalone may still use this for its own inventory import, so removal must be coordinated. |
+| `aap.configAsCode.importBcmAgentsEnabled` | Enables BCM inventory backend for agent import | Same as above — tied to the pool model |
+| `aap.importAgents` | Server inventory list for BareMetalHost CR provisioning (BMC addresses, credentials) | **Retained for BMaaS** — bare-metal host inventory registration is still needed. CaaS no longer consumes it for pool creation, but BMaaS uses it for standalone BareMetalInstance provisioning. |
+| `aap.configAsCode.env.IMPORT_AGENTS_NAMESPACE` | Namespace for BareMetalHost, Agent, and InfraEnv CRs (default: `hardware-inventory`) | **Still needed** — the `hardware-inventory` namespace hosts inventory resources. CaaS creates per-cluster InfraEnvs in cluster namespaces, not here. |
+| `aap.configAsCode.env.IMPORT_AGENTS_INFRAENV_NAME` | Shared InfraEnv CR name for agent discovery | **Remove for CaaS** — CaaS creates per-cluster InfraEnvs. BMaaS standalone may still use a shared InfraEnv for its own inventory. |
+
+**Enclave Wizard changes:**
+- The Wizard's CaaS configuration panel (if it exposes `importAgentsEnabled` or pool-related settings) must be updated to remove or disable pool configuration for CaaS deployments.
+- New prerequisite: the assisted image service must be disabled. If Enclave controls this setting, it must default to disabled for CaaS deployments.
+- New prerequisite: DiskImage registration and ClusterVersion linking. The Wizard should guide the Cloud Infrastructure Admin through registering RHCOS DiskImages and linking them to ClusterVersions (see Setup Flow, Cloud Infrastructure Admin steps 1-2).
+
+**AAP template changes:**
+- `playbook_osac_create_bare_metal_pool.yml` and `playbook_osac_delete_bare_metal_pool.yml` are no longer invoked by CaaS. They may be retained for BMaaS standalone use or removed if BareMetalPool is fully deprecated.
+- The `cluster_infra` step collections (`agentless_net.steps`, `ci.steps`, `nico.steps`) are no longer dispatched for CaaS provisioning — the BareMetalWorkerReconciler replaces their functionality.
 
 ### Implementation Details/Notes/Constraints
 
@@ -225,9 +358,12 @@ type ClusterOrderStatus struct {
 }
 
 type WorkerStatus struct {
+    // NodeSet identifies which node set this worker belongs to (e.g., "compute", "gpu").
+    // Used to partition workers for independent per-node-set scaling.
+    NodeSet string `json:"nodeSet"`
     // Name of the worker slot (e.g., "bm-cluster-a-worker-0").
     Name string `json:"name"`
-    // Kind of the backing resource (BareMetalInstance or ComputeInstance).
+    // Kind of the backing resource (BareMetalInstance).
     Kind string `json:"kind"`
     // ResourceID is the fulfillment-service resource ID.
     ResourceID string `json:"resourceID,omitempty"`
@@ -272,17 +408,20 @@ status:
     - type: InfraEnvReady
       status: "True"
   workers:
-    - name: bm-cluster-a-worker-0
+    - nodeSet: compute
+      name: bm-cluster-a-worker-0
       kind: BareMetalInstance
       resourceID: "uuid-0"
       phase: Ready
       attemptCount: 1
-    - name: bm-cluster-a-worker-1
+    - nodeSet: compute
+      name: bm-cluster-a-worker-1
       kind: BareMetalInstance
       resourceID: "uuid-1"
       phase: Ready
       attemptCount: 1
-    - name: bm-cluster-a-worker-2
+    - nodeSet: compute
+      name: bm-cluster-a-worker-2
       kind: BareMetalInstance
       resourceID: "uuid-2"
       phase: Failed
@@ -291,12 +430,14 @@ status:
       lastFailureMessage: "Agent did not register within 30m"
       lastFailureTime: "2026-08-10T14:30:00Z"
       nextRetryTime: "2026-08-10T15:00:00Z"
-    - name: bm-cluster-a-worker-3
+    - nodeSet: gpu
+      name: bm-cluster-a-worker-3
       kind: BareMetalInstance
       resourceID: "uuid-3"
       phase: Ready
       attemptCount: 1
-    - name: bm-cluster-a-worker-4
+    - nodeSet: gpu
+      name: bm-cluster-a-worker-4
       kind: BareMetalInstance
       resourceID: "uuid-4"
       phase: Failed
@@ -347,7 +488,7 @@ spec:
   sshAuthorizedKey: <from ClusterOrder spec>
 ```
 
-The InfraEnv uses **late binding** — no `clusterRef`. Agents register as unbound and the controller explicitly binds them by setting `clusterDeploymentName` after MAC correlation. This gives the controller full control over the Agent binding lifecycle: on scale-down, CAPA clears `clusterDeploymentName`, the Agent enters `unbinding-pending-user-action`, and the controller reacts by deleting the BMI. CAPI handles node drain and Node object deletion independently — the pre-terminate hook clears as soon as the Agent reaches `unbinding-pending-user-action`, so node removal does not depend on the host rebooting into discovery.
+The InfraEnv uses **late binding** — no `clusterRef`. Agents register as unbound and the controller explicitly binds them by setting `clusterDeploymentName` after MAC correlation. This gives the controller full control over the Agent binding lifecycle: on scale-down, CAPA clears `clusterDeploymentName`, the Agent enters `unbinding-pending-user-action`, and the controller reacts by deleting the Agent CR and then the BMI. CAPI handles node drain and Node object deletion independently — the pre-terminate hook clears as soon as the Agent reaches `unbinding-pending-user-action`, so node removal does not depend on the host rebooting into discovery.
 
 One InfraEnv per cluster provides pull secret isolation (each cluster's InfraEnv carries the cluster-specific pull secret) and supports future static networking (per-host NMStateConfig is InfraEnv-scoped). Agent-to-cluster isolation is enforced by the MAC correlation algorithm (see MAC Address Correlation), which scopes matching to BMIs owned by the current ClusterOrder.
 
@@ -357,7 +498,9 @@ The discovery ignition is architecture-neutral (the `assisted-installer-agent` i
 
 #### RHCOS DiskImage Resolution
 
-The controller resolves the RHCOS boot image via a `DiskImageReference` on the `ClusterVersion` resource (dependency: OSAC-2540 DiskImage, OSAC-1270 BMI DiskImage integration, OSAC-1330 type-safe references). The private `ClusterVersionSpec` gains a new field:
+The controller resolves the RHCOS boot image via a `DiskImageReference` on the `ClusterVersion` resource. **This design owns the `disk_image` field on `ClusterVersionSpec`** — it is not covered by OSAC-2540 (which adds DiskImage to ComputeInstance only) or OSAC-1270 (which adds DiskImage to BareMetalInstance). The implementation requires OSAC-2540 for the DiskImage resource itself, OSAC-1270 for `source_type: "disk_image"` on `BareMetalInstanceImage`, and OSAC-1330 for the typed reference pattern.
+
+The private `ClusterVersionSpec` gains a new field:
 
 ```protobuf
 message ClusterVersionSpec {
@@ -367,6 +510,12 @@ message ClusterVersionSpec {
 ```
 
 The controller reads the cluster's current ClusterVersion, follows the `disk_image` reference to get the DiskImage ID, and passes it as `spec.image.source_ref` on the BMI. No label-based lookup, no ambiguity — each ClusterVersion references exactly one DiskImage. The typed reference (per OSAC-1330) provides reference validation at ClusterVersion creation time and deletion protection (the DiskImage cannot be deleted while referenced by an active ClusterVersion).
+
+**Cross-component changes introduced by this field:**
+- `ClusterVersionSpec` proto: add `DiskImageReference disk_image = 7` (private API only — tenants don't set this)
+- `ClusterVersionsServer`: extend `Update` to accept the `disk_image` field; extend `Create` to optionally set it
+- CLI: extend `osac create/update clusterversion` with `--disk-image <id>` flag
+- DiskImage deletion protection: extend OSAC-2540's DB trigger to check `cluster_versions` in addition to `compute_instances` — a DiskImage referenced by an active ClusterVersion must not be deletable
 
 The controller reads the cluster's **current** ClusterVersion reference, not the creation-time version. Note: until cluster upgrades are implemented, this is always the creation-time version. Once upgrades land, the Cluster's ClusterVersion reference will be updated by the upgrade flow — this is the most reasonable assumption but should be treated as a dependency since cluster upgrades are still at the PRD stage.
 
@@ -386,26 +535,33 @@ The CLI must support setting the `disk_image` reference on ClusterVersion — th
 
 **Future automation path:** The OCP release image (`ClusterVersion.spec.image`) contains the RHCOS image reference as a component (`rhel-coreos`). A future utility could introspect registered ClusterVersions, extract the RHCOS image reference from each release payload, and automatically create the DiskImage and set the `disk_image` reference on the ClusterVersion. This removes the manual coupling — adding a new ClusterVersion would automatically produce and link the matching DiskImage. Note: directly using the RHCOS OCI image from the release payload as the DiskImage `source_ref` is not possible today because OCP BMO does not support this image format (planned for OCP 5.1). Until then, the qcow2 repackaging step remains necessary.
 
+**Cluster upgrade path:** The `ClusterVersion → DiskImage` link is designed with upgrades in mind. When the cluster upgrade flow lands, the upgrade updates the Cluster's ClusterVersion reference (e.g., `4.18.0` → `4.19.0`). The controller detects the change, resolves the new ClusterVersion's `disk_image` reference (e.g., `rhcos-4.19`), and new workers provisioned during or after the upgrade boot with the updated image. Existing workers upgrade through the normal OCP upgrade path — they are not reprovisioned. This is why `disk_image` lives on `ClusterVersion` rather than on the Cluster or ClusterOrder: it naturally follows the version, so upgrading automatically selects the matching boot image.
+
 #### BMI Creation via Private API
 
-For each worker, the controller calls `BareMetalInstances.Create` on the private API. The existing `BareMetalInstanceSpec` proto already has the required fields. The `source_type` value `"disk_image"` on `BareMetalInstanceImage` is introduced by the DiskImage integration (OSAC-1270) — this design consumes it but does not own the proto change:
+For each worker, the controller calls `BareMetalInstances.Create` on the private API. The private API is unchanged — `spec.catalog_item` remains required. CaaS uses a **system-owned `BareMetalInstanceCatalogItem`** with most parameters unlocked, acting as a pass-through. The `BareMetalInstanceType` from the node set determines the hardware profile. The `source_type` value `"disk_image"` on `BareMetalInstanceImage` is introduced by the DiskImage integration (OSAC-1270) — this design consumes it but does not own the proto change:
 
 ```protobuf
 // Existing fields in osac.private.v1.BareMetalInstanceSpec used by CaaS
 // (field numbers omitted for clarity — see baremetal_instance_type.proto for canonical numbering):
 message BareMetalInstanceSpec {
-  string catalog_item = ...;                                // resolved from nodeRequest.resourceClass → BareMetalInstanceCatalogItem
-  optional BareMetalInstanceImage image = ...;              // RHCOS DiskImage reference (see DiskImage Resolution)
+  BareMetalInstanceCatalogItemReference catalog_item = ...; // system-owned catalog item (pass-through)
+  optional BareMetalInstanceImage image = ...;              // RHCOS DiskImage reference (see RHCOS DiskImage Resolution)
   optional string user_data = ...;                          // inline discovery ignition content (max 64KB)
   repeated BareMetalNetworkAttachment network_attachments = ...;
+  string instance_type = 20;                                // BareMetalInstanceType name from ClusterNodeSet (OSAC-1201)
   // ... other existing fields (ssh_public_key, run_strategy, template_parameters, etc.) omitted
 }
 
 message BareMetalInstanceImage {
   string source_type = ...;  // existing value "registry"; "disk_image" added by OSAC-1270
-  string source_ref = ...;   // DiskImage ID resolved for target OCP version + architecture
+  string source_ref = ...;   // DiskImage ID from ClusterVersion.spec.disk_image reference
 }
 ```
+
+The system-owned catalog item is a deployment prerequisite — created during OSAC installation with unlocked parameters so the CaaS controller can set image, user_data, and network_attachments freely. The `BareMetalInstanceType` referenced in the `ClusterNodeSet` determines which host hardware profile is allocated by BMaaS.
+
+**gRPC call behavior:** This controller is the first in osac-operator to call `Create` and `Delete` on the fulfillment-service private API (existing controllers only call `Signal`). All gRPC calls use a context deadline of 30 seconds. On persistent failure (3 consecutive errors), the controller sets a `FulfillmentServiceUnavailable` condition on the ClusterOrder and backs off to 5-minute requeue intervals. The controller-runtime requeue provides the retry loop; the deadline prevents a hung fulfillment-service from blocking the controller goroutine.
 
 The controller sets the following metadata fields on the created BMI:
 
@@ -413,26 +569,47 @@ The controller sets the following metadata fields on the created BMI:
 - `labels["osac.openshift.io/cluster-order"]`: `"<order-id>"` — links BMI to parent ClusterOrder
 - `annotations["osac.openshift.io/owner-reference"]`: `"ClusterOrder/<order-id>"`
 
-**Idempotency on lost responses:** If `BareMetalInstances.Create` succeeds but the response or status update is lost, the controller must not create a duplicate BMI on the next reconciliation. Before calling `Create` for a worker slot, the controller lists BMIs in the `system` tenant filtered by `osac.openshift.io/cluster-order` label and checks for an existing BMI matching the expected worker name. If found, it skips creation and adds the existing BMI to `status.workers`. This relies on the private API's read-after-write consistency (PostgreSQL, no caching layer). Alternatively, a unique constraint on `(name, tenant)` in the fulfillment-service would allow the controller to handle `AlreadyExists` responses directly — this would be a stronger guarantee but requires a fulfillment-service schema change outside the scope of this design.
+**Idempotency on lost responses:** If `BareMetalInstances.Create` succeeds but the response or status update is lost, the controller must not create a duplicate BMI on the next reconciliation. Two mechanisms prevent duplicates:
 
-#### Catalog Item Resolution
+1. **List-before-create (primary):** Before calling `Create` for a worker slot, the controller lists BMIs in the `system` tenant filtered by `osac.openshift.io/cluster-order` label and checks for an existing BMI matching the expected deterministic name (`<cluster-order-name>-worker-<index>`). If found, it skips creation and adds the existing BMI to `status.workers`.
 
-`BareMetalInstances.Create` requires a `spec.catalog_item` reference (`BareMetalInstanceCatalogItem`). The current `resourceClass` on `ClusterOrder.nodeRequests[]` carries a HostType name (e.g., `"fc430"`), which does not map directly to a CatalogItem — the resolution chain is HostType → Template → CatalogItem, and it is ambiguous (multiple Templates can reference the same HostType, multiple CatalogItems can reference the same Template).
+2. **Database uniqueness constraint (safety net):** [OSAC-3266](https://redhat.atlassian.net/browse/OSAC-3266) adds a `UNIQUE(tenant, project, name)` constraint on all resource tables including `bare_metal_instances`. If a race between list and create results in a duplicate `Create` call, the fulfillment-service returns `AlreadyExists`. The controller handles this by retrieving the existing BMI and adding it to `status.workers` — same outcome as the list-before-create path.
 
-To avoid this ambiguity, the ClusterTemplate must carry the CatalogItem reference for CaaS node sets. This is a small addition to the ClusterTemplate metadata (`meta/osac.yaml`): a `catalog_item` field per node request entry, set by the Cloud Infrastructure Admin when defining the template:
+#### ClusterNodeSet Redesign
+
+The current `ClusterNodeSet` proto references a `HostType`, which does not map directly to a provisioning resource for BMI creation. This design replaces `host_type` with a direct `BareMetalInstanceTypeReference` field:
+
+```protobuf
+// A named group of worker nodes within a cluster.
+message ClusterNodeSet {
+  // BareMetalInstanceType that defines the hardware profile for workers in this node set.
+  // Immutable after creation.
+  BareMetalInstanceTypeReference baremetal_instance_type = 1;
+
+  // Desired number of worker nodes. Must be > 0 on create; can be scaled to 0 after.
+  int32 size = 3;
+}
+```
+
+The `BareMetalInstanceType` is an admin-managed resource defining hardware specifications (CPU architecture, cores, memory, network ports, host label selector). The Cloud Infrastructure Admin creates `BareMetalInstanceType` entries for each available hardware profile. Hardware details (specific host, MAC address, network configuration) are not known until runtime — the `BareMetalInstanceType` defines *what kind* of host is needed, and BMaaS resolves *which specific host* at provisioning time via the host label selector. The `ClusterCatalogItem` (cluster template) can restrict which instance types are allowed for node sets; without restriction, any available `BareMetalInstanceType` can be selected.
+
+This change:
+- Eliminates the ambiguous HostType → Template → CatalogItem reverse lookup — the controller reads the instance type reference directly from the node set and passes it to the private API.
+- The `BareMetalInstanceType` carries hardware metadata (CPU architecture, network ports) needed for DiskImage architecture resolution and fabric interface selection.
+- The private `BareMetalInstances.Create` API is unchanged — CaaS uses a system-owned `BareMetalInstanceCatalogItem` with unlocked parameters as a pass-through, while the `BareMetalInstanceType` determines the hardware profile.
+- VM worker node sets (OSAC-1589) use a separate provisioning path (AAP template hooks, not a controller) and are out of scope for this `ClusterNodeSet` redesign.
+
+The ClusterTemplate `meta/osac.yaml` entries update accordingly:
 
 ```yaml
 # ocp-small/meta/osac.yaml
 title: OpenShift Small Cluster
 default_node_request:
-  - resourceClass: fc430
-    catalogItem: bm-standard      # new field — BareMetalInstanceCatalogItem name
+  - baremetalInstanceType: bm-standard
     numberOfNodes: 2
 ```
 
-The controller reads the CatalogItem reference from the template parameters rather than reverse-looking it up from the HostType. The `catalogItem` field is passed through to the ClusterOrder as a template parameter (alongside the existing `resourceClass`), making it available to the `BareMetalWorkerReconciler` without changes to the `NodeRequest` CRD type.
-
-Changing `resourceClass` itself to reference a CatalogItem instead of a HostType is a broader change that affects the entire stack (fulfillment-service, osac-operator, AAP roles, bare-metal-fulfillment-operator) and is out of scope for this design.
+This is a cross-component change affecting the fulfillment-service proto (ClusterNodeSet + BareMetalInstanceSpec), ClusterTemplate definitions, and the osac-operator's `NodeRequest` type. It replaces the existing `host_type`-based model.
 
 #### System Tenant Isolation
 
@@ -459,6 +636,21 @@ If zero candidates match, the controller continues watching. If multiple candida
 
 After the first successful MAC match, the controller labels the Agent with `osac.openshift.io/worker-name` pointing to the worker slot name (e.g., `bm-cluster-a-worker-0`). Subsequent reconciliations and scale-down lookups use this label instead of re-doing MAC correlation — the same pattern CAPA uses with the `agentMachineRef` label.
 
+#### Network Attachment Enrichment
+
+The BM controller reads the cluster-level network attachment from `ClusterOrder.spec.networkAttachments[0]` (a `ClusterNetworkAttachment` carrying `subnetRef` + `securityGroupRefs`, defined by OSAC-1436) and enriches it into a per-BMI `BareMetalNetworkAttachment` for the private API call:
+
+| ClusterNetworkAttachment (input) | BareMetalNetworkAttachment (output) | Source |
+|---|---|---|
+| `subnetRef` | `subnet` | Pass-through |
+| `securityGroupRefs[]` | `security_groups[]` | Pass-through |
+| — | `interface` | Resolved from `BareMetalInstanceType.network_ports[]` (first port with role `fabric`) |
+| — | `primary: true` | Always set — CaaS BM workers have a single network attachment |
+
+This enrichment is a read-only consumer of the ClusterOrder's `networkAttachments` field — the BM controller does not define or modify the field shape. The `networkAttachments` field uses `[]ClusterNetworkAttachment` (the cluster-specific attachment type per networking-decisions.md, not ComputeInstance's `NetworkAttachment`). This design requires the field to be present on the ClusterOrder CRD before the BM controller can read it.
+
+The `interface` field is resolved at BMI creation time, not stored on the ClusterOrder. Different node sets in the same cluster can reference different `BareMetalInstanceType`s with different network port configurations — the interface is resolved per node set, not per cluster.
+
 #### Minimum MCE Version
 
 The MGMT-24903 fix (persistent-boot day-2 installs) is merged to assisted-service master ([PR #10717](https://github.com/openshift/assisted-service/pull/10717), 2026-07-29) and assisted-installer-agent master ([PR #1568](https://github.com/openshift/assisted-installer-agent/pull/1568), 2026-07-30). The fix ships in MCE 5.0. Without it, workers fail to install because `osImageURL` is stripped from the ignition config. The controller does not implement a workaround — MCE >= 5.0 is a deployment prerequisite.
@@ -471,7 +663,7 @@ The assisted image service must be **disabled** for CaaS deployments. CaaS does 
 
 The bare-metal worker management is implemented as a **separate controller** (`BareMetalWorkerReconciler`) within osac-operator, not folded into the ClusterOrder controller. Both controllers watch the same `ClusterOrder` CR:
 
-- **ClusterOrder controller** — orchestrates the generic cluster lifecycle: AAP provisioning, NodePool management, status aggregation (`desiredWorkers`, `currentWorkers`, `readyWorkers` computed from the full `status.workers[]` list), and tenant-visible condition translation.
+- **ClusterOrder controller** — orchestrates the generic cluster lifecycle: AAP provisioning, NodePool creation (via AAP), status aggregation (`desiredWorkers`, `currentWorkers`, `readyWorkers` computed from the full `status.workers[]` list), and tenant-visible condition translation.
 - **BareMetalWorkerReconciler** — handles all BM-specific phases, invoked after the ClusterDeployment exists:
 
 1. **ensureInfraEnv** — list InfraEnvs owned by this ClusterOrder (via ownerReference); create one if none exists; wait for ignition readiness.
@@ -479,9 +671,9 @@ The bare-metal worker management is implemented as a **separate controller** (`B
 3. **correlateAgents** — watch Agents, match to BMIs via MAC, bind to cluster, label for NodePool.
 4. **reconcileNodePoolReplicas** — set NodePool replicas to match the number of correlated agents.
 
-This separation keeps the ClusterOrder controller generic — it does not contain BM-specific logic (InfraEnv, ignition, MAC correlation, Agent handling). When VM worker support is added, a `VMWorkerReconciler` follows the same pattern without touching the BM controller or the ClusterOrder controller.
+This separation keeps the ClusterOrder controller generic — it does not contain BM-specific logic (InfraEnv, ignition, MAC correlation, Agent handling). VM worker support (OSAC-1589) uses AAP template hooks rather than a controller, so no `VMWorkerReconciler` is planned.
 
-**Shared `status.workers[]`:** Both BM and future VM worker controllers write to the same `status.workers[]` field, partitioned by `kind` — each controller only adds, updates, or removes entries matching its kind (`BareMetalInstance` or `ComputeInstance`). The ClusterOrder controller reads the full list to compute aggregates. If two controllers update status in the same reconciliation cycle, Kubernetes optimistic concurrency (`resourceVersion` conflict) causes one to retry on the next requeue — standard controller-runtime behavior, no data loss.
+**Shared `status.workers[]`:** The `BareMetalWorkerReconciler` writes to `status.workers[]` (filtered by `kind: BareMetalInstance`). The ClusterOrder controller reads the full list to compute aggregates. If two controllers update status in the same reconciliation cycle, Kubernetes optimistic concurrency (`resourceVersion` conflict) causes one to retry on the next requeue — standard controller-runtime behavior, no data loss. The existing `patchStatusWithRetry` must be extended to include `Workers`, `DesiredWorkers`, `CurrentWorkers`, and `ReadyWorkers` fields, or the `BareMetalWorkerReconciler` must use its own status patch path that handles worker fields without clobbering the ClusterOrder controller's fields.
 
 Each phase is idempotent. The controller re-enters from the top on each reconciliation cycle and progresses through completed phases without repeating side effects (BMI creation is guarded by checking `status.workers` for existing entries with `kind: BareMetalInstance`).
 
@@ -516,7 +708,13 @@ The private API token (`OSAC_FULFILLMENT_TOKEN_FILE`) authenticates as `service-
 
 ### RBAC / Tenancy
 
-The osac-operator's ClusterRole must be extended with `get`, `list`, `watch`, `patch`, and `delete` on `agents` in the `agent-install.openshift.io` API group. This is required for MAC correlation (watch/list), cluster binding (patch `clusterDeploymentName`), NodePool label application (patch labels), and Agent CR cleanup on scale-down (delete). The existing service account permissions for creating CRs in cluster namespaces and calling the private API are unchanged.
+The osac-operator gains a new Go module dependency on `openshift/assisted-service` for InfraEnv and Agent API types. These types must be registered with the controller-runtime scheme.
+
+The osac-operator's ClusterRole must be extended with:
+- `create`, `get`, `list`, `watch` on `infraenvs` in the `agent-install.openshift.io` API group (InfraEnv creation and ignition readiness polling)
+- `get`, `list`, `watch`, `patch`, `delete` on `agents` in the `agent-install.openshift.io` API group (MAC correlation, cluster binding via `clusterDeploymentName` patch, NodePool label application, Agent CR cleanup on scale-down)
+
+The existing service account permissions for creating CRs in cluster namespaces and calling the private API are unchanged.
 
 CaaS-managed BMIs carry `metadata.tenant = "system"` (the builtin system tenant). The existing tenancy logic makes them invisible to all regular users — no label-based filtering is needed. The `osac.openshift.io/cluster-order` label links BMIs to their parent ClusterOrder, enabling Cloud Provider Admin queries via the private API.
 
@@ -532,7 +730,7 @@ Tenant-owned BMaaS workflows are unaffected. A tenant creating their own BareMet
 | `osac_clusterorder_worker_provisioning_duration_seconds` | Histogram | `tenant`, `worker_type` | Time from worker creation to NodePool join |
 | `osac_clusterorder_worker_agent_correlation_duration_seconds` | Histogram | `tenant`, `worker_type` | Time from worker `Running` to Agent MAC match (bare_metal only) |
 
-Per-ClusterOrder metrics would create unbounded label cardinality at scale. Metrics are aggregated by `tenant` (bounded). Per-ClusterOrder detail is available via the ClusterOrder status fields and Kubernetes events, which are the appropriate layer for per-instance diagnostics.
+`worker_type` label values: `bare_metal` (BareMetalInstance workers). Per-ClusterOrder metrics would create unbounded label cardinality at scale. Metrics are aggregated by `tenant` (bounded). Per-ClusterOrder detail is available via the ClusterOrder status fields and Kubernetes events, which are the appropriate layer for per-instance diagnostics.
 
 **Kubernetes Events:**
 
@@ -554,7 +752,7 @@ Per-ClusterOrder metrics would create unbounded label cardinality at scale. Metr
 | MAC address dependency (OSAC-2308/OSAC-3254) not delivered before this feature | Agent-to-BMI correlation impossible; entire feature blocked | Feature gated on this dependency. No partial implementation without MAC correlation. |
 | DiskImage dependency (OSAC-2540/OSAC-1270) not delivered before this feature | Controller cannot resolve RHCOS boot image via DiskImage; BMI creation blocked | Feature gated on this dependency. Cloud Infrastructure Admin must register RHCOS DiskImages before CaaS bare-metal provisioning is enabled. |
 | RHCOS DiskImage not linked to ClusterVersion | Controller cannot resolve boot image; BMI creation blocked with `RHCOSImageNotFound` condition | Cloud Infrastructure Admin must register DiskImages and link them to ClusterVersions via `--disk-image` before enabling CaaS provisioning. Reference validation catches this at ClusterVersion creation time. |
-| BMaaS deprovision failure leaves hosts in limbo during scale-down | Hosts are not cleaned up; potential data leakage if reassigned | Controller sets a 30-minute timeout for unbinding. Operators alerted via `WorkerFailed` event. Manual intervention documented in support procedures. |
+| BMaaS deprovision failure leaves hosts in limbo during scale-down | Hosts are not cleaned up; potential data leakage if reassigned | Worker remains in `Unbinding` phase with error details in `lastFailureReason`. Operators alerted via `osac_clusterorder_workers_failed` metric. Manual intervention documented in support procedures. |
 | Discovery ignition exceeds `bareMetalInstanceUserDataMaxBytes` (64KB) | BMI creation rejected | PoC measured 15KB. The controller emits a `DiscoveryIgnitionSizeWarning` event when the fetched ignition exceeds 48KB (75% of the 64KB limit), giving operators advance notice before BMI creation starts failing. |
 | Concurrent scale operations on multiple clusters exhaust host inventory | Multiple ClusterOrders compete for limited hosts; some fail | BMI creation fails, worker enters `Failed` phase. ClusterOrder status reflects partial provisioning. Inventory sizing is the admin's responsibility. |
 
@@ -593,20 +791,20 @@ Replace the controller-based flow with a new AAP role that calls the private API
 - BareMetalWorkerReconciler: reconciliation is idempotent — re-running with the same state produces no new API calls.
 - System tenant isolation: CaaS-managed BMIs under `system` tenant are not returned by public `BareMetalInstances.List` for any regular tenant.
 - System tenant isolation: public `BareMetalInstances.Get` returns `NotFound` for system-tenant BMIs when called by a regular tenant.
-- RBAC: osac-operator's ClusterRole includes `patch` on `agents` in the `agent-install.openshift.io` API group.
+- RBAC: osac-operator's ClusterRole includes `get`, `list`, `watch`, `patch`, and `delete` on `agents` in the `agent-install.openshift.io` API group.
 
 ### Integration Tests
 
 - Create a ClusterOrder with bare-metal node requests in a kind cluster. Verify InfraEnv CR is created with correct spec. Verify BMI creation calls reach the fulfillment-service (mocked private API). Verify ClusterOrder status reflects `workers` entries.
 - Simulate Agent registration by creating Agent CRs with matching MAC addresses. Verify correlation and labeling.
-- Simulate scale-down by decreasing `nodeRequests`. Verify NodePool replicas decrease and BMI delete is called for the excess workers.
+- Simulate scale-down by decreasing `nodeRequests`. Verify NodePool replicas decrease, Agent CRs are deleted, and BMI delete is called for the excess workers.
 - Verify ClusterOrder deletion cleans up all BMIs and the InfraEnv before removing the finalizer.
 
 ### E2E Tests
 
 - Full provisioning flow: create a Cluster with a bare-metal node set via the fulfillment-service public API. Verify workers join and ClusterOrder reaches `Ready`. (Requires a test environment with BMaaS hosts and assisted-service.)
 - Scale-up: increase node count on an existing cluster. Verify new workers are provisioned and join.
-- Scale-down: decrease node count. Verify workers are drained, agents unbound, BMIs deleted.
+- Scale-down: decrease node count. Verify workers are drained, Agent CRs deleted, BMIs deleted.
 - Cluster deletion: delete a cluster with bare-metal workers. Verify all BMIs are cleaned up.
 - System tenant isolation: verify `osac list baremetalinstances` as a tenant user does not return CaaS-managed instances (system tenant).
 - Pool removal: verify no BareMetalPool CRs are created during CaaS cluster provisioning. Verify the `cluster_infra` AAP step no longer references BareMetalPool.
@@ -647,7 +845,7 @@ CaaS-managed BMIs are assigned to the builtin `system` tenant, which already exi
 - ClusterOrder stuck in `Progressing` with condition `WorkersFailed`: check `status.workers[]` for the referenced BMI names, then inspect each via the private API (`osac get baremetalinstances <name> --private`) for provisioning job errors and state.
 - Alert: `osac_clusterorder_workers_failed > 0` sustained for 15 minutes.
 - Agent registration timeout: check InfraEnv status for ignition generation errors. Verify DiskImage is reachable. Check BMI status for host allocation failures.
-- Scale-down stall: Agent stuck in unbound state — check BMI status via the private API for deprovision errors. Investigate the BMaaS backend if the BMI remains in `Deleting`.
+- Scale-down stall: Agent stuck in `unbinding-pending-user-action` — verify osac-operator has `delete` permission on `agents` in `agent-install.openshift.io`. Check BMI status via the private API for deprovision errors. Investigate the BMaaS backend if the BMI remains in `Deleting`.
 
 **Disabling the feature:**
 - Set the cluster template to exclude bare-metal resource classes. Existing clusters with bare-metal workers continue running — the controller does not deprovision workers unless instructed (scale-down or delete).

--- a/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
+++ b/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
@@ -12,7 +12,6 @@ see-also:
   - "/enhancements/OSAC-2540-disk-image"
   - "/enhancements/OSAC-1201-baremetal-instance-types"
   - "/enhancements/OSAC-1330-type-safe-resource-references"
-  - "/enhancements/OSAC-1567-secret-management"
 replaces:
   - N/A
 superseded-by:
@@ -23,7 +22,7 @@ superseded-by:
 
 ## Summary
 
-This design adds on-demand bare-metal worker node provisioning to CaaS by having the osac-operator ClusterOrder controller create BareMetalInstances via the fulfillment-service private gRPC API. Each instance references a pre-registered RHCOS DiskImage and a Secret containing discovery ignition from the shared platform-level InfraEnv, causing the host to register as an assisted-service Agent and join the HyperShift-managed cluster as a worker node. The existing BareMetalPool-based static pre-boot pool is removed. See [PRD](prd.md) for detailed requirements.
+This design adds on-demand bare-metal worker node provisioning to CaaS by having the osac-operator ClusterOrder controller create BareMetalInstances via the fulfillment-service private gRPC API. Each instance references a pre-registered RHCOS DiskImage and carries discovery ignition inline from the shared platform-level InfraEnv, causing the host to register as an assisted-service Agent and join the HyperShift-managed cluster as a worker node. The existing BareMetalPool-based static pre-boot pool is removed. See [PRD](prd.md) for detailed requirements.
 
 ## Motivation
 
@@ -52,7 +51,7 @@ The new approach eliminates the pool by provisioning workers on-demand. When a C
 The ClusterOrder controller in osac-operator gains a new reconciliation phase for bare-metal worker management. When a ClusterOrder's `nodeRequests` reference bare-metal resource classes, the controller:
 
 1. Ensures a shared `InfraEnv` CR exists on the hub cluster to generate discovery ignition (one per platform, not per cluster).
-2. Stores the InfraEnv's discovery ignition as a Secret via `Secrets.Create` on the private API, then creates `BareMetalInstance` objects referencing the RHCOS DiskImage and the ignition Secret.
+2. Fetches discovery ignition from the InfraEnv and creates `BareMetalInstance` objects with the ignition passed inline as `user_data`, referencing the RHCOS DiskImage.
 3. Correlates registered Agents to BMIs via MAC address, binds them to the cluster's ClusterDeployment, and labels them for NodePool selection.
 
 No new CRDs are introduced. The design extends the ClusterOrder CRD status with a `workers` field to track CaaS-managed worker resources. BareMetalInstances created by CaaS are assigned to the builtin `system` tenant, making them invisible to tenant APIs via the existing tenancy logic.
@@ -115,15 +114,14 @@ The diagram shows the end-to-end provisioning flow. The controller waits for eac
 **Step-by-step:**
 
 1. The ClusterOrder controller detects `nodeRequests` with bare-metal resource classes by checking the resource class against BareMetalInstanceType definitions.
-2. After AAP creates the HostedCluster and the ClusterDeployment CR exists, the controller ensures the shared platform-level `InfraEnv` CR exists (see InfraEnv Creation). The InfraEnv has no `clusterRef` — agents register as unbound and the controller explicitly binds them to the correct cluster in step 9.
+2. After AAP creates the HostedCluster and the ClusterDeployment CR exists, the controller ensures the shared platform-level `InfraEnv` CR exists (see InfraEnv Creation). The InfraEnv has no `clusterRef` — agents register as unbound and the controller explicitly binds them to the correct cluster in step 8.
 3. The controller reads the InfraEnv's `status.bootArtifacts.discoveryIgnitionURL` and fetches the discovery ignition content. The ignition is architecture-neutral (the `assisted-installer-agent` image is a multi-arch manifest), so the same InfraEnv serves hosts of any architecture.
-4. The controller creates a Secret via `Secrets.Create` on the private API, storing the discovery ignition content. The Secret is encrypted at rest via the Vault backend (OSAC-1567). One Secret is created per cluster for lifecycle management (deleted when the cluster is decommissioned), even though the ignition content is identical across clusters since it comes from the shared InfraEnv.
-5. For each bare-metal worker requested, the controller calls `BareMetalInstances.Create` on the private API with: `spec.catalog_item` resolved from the resource class, `spec.image` set to the resolved RHCOS DiskImage ID (see RHCOS DiskImage Resolution), `spec.user_data` referencing the ignition Secret, `spec.network_attachments` built from the Cluster's `ClusterNetworkAttachment` (subnet + security groups) and the node set's HostType (fabric interface), and `metadata.tenant = "system"` (see System Tenant Isolation). The network attachment mapping is a pass-through: the controller reads the Cluster's `ClusterNetworkAttachment` for the subnet and security group references, resolves the fabric interface name from the node set's HostType definition (first interface with role `fabric`), and constructs a `BareMetalNetworkAttachment` with `primary: true`. BMaaS handles the physical networking — moving the host to the tenant subnet VLAN and assigning an IP via fabric DHCP — as part of BMI provisioning (dependency: OSAC-1437). If the host fails to join the tenant network, the agent will not register on the expected subnet, and the existing `AgentRegistrationTimeout` handles this failure mode. API and ingress VIPs are provisioned by the existing AAP template (MetalLB LoadBalancer Services) and are not managed by this controller.
-6. The controller updates ClusterOrder status with the BMI IDs in `workers[]`.
-7. BMaaS allocates a host, writes the qcow2 to disk via Ironic, and boots with the discovery ignition. The host registers as an Agent with assisted-service.
-8. The controller watches Agent CRs in the cluster namespace. When a new Agent appears, the controller matches its inventory MAC address against BMI status MAC addresses (`status.host.mac_address`, dependency OSAC-2308/OSAC-3254).
-9. Once correlated, the controller sets the Agent's `clusterDeploymentName` to the cluster's ClusterDeployment and applies the `agentBareMetal` role label so the NodePool's `agentLabelSelector` selects it. This requires the osac-operator to modify `agent-install.openshift.io/v1beta1` Agent resources — a cross-API-group coupling. This is unavoidable: the assisted-service Agent API does not provide an auto-bind mechanism for late-binding agents, so an external controller must set `clusterDeploymentName` and apply labels. The osac-operator's RBAC must include `patch` on `agents` in the `agent-install.openshift.io` API group.
-10. HyperShift installs the Agent as a worker node. The controller monitors NodePool `.status.replicas` to confirm convergence.
+4. For each bare-metal worker requested, the controller calls `BareMetalInstances.Create` on the private API with: `spec.catalog_item` resolved from the resource class, `spec.image` set to the resolved RHCOS DiskImage ID (see RHCOS DiskImage Resolution), `spec.user_data` set to the fetched ignition content inline (the `user_data` field accepts raw first-boot data up to 64KB; the PoC measured 15KB), `spec.network_attachments` built from the Cluster's `ClusterNetworkAttachment` (subnet + security groups) and the node set's HostType (fabric interface), and `metadata.tenant = "system"` (see System Tenant Isolation). The network attachment mapping is a pass-through: the controller reads the Cluster's `ClusterNetworkAttachment` for the subnet and security group references, resolves the fabric interface name from the node set's HostType definition (first interface with role `fabric`), and constructs a `BareMetalNetworkAttachment` with `primary: true`. BMaaS handles the physical networking — moving the host to the tenant subnet VLAN and assigning an IP via fabric DHCP — as part of BMI provisioning (dependency: OSAC-1437). If the host fails to join the tenant network, the agent will not register on the expected subnet, and the existing `AgentRegistrationTimeout` handles this failure mode. API and ingress VIPs are provisioned by the existing AAP template (MetalLB LoadBalancer Services) and are not managed by this controller.
+5. The controller updates ClusterOrder status with the BMI references in `workers[]`.
+6. BMaaS allocates a host, writes the qcow2 to disk via Ironic, and boots with the discovery ignition. The host registers as an Agent with assisted-service.
+7. The controller watches Agent CRs in the cluster namespace. When a new Agent appears, the controller matches its inventory MAC address against BMI status MAC addresses (`status.host.mac_address`, dependency OSAC-2308/OSAC-3254).
+8. Once correlated, the controller sets the Agent's `clusterDeploymentName` to the cluster's ClusterDeployment and applies the `agentBareMetal` role label so the NodePool's `agentLabelSelector` selects it. This requires the osac-operator to modify `agent-install.openshift.io/v1beta1` Agent resources — a cross-API-group coupling. This is unavoidable: the assisted-service Agent API does not provide an auto-bind mechanism for late-binding agents, so an external controller must set `clusterDeploymentName` and apply labels. The osac-operator's RBAC must include `patch` on `agents` in the `agent-install.openshift.io` API group.
+9. HyperShift installs the Agent as a worker node. The controller monitors NodePool `.status.replicas` to confirm convergence.
 
 #### Scale-Up
 
@@ -134,7 +132,7 @@ A Tenant User increases `node_sets[].size` for a bare-metal node set. The fulfil
 1. The controller computes `desired - current` where `current` is `status.currentWorkers` (workers in active phases: `Provisioning`, `WaitingForAgent`, `Binding`, `Ready`). Workers in `Failed` phase do not count toward capacity — new workers are created to fill the gap once their retry backoff expires.
 2. The controller re-reads the shared InfraEnv's `status.bootArtifacts.discoveryIgnitionURL` to fetch fresh ignition.
 3. The controller resolves the RHCOS DiskImage from the NodePool's current release image (not the ClusterOrder's original). This ensures workers added after a cluster upgrade use a compatible boot image.
-4. For each new worker, the controller follows provisioning steps 4-10 from the initial flow (the ignition Secret from step 4 is reused — one per cluster, not per worker).
+4. For each new worker, the controller follows provisioning steps 4-9 from the initial flow (the ignition content is re-fetched in step 2 above).
 5. Partial success is reported: if 3 of 5 new workers succeed and 2 fail, the ClusterOrder status shows 3 additional `Ready` workers and 2 `Failed`. The tenant sees the cluster with the successfully added workers; the failed slots are visible via ClusterOrder conditions and events.
 
 #### Scale-Down
@@ -265,7 +263,7 @@ Example: a 5-worker cluster where 3 workers are ready and 2 are retrying:
 status:
   phase: Progressing
   desiredWorkers: 5
-  currentWorkers: 5
+  currentWorkers: 3
   readyWorkers: 3
   conditions:
     - type: WorkersFailed
@@ -312,7 +310,7 @@ status:
 
 The `workers[]` list always contains all worker references regardless of their individual state. The `WorkersFailed` condition provides the aggregate summary. The ClusterOrder remains in `Progressing` phase (not `Failed`) because 3 workers are operational. Per-worker detail (which slot failed, why, when the next retry is) is visible directly in the status.
 
-The controller tracks worker lifecycle through phases: `Provisioning` → `WaitingForAgent` → `Binding` → `Ready` (and `Unbinding` → `Deleting` for scale-down). `Failed` is reachable from any active phase.
+The controller tracks worker lifecycle through phases: `Provisioning` → `WaitingForAgent` → `Binding` → `Ready` (and `Unbinding` → `Deleting` for scale-down). `Failed` is reachable only from provisioning phases (`Provisioning`, `WaitingForAgent`, `Binding`) and triggers automatic retry. Teardown issues (e.g., agent unbinding timeout, BMI deletion failure) keep the worker in `Unbinding` or `Deleting` with error details in `lastFailureReason` — they do not transition to `Failed` and do not trigger replacement, since the intent is removal, not reprovisioning.
 
 **Retry behavior:** The API is declarative — the controller retries indefinitely until the desired state is reached. There is no `PermanentlyFailed` state. When a worker enters `Failed`, the controller deletes the failed BMI and creates a replacement with escalating backoff:
 
@@ -355,7 +353,7 @@ Agent-to-cluster isolation is enforced by the MAC correlation algorithm (see MAC
 
 The controller resolves the RHCOS boot image via a pre-registered DiskImage resource (dependency: OSAC-2540 DiskImage, OSAC-1270 BMI DiskImage integration). The Cloud Infrastructure Admin registers RHCOS qcow2 images as provider-global DiskImages with guest OS family (`linux`) and architecture (`amd64`), and applies a CaaS-specific label `osac.openshift.io/ocp-version: "4.22"` to enable version-based lookup. This label is a CaaS convention — the DiskImage resource itself (OSAC-2540) has no OCP version field, since version-based lookup is a CaaS-specific need. If richer metadata is needed (e.g., multiple image variants per version, automated registration), a dedicated `ClusterDiskImage` resource could wrap DiskImage with CaaS-specific fields. Labeling is sufficient for this design.
 
-The controller reads `NodePool.spec.release.image`, extracts the OCP major.minor version (e.g., `4.22` from `ocp-release:4.22.5-x86_64`), and resolves the matching DiskImage by querying for provider-global DiskImages with the `osac.openshift.io/ocp-version` label matching the target version and the correct architecture.
+The controller reads `NodePool.spec.release.image`, extracts the OCP major.minor version (e.g., `4.22` from `ocp-release:4.22.5-x86_64`), and resolves the worker architecture from the node set's `BareMetalInstanceType` (which defines the HostType and its CPU architecture). It then queries for provider-global DiskImages matching both the `osac.openshift.io/ocp-version` label and the resolved architecture. This design targets `amd64` only; other architectures require Cloud Infrastructure Admin to register the corresponding RHCOS DiskImages.
 
 Using the NodePool's current release image rather than the ClusterOrder's original ensures scale-up works correctly after cluster upgrades. A cluster created at OCP 4.18 and later upgraded to 4.22 would use a 4.22 boot image for new workers. Using the original 4.18 image could cause agent compatibility issues — the assisted-installer agent in an older RHCOS may not be compatible with a newer cluster's API or ignition format.
 
@@ -375,7 +373,7 @@ For each worker, the controller calls `BareMetalInstances.Create` on the private
 message BareMetalInstanceSpec {
   string catalog_item = ...;                                // resolved from nodeRequest.resourceClass → BareMetalInstanceCatalogItem
   optional BareMetalInstanceImage image = ...;              // RHCOS DiskImage reference (see DiskImage Resolution)
-  optional string user_data = ...;                          // Secret reference containing discovery ignition
+  optional string user_data = ...;                          // inline discovery ignition content (max 64KB)
   repeated BareMetalNetworkAttachment network_attachments = ...;
   // ... other existing fields (ssh_public_key, run_strategy, template_parameters, etc.) omitted
 }
@@ -391,6 +389,8 @@ The controller sets the following metadata fields on the created BMI:
 - `name`: `"<cluster-order-name>-worker-<index>"`
 - `labels["osac.openshift.io/cluster-order"]`: `"<order-id>"` — links BMI to parent ClusterOrder
 - `annotations["osac.openshift.io/owner-reference"]`: `"ClusterOrder/<order-id>"`
+
+**Idempotency on lost responses:** If `BareMetalInstances.Create` succeeds but the response or status update is lost, the controller must not create a duplicate BMI on the next reconciliation. Before calling `Create` for a worker slot, the controller lists BMIs in the `system` tenant filtered by `osac.openshift.io/cluster-order` label and checks for an existing BMI matching the expected worker name. If found, it skips creation and adds the existing BMI to `status.workers`. This relies on the private API's read-after-write consistency (PostgreSQL, no caching layer). Alternatively, a unique constraint on `(name, tenant)` in the fulfillment-service would allow the controller to handle `AlreadyExists` responses directly — this would be a stronger guarantee but requires a fulfillment-service schema change outside the scope of this design.
 
 #### System Tenant Isolation
 
@@ -438,7 +438,7 @@ All four phases are handled within the ClusterOrder controller rather than split
 
 CaaS-managed BMIs are created under the builtin `system` tenant via the private API. The `system` tenant is excluded from `DetermineVisibleTenants`, so these BMIs are invisible to all regular users without any additional filtering. The private API bypasses tenant-scoped OPA policies because it operates with system-level credentials. Ownership is traceable via the `osac.openshift.io/owner-reference` annotation linking each BMI to its parent ClusterOrder (which belongs to the real tenant).
 
-The discovery ignition contains the InfraEnv's pull secret and the assisted-service endpoint URL (both platform-level, not cluster-specific). It is stored as an OSAC Secret (OSAC-1567) encrypted at rest via the Vault backend, and referenced from the BMI's `user_data` field. The `user_data` field is immutable (enforced by the proto `IMMUTABLE` field behavior annotation). The ignition comes from the shared platform-level InfraEnv and is not cluster-scoped — agent-to-cluster binding is enforced by the MAC correlation algorithm, not by the ignition content. The Secret is deleted when the cluster is decommissioned (owned by the ClusterOrder lifecycle).
+The discovery ignition contains the InfraEnv's pull secret and the assisted-service endpoint URL (both platform-level, not cluster-specific). It is passed inline as `user_data` on each BMI (max 64KB; PoC measured 15KB). The `user_data` field is immutable (enforced by the proto `IMMUTABLE` field behavior annotation). The ignition comes from the shared platform-level InfraEnv and is not cluster-scoped — agent-to-cluster binding is enforced by the MAC correlation algorithm, not by the ignition content.
 
 No changes to authentication or authorization flows are required. The existing OPA policies enforce tenant isolation for all public API access. The osac-operator authenticates to the private API using a token file mounted from a Kubernetes Secret (`OSAC_FULFILLMENT_TOKEN_FILE`), following the same pattern used by the existing feedback controllers for Signal RPCs.
 
@@ -457,13 +457,13 @@ The private API token (`OSAC_FULFILLMENT_TOKEN_FILE`) authenticates as `service-
 | Agent does not register within timeout | Worker phase set to `Failed`, reason `AgentRegistrationTimeout` | Controller deletes the timed-out BMI and retries with escalating backoff (capped at 30m) | Cluster shows `WORKER_PROVISIONING_FAILED` |
 | MAC correlation finds no match | Agent remains uncorrelated | Controller logs a warning and continues watching. If all BMIs are correlated and extra agents exist, they are ignored | No direct tenant impact |
 | Agent binding to NodePool fails | Agent not installed as worker | assisted-service reports failure in Agent conditions; controller reflects in worker phase | Cluster shows degraded worker count |
-| Scale-down: Agent unbinding times out | Agent stuck in `unbinding-pending-user-action` longer than 30 minutes | Controller logs warning, sets worker phase to `Failed`. Manual intervention required to investigate Ironic deprovision failure | Node count mismatch visible in Cluster status |
+| Scale-down: Agent unbinding times out | Agent stuck in `unbinding-pending-user-action` longer than 30 minutes | Worker remains in `Unbinding` phase with `lastFailureReason: AgentUnbindingTimeout`. Controller retries periodically. Manual intervention required to investigate Ironic deprovision failure. No replacement is triggered | Node count mismatch visible in Cluster status |
 | BMI deletion fails | BMI stuck in `Deleting` (e.g., AAP deprovision job fails with `blockDeletionOnFailure: true`) | Controller retries delete periodically. Alerting notifies operators | Scale-down appears incomplete in Cluster status |
 | Controller restart mid-reconciliation | Controller resumes from current state on restart | Idempotent reconciliation logic rebuilds in-memory state from CRD status and re-queries BMI/Agent state | Temporary stall, no data loss |
 
 ### RBAC / Tenancy
 
-No new RBAC roles are introduced. The osac-operator's service account already has permissions to create CRs in cluster namespaces and call the private API.
+The osac-operator's ClusterRole must be extended with `get`, `list`, `watch`, and `patch` on `agents` in the `agent-install.openshift.io` API group. This is required for MAC correlation (watch/list), cluster binding (patch `clusterDeploymentName`), and NodePool label application (patch labels). The existing service account permissions for creating CRs in cluster namespaces and calling the private API are unchanged.
 
 CaaS-managed BMIs carry `metadata.tenant = "system"` (the builtin system tenant). The existing tenancy logic makes them invisible to all regular users — no label-based filtering is needed. The `osac.openshift.io/cluster-order` label links BMIs to their parent ClusterOrder, enabling Cloud Provider Admin queries via the private API.
 
@@ -582,7 +582,7 @@ The ClusterOrder CRD gains a new status field (`workers`). On downgrade, the old
 
 ## Version Skew Strategy
 
-The osac-operator (controller) and fulfillment-service (private API) must be upgraded together or the operator first. The controller calls `Secrets.Create` and `BareMetalInstances.Create` with existing fields. The `source_type: "disk_image"` value is introduced by the DiskImage integration (OSAC-1270), a listed dependency — the fulfillment-service must have OSAC-1270 implemented before CaaS bare-metal provisioning is enabled, so there is no version skew scenario for this value.
+The osac-operator (controller) and fulfillment-service (private API) must be upgraded together or the operator first. The controller calls `BareMetalInstances.Create` with existing fields. The `source_type: "disk_image"` value is introduced by the DiskImage integration (OSAC-1270), a listed dependency — the fulfillment-service must have OSAC-1270 implemented before CaaS bare-metal provisioning is enabled, so there is no version skew scenario for this value.
 
 CaaS-managed BMIs are assigned to the builtin `system` tenant, which already exists in the fulfillment-service database (migration 48). No fulfillment-service changes are required for tenant isolation — the existing tenancy logic excludes the `system` tenant from regular user queries. There is no version skew risk for visibility.
 

--- a/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
+++ b/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
@@ -22,7 +22,7 @@ superseded-by:
 
 ## Summary
 
-This design adds on-demand bare-metal worker node provisioning to CaaS by having the osac-operator ClusterOrder controller create BareMetalInstances via the fulfillment-service private gRPC API. Each instance references a pre-registered RHCOS DiskImage and carries discovery ignition inline from a cluster-specific InfraEnv, causing the host to register as an assisted-service Agent and join the HyperShift-managed cluster as a worker node. The existing BareMetalPool-based static pre-boot pool is removed. See [PRD](prd.md) for detailed requirements.
+This design adds on-demand bare-metal worker node provisioning to CaaS via a dedicated `BareMetalWorkerReconciler` in osac-operator that creates BareMetalInstances via the fulfillment-service private gRPC API. Each instance references a pre-registered RHCOS DiskImage and carries discovery ignition inline from a cluster-specific InfraEnv, causing the host to register as an assisted-service Agent and join the HyperShift-managed cluster as a worker node. The existing BareMetalPool-based static pre-boot pool is removed. See [PRD](prd.md) for detailed requirements.
 
 ## Motivation
 
@@ -32,7 +32,7 @@ The new approach eliminates the pool by provisioning workers on-demand. When a C
 
 ### Goals
 
-- Reuse the existing ClusterOrder controller reconciliation pattern and the private gRPC API for BMI lifecycle management.
+- Implement bare-metal worker management as a dedicated controller (`BareMetalWorkerReconciler`) within osac-operator, keeping the ClusterOrder controller generic and extensible for future VM worker support.
 - Keep all CaaS-managed bare-metal infrastructure (BMIs, InfraEnvs, Agents) invisible to tenant-facing APIs and UIs.
 - Support both initial provisioning and manual scale-up/scale-down through the same controller logic.
 - Ensure host cleanup on scale-down and cluster deletion flows through BMaaS's existing deprovision pipeline via `BareMetalInstances.Delete`.
@@ -48,7 +48,7 @@ The new approach eliminates the pool by provisioning workers on-demand. When a C
 
 ## Proposal
 
-The ClusterOrder controller in osac-operator gains a new reconciliation phase for bare-metal worker management. When a ClusterOrder's `nodeRequests` reference bare-metal resource classes, the controller:
+A new `BareMetalWorkerReconciler` in osac-operator watches `ClusterOrder` CRs for bare-metal worker management. When a ClusterOrder's `nodeRequests` reference bare-metal resource classes, the controller:
 
 1. Creates a cluster-specific `InfraEnv` CR on the hub cluster to generate discovery ignition.
 2. Fetches discovery ignition from the InfraEnv and creates `BareMetalInstance` objects with the ignition passed inline as `user_data`, referencing the RHCOS DiskImage.
@@ -113,10 +113,10 @@ The diagram shows the end-to-end provisioning flow. The controller waits for eac
 
 **Step-by-step:**
 
-1. The ClusterOrder controller identifies bare-metal node sets from `nodeRequests[]`. The `resourceClass` maps to a HostType; bare-metal HostTypes are distinguished by having physical network interfaces defined (per HostType proto convention).
+1. The `BareMetalWorkerReconciler` identifies bare-metal node sets from `nodeRequests[]`. The `resourceClass` maps to a HostType; bare-metal HostTypes are distinguished by having physical network interfaces defined (per HostType proto convention).
 2. After AAP creates the HostedCluster and the ClusterDeployment CR exists, the controller creates a cluster-specific `InfraEnv` CR (see InfraEnv Creation). The InfraEnv uses late binding (no `clusterRef`) — agents register as unbound and the controller explicitly binds them in step 8.
 3. The controller polls the InfraEnv status until `status.bootArtifacts.discoveryIgnitionURL` is populated, then fetches the discovery ignition content. The ignition is architecture-neutral (the `assisted-installer-agent` image is a multi-arch manifest).
-4. For each bare-metal worker requested, the controller calls `BareMetalInstances.Create` on the private API with: `spec.catalog_item` resolved from the resource class, `spec.image` set to the resolved RHCOS DiskImage ID (see RHCOS DiskImage Resolution), `spec.user_data` set to the fetched ignition content inline (the `user_data` field accepts raw first-boot data up to 64KB; the PoC measured 15KB), `spec.network_attachments` built from the Cluster's `ClusterNetworkAttachment` (subnet + security groups) and the node set's HostType (fabric interface), and `metadata.tenant = "system"` (see System Tenant Isolation). The network attachment mapping is a pass-through: the controller reads the Cluster's `ClusterNetworkAttachment` for the subnet and security group references, resolves the fabric interface name from the node set's HostType definition (first interface with role `fabric`), and constructs a `BareMetalNetworkAttachment` with `primary: true`. BMaaS handles the physical networking — moving the host to the tenant subnet VLAN and assigning an IP via fabric DHCP — as part of BMI provisioning (dependency: OSAC-1437). If the host fails to join the tenant network, the agent will not register on the expected subnet, and the existing `AgentRegistrationTimeout` handles this failure mode. API and ingress VIPs are provisioned by the existing AAP template (MetalLB LoadBalancer Services) and are not managed by this controller.
+4. For each bare-metal worker requested, the controller calls `BareMetalInstances.Create` on the private API with: `spec.catalog_item` resolved from the ClusterTemplate's CaaS configuration (see Catalog Item Resolution), `spec.image` set to the resolved RHCOS DiskImage ID (see RHCOS DiskImage Resolution), `spec.user_data` set to the fetched ignition content inline (the `user_data` field accepts raw first-boot data up to 64KB; the PoC measured 15KB), `spec.network_attachments` built from the Cluster's `ClusterNetworkAttachment` (subnet + security groups) and the node set's HostType (fabric interface), and `metadata.tenant = "system"` (see System Tenant Isolation). The network attachment mapping is a pass-through: the controller reads the Cluster's `ClusterNetworkAttachment` for the subnet and security group references, resolves the fabric interface name from the node set's HostType definition (first interface with role `fabric`), and constructs a `BareMetalNetworkAttachment` with `primary: true`. BMaaS handles the physical networking — moving the host to the tenant subnet VLAN and assigning an IP via fabric DHCP — as part of BMI provisioning (dependency: OSAC-1437). If the host fails to join the tenant network, the agent will not register on the expected subnet, and the existing `AgentRegistrationTimeout` handles this failure mode. API and ingress VIPs are provisioned by the existing AAP template (MetalLB LoadBalancer Services) and are not managed by this controller.
 5. The controller updates ClusterOrder status with the BMI references in `workers[]`.
 6. BMaaS allocates a host, provisions it with the DiskImage and discovery ignition, and boots it. The host registers as an Agent with assisted-service.
 7. The controller watches Agent CRs in the cluster namespace. When a new Agent appears, the controller matches its inventory MAC address against BMI status MAC addresses (`status.host.mac_address`, dependency OSAC-2308/OSAC-3254).
@@ -167,12 +167,13 @@ This diagram shows the scale-down flow. CAPI handles node drain and agent unbind
 3. CAPI's MachineDeployment controller manages MachineSets, which select Machines for deletion. CaaS does not control the selection order.
 4. CAPI drains each selected node, then the AgentMachine controller unbinds the Agent (clears `ClusterDeploymentName`). Since workers are post-installation, the Agent transitions to `unbinding-pending-user-action` and remains there — CAPA considers its job done at this point.
 5. The controller watches for Agents entering `unbinding-pending-user-action` and matches them back to BMIs via MAC address.
-6. The controller calls `BareMetalInstances.Delete` on the private API. BMaaS handles full host cleanup before returning the host to inventory. CaaS does not independently verify cleanup completion — this is a trust boundary between CaaS and BMaaS. If BMaaS cleanup fails, the host must not be reallocated; this guarantee is BMaaS's responsibility.
-7. The controller retains the worker entry in `status.workers` in `Deleting` phase until the BMI deletion is confirmed. This prevents orphaned hosts — if `Delete` succeeds but cleanup stalls, the controller still has the reference to retry or alert.
+6. The controller deletes the Agent CR. CAPA does not delete the Agent — it only clears `ClusterDeploymentName` and removes its own hook/finalizer. Without a BMH to drive the Agent back to discovery, the Agent CR would remain in `unbinding-pending-user-action` indefinitely. CaaS owns this cleanup.
+7. The controller calls `BareMetalInstances.Delete` on the private API. BMaaS handles full host cleanup before returning the host to inventory. CaaS does not independently verify cleanup completion — this is a trust boundary between CaaS and BMaaS. If BMaaS cleanup fails, the host must not be reallocated; this guarantee is BMaaS's responsibility.
+8. The controller retains the worker entry in `status.workers` in `Deleting` phase until the BMI deletion is confirmed. This prevents orphaned hosts — if `Delete` succeeds but cleanup stalls, the controller still has the reference to retry or alert.
 
 #### Cluster Deletion
 
-On ClusterOrder deletion, the controller runs the scale-down flow for all remaining workers (steps 2-7) before allowing the AAP deprovision job to destroy the HostedCluster. The InfraEnv CR is cleaned up automatically by Kubernetes garbage collection via its ownerReference to the ClusterOrder — no explicit deletion is needed. The ClusterOrder's finalizer prevents premature deletion, ensuring all BMIs are cleaned up before the ClusterOrder (and its owned InfraEnv) are removed.
+On ClusterOrder deletion, the controller runs the scale-down flow for all remaining workers (steps 2-8) before allowing the AAP deprovision job to destroy the HostedCluster. The InfraEnv CR is cleaned up automatically by Kubernetes garbage collection via its ownerReference to the ClusterOrder — no explicit deletion is needed. The ClusterOrder's finalizer prevents premature deletion, ensuring all BMIs are cleaned up before the ClusterOrder (and its owned InfraEnv) are removed.
 
 ### API Extensions
 
@@ -405,6 +406,14 @@ The controller sets the following metadata fields on the created BMI:
 
 **Idempotency on lost responses:** If `BareMetalInstances.Create` succeeds but the response or status update is lost, the controller must not create a duplicate BMI on the next reconciliation. Before calling `Create` for a worker slot, the controller lists BMIs in the `system` tenant filtered by `osac.openshift.io/cluster-order` label and checks for an existing BMI matching the expected worker name. If found, it skips creation and adds the existing BMI to `status.workers`. This relies on the private API's read-after-write consistency (PostgreSQL, no caching layer). Alternatively, a unique constraint on `(name, tenant)` in the fulfillment-service would allow the controller to handle `AlreadyExists` responses directly — this would be a stronger guarantee but requires a fulfillment-service schema change outside the scope of this design.
 
+#### Catalog Item Resolution
+
+`BareMetalInstances.Create` requires a `spec.catalog_item` reference (`BareMetalInstanceCatalogItem`). The current `resourceClass` on `ClusterOrder.nodeRequests[]` carries a HostType name (e.g., `"fc430"`), which does not map directly to a CatalogItem — the resolution chain is HostType → Template → CatalogItem, and it is ambiguous (multiple Templates can reference the same HostType, multiple CatalogItems can reference the same Template).
+
+To avoid this ambiguity, the ClusterTemplate must carry the CatalogItem reference for CaaS node sets. This is a small addition to the ClusterTemplate metadata (`meta/osac.yaml`): a `catalog_item` field per node request entry, set by the Cloud Infrastructure Admin when defining the template. The controller reads the CatalogItem reference from the template parameters rather than reverse-looking it up from the HostType.
+
+Changing `resourceClass` itself to reference a CatalogItem instead of a HostType is a broader change that affects the entire stack (fulfillment-service, osac-operator, AAP roles, bare-metal-fulfillment-operator) and is out of scope for this design.
+
 #### System Tenant Isolation
 
 CaaS-managed BMIs are created under the builtin `system` tenant (`metadata.tenant = "system"`) rather than the cluster's tenant. The `system` tenant is a fulfillment-service builtin (migration 48) that is excluded from `DetermineVisibleTenants` — objects under it are invisible to all regular users without any additional filtering logic. This provides automatic tenant isolation: CaaS-managed BMIs never appear in tenant API responses (List, Get, Update, Delete) because the tenancy layer excludes them before any server-level filtering runs.
@@ -434,18 +443,23 @@ The MGMT-24903 fix (persistent-boot day-2 installs) is merged to assisted-servic
 
 #### Controller Reconciliation Structure
 
-The bare-metal worker management integrates into the existing ClusterOrder controller as a new reconciliation phase, invoked after the AAP provisioning job creates the HostedCluster:
+The bare-metal worker management is implemented as a **separate controller** (`BareMetalWorkerReconciler`) within osac-operator, not folded into the ClusterOrder controller. Both controllers watch the same `ClusterOrder` CR:
+
+- **ClusterOrder controller** — orchestrates the generic cluster lifecycle: AAP provisioning, NodePool management, status aggregation (`desiredWorkers`, `currentWorkers`, `readyWorkers` computed from the full `status.workers[]` list), and tenant-visible condition translation.
+- **BareMetalWorkerReconciler** — handles all BM-specific phases, invoked after the ClusterDeployment exists:
 
 1. **ensureInfraEnv** — list InfraEnvs owned by this ClusterOrder (via ownerReference); create one if none exists; wait for ignition readiness.
-2. **reconcileWorkers** — compare desired count (from `nodeRequests`) with current `workers` count. Create or delete BMIs as needed.
-3. **correlateAgents** — watch Agents, match to BMIs via MAC, label for NodePool.
+2. **reconcileWorkers** — compare desired count (from bare-metal `nodeRequests`) with current BM workers in `status.workers[]` (filtered by `kind: BareMetalInstance`). Create or delete BMIs as needed.
+3. **correlateAgents** — watch Agents, match to BMIs via MAC, bind to cluster, label for NodePool.
 4. **reconcileNodePoolReplicas** — set NodePool replicas to match the number of correlated agents.
 
-Each phase is idempotent. The controller re-enters from the top on each reconciliation cycle and progresses through completed phases without repeating side effects (BMI creation is guarded by checking `status.workers` for existing entries).
+This separation keeps the ClusterOrder controller generic — it does not contain BM-specific logic (InfraEnv, ignition, MAC correlation, Agent handling). When VM worker support is added, a `VMWorkerReconciler` follows the same pattern without touching the BM controller or the ClusterOrder controller.
 
-**State rebuild on restart:** Worker lifecycle state (`phase`, `attemptCount`, failure details) is persisted in `ClusterOrder.status.workers[]` and survives controller restarts. On restart, the controller re-derives each worker's phase from live BMI and Agent state to detect changes that occurred while the controller was down — e.g., a BMI that transitioned to `Running` or an Agent that registered. For each entry in `status.workers[]`, the controller: (1) looks up the BMI via the private API using `resourceID`, (2) reads the BMI's MAC from status, (3) lists Agents in the cluster namespace and matches by MAC, (4) updates the phase if live state has progressed — e.g., BMI running with no matching Agent → `WaitingForAgent`; BMI running with bound Agent in NodePool → `Ready`; BMI gone → stale entry, remove. The `attemptCount` and failure history are preserved from the persisted status, not re-derived. For typical cluster sizes (3-50 workers), this is a handful of API calls per restart.
+**Shared `status.workers[]`:** Both BM and future VM worker controllers write to the same `status.workers[]` field, partitioned by `kind` — each controller only adds, updates, or removes entries matching its kind (`BareMetalInstance` or `ComputeInstance`). The ClusterOrder controller reads the full list to compute aggregates. If two controllers update status in the same reconciliation cycle, Kubernetes optimistic concurrency (`resourceVersion` conflict) causes one to retry on the next requeue — standard controller-runtime behavior, no data loss.
 
-All four phases are handled within the ClusterOrder controller rather than split across separate controllers because they share sequential dependencies and ClusterOrder status state. The InfraEnv must exist before BMIs can be created, BMIs must be provisioned before agents can be correlated, and agents must be correlated before NodePool replicas can be set. Splitting these into independent controllers would require coordination mechanisms (shared status fields, cross-controller watches) that add complexity without benefit — the ClusterOrder is the single natural owner of the full bare-metal worker lifecycle.
+Each phase is idempotent. The controller re-enters from the top on each reconciliation cycle and progresses through completed phases without repeating side effects (BMI creation is guarded by checking `status.workers` for existing entries with `kind: BareMetalInstance`).
+
+**State rebuild on restart:** Worker lifecycle state (`phase`, `attemptCount`, failure details) is persisted in `ClusterOrder.status.workers[]` and survives controller restarts. On restart, the controller re-derives each worker's phase from live BMI and Agent state to detect changes that occurred while the controller was down — e.g., a BMI that transitioned to `Running` or an Agent that registered. For each entry in `status.workers[]` with `kind: BareMetalInstance`, the controller: (1) looks up the BMI via the private API using `resourceID`, (2) reads the BMI's MAC from status, (3) lists Agents in the cluster namespace and matches by MAC, (4) updates the phase if live state has progressed — e.g., BMI running with no matching Agent → `WaitingForAgent`; BMI running with bound Agent in NodePool → `Ready`; BMI gone → stale entry, remove. The `attemptCount` and failure history are preserved from the persisted status, not re-derived.
 
 ### Security Considerations
 
@@ -476,7 +490,7 @@ The private API token (`OSAC_FULFILLMENT_TOKEN_FILE`) authenticates as `service-
 
 ### RBAC / Tenancy
 
-The osac-operator's ClusterRole must be extended with `get`, `list`, `watch`, and `patch` on `agents` in the `agent-install.openshift.io` API group. This is required for MAC correlation (watch/list), cluster binding (patch `clusterDeploymentName`), and NodePool label application (patch labels). The existing service account permissions for creating CRs in cluster namespaces and calling the private API are unchanged.
+The osac-operator's ClusterRole must be extended with `get`, `list`, `watch`, `patch`, and `delete` on `agents` in the `agent-install.openshift.io` API group. This is required for MAC correlation (watch/list), cluster binding (patch `clusterDeploymentName`), NodePool label application (patch labels), and Agent CR cleanup on scale-down (delete). The existing service account permissions for creating CRs in cluster namespaces and calling the private API are unchanged.
 
 CaaS-managed BMIs carry `metadata.tenant = "system"` (the builtin system tenant). The existing tenancy logic makes them invisible to all regular users — no label-based filtering is needed. The `osac.openshift.io/cluster-order` label links BMIs to their parent ClusterOrder, enabling Cloud Provider Admin queries via the private API.
 
@@ -538,18 +552,19 @@ Have the controller (or AAP role) create BareMetalInstance CRs directly on the h
 
 Replace the controller-based flow with a new AAP role that calls the private API and manages the agent correlation loop. **Rejected** because AAP jobs are one-shot — they do not naturally handle the asynchronous agent registration and correlation flow. The controller's watch-based reconciliation model is the correct abstraction for reacting to Agent CR state changes over time. Scale-up and scale-down events also need reactive handling that controllers provide.
 
+
 ## Test Plan
 
 ### Unit Tests
 
-- ClusterOrder controller: `reconcileWorkers` creates the correct number of BMIs when desired count exceeds current count.
-- ClusterOrder controller: `reconcileWorkers` calls `BareMetalInstances.Delete` for excess BMIs when desired count is less than current count.
-- ClusterOrder controller: `correlateAgents` matches an Agent to a BMI when their MAC addresses match.
-- ClusterOrder controller: `correlateAgents` does not match Agents from a different namespace.
-- ClusterOrder controller: `ensureInfraEnv` creates an InfraEnv with late binding (no `clusterRef`) and correct owner reference.
-- ClusterOrder controller: worker phase transitions correctly through `Provisioning` → `WaitingForAgent` → `Binding` → `Ready`.
-- ClusterOrder controller: worker phase transitions to `Failed` after agent registration timeout.
-- ClusterOrder controller: reconciliation is idempotent — re-running with the same state produces no new API calls.
+- BareMetalWorkerReconciler: `reconcileWorkers` creates the correct number of BMIs when desired count exceeds current count.
+- BareMetalWorkerReconciler: `reconcileWorkers` calls `BareMetalInstances.Delete` for excess BMIs when desired count is less than current count.
+- BareMetalWorkerReconciler: `correlateAgents` matches an Agent to a BMI when their MAC addresses match.
+- BareMetalWorkerReconciler: `correlateAgents` does not match Agents from a different namespace.
+- BareMetalWorkerReconciler: `ensureInfraEnv` creates an InfraEnv with late binding (no `clusterRef`) and correct owner reference.
+- BareMetalWorkerReconciler: worker phase transitions correctly through `Provisioning` → `WaitingForAgent` → `Binding` → `Ready`.
+- BareMetalWorkerReconciler: worker phase transitions to `Failed` after agent registration timeout.
+- BareMetalWorkerReconciler: reconciliation is idempotent — re-running with the same state produces no new API calls.
 - System tenant isolation: CaaS-managed BMIs under `system` tenant are not returned by public `BareMetalInstances.List` for any regular tenant.
 - System tenant isolation: public `BareMetalInstances.Get` returns `NotFound` for system-tenant BMIs when called by a regular tenant.
 - RBAC: osac-operator's ClusterRole includes `patch` on `agents` in the `agent-install.openshift.io` API group.

--- a/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
+++ b/enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/design.md
@@ -11,6 +11,8 @@ prd:
 see-also:
   - "/enhancements/OSAC-2540-disk-image"
   - "/enhancements/OSAC-1201-baremetal-instance-types"
+  - "/enhancements/OSAC-1330-type-safe-resource-references"
+  - "/enhancements/OSAC-1567-secret-management"
 replaces:
   - N/A
 superseded-by:
@@ -21,13 +23,13 @@ superseded-by:
 
 ## Summary
 
-This design adds on-demand bare-metal worker node provisioning to CaaS by having the osac-operator ClusterOrder controller create BareMetalInstances via the fulfillment-service private gRPC API. Each instance references a pre-registered RHCOS DiskImage and carries cluster-specific discovery ignition as `user_data`, causing the host to register as an assisted-service Agent and join the HyperShift-managed cluster as a worker node. The existing BareMetalPool-based static pre-boot pool is removed. See [PRD](prd.md) for detailed requirements.
+This design adds on-demand bare-metal worker node provisioning to CaaS by having the osac-operator ClusterOrder controller create BareMetalInstances via the fulfillment-service private gRPC API. Each instance references a pre-registered RHCOS DiskImage and a Secret containing discovery ignition from the shared platform-level InfraEnv, causing the host to register as an assisted-service Agent and join the HyperShift-managed cluster as a worker node. The existing BareMetalPool-based static pre-boot pool is removed. See [PRD](prd.md) for detailed requirements.
 
 ## Motivation
 
 CaaS currently provisions bare-metal worker nodes through a static pre-boot pool: a cron job maintains hosts running the Assisted Installer ISO via BareMetalPool resources. This wastes capacity on idle hosts, is difficult to right-size, and couples cluster provisioning to a fragile pool management process. When the pool is exhausted, cluster scale-up fails silently until an administrator intervenes.
 
-The new approach eliminates the pool by provisioning workers on-demand. When a ClusterOrder specifies bare-metal resource classes, the controller creates individual BareMetalInstances through the BMaaS private API, each configured with a cluster-specific discovery ignition. This gives CaaS per-instance control over image and boot configuration while keeping all infrastructure details hidden from tenants. The PoC (OSAC-2817) validated this flow end-to-end: BMI provisioning took approximately 6 minutes, the agent registered successfully, and the worker joined the HyperShift cluster.
+The new approach eliminates the pool by provisioning workers on-demand. When a ClusterOrder specifies bare-metal resource classes, the controller creates individual BareMetalInstances through the BMaaS private API, each configured with discovery ignition and a version-matched RHCOS DiskImage. This gives CaaS per-instance control over image and boot configuration while keeping all infrastructure details hidden from tenants. The PoC (OSAC-2817) validated this flow end-to-end: BMI provisioning took approximately 6 minutes, the agent registered successfully, and the worker joined the HyperShift cluster.
 
 ### Goals
 
@@ -49,11 +51,11 @@ The new approach eliminates the pool by provisioning workers on-demand. When a C
 
 The ClusterOrder controller in osac-operator gains a new reconciliation phase for bare-metal worker management. When a ClusterOrder's `nodeRequests` reference bare-metal resource classes, the controller:
 
-1. Creates a cluster-specific `InfraEnv` CR on the hub cluster to generate discovery ignition.
-2. Creates `BareMetalInstance` objects via the fulfillment-service private API, passing the RHCOS qcow2 image URL and the InfraEnv's discovery ignition as `user_data`.
-3. Correlates registered Agents to BMIs via MAC address and labels them for NodePool selection.
+1. Ensures a shared `InfraEnv` CR exists on the hub cluster to generate discovery ignition (one per platform, not per cluster).
+2. Stores the InfraEnv's discovery ignition as a Secret via `Secrets.Create` on the private API, then creates `BareMetalInstance` objects referencing the RHCOS DiskImage and the ignition Secret.
+3. Correlates registered Agents to BMIs via MAC address, binds them to the cluster's ClusterDeployment, and labels them for NodePool selection.
 
-No new CRDs are introduced. The design extends the ClusterOrder CRD status with a `workers` field to track CaaS-managed worker resources. BareMetalInstances created by CaaS are hidden from tenant APIs via a well-known metadata label.
+No new CRDs are introduced. The design extends the ClusterOrder CRD status with a `workers` field to track CaaS-managed worker resources. BareMetalInstances created by CaaS are assigned to the builtin `system` tenant, making them invisible to tenant APIs via the existing tenancy logic.
 
 **Dependencies (unresolved — block implementation):**
 
@@ -61,6 +63,7 @@ No new CRDs are introduced. The design extends the ClusterOrder CRD status with 
 |-----------|------|----------------------|
 | MAC address in BareMetalInstance status | [OSAC-2308](https://redhat.atlassian.net/browse/OSAC-2308), [OSAC-3254](https://redhat.atlassian.net/browse/OSAC-3254) | Agent-to-BMI correlation impossible; entire feature blocked |
 | DiskImage resource + BMI DiskImage integration | [OSAC-2540](https://redhat.atlassian.net/browse/OSAC-2540), [OSAC-1270](https://redhat.atlassian.net/browse/OSAC-1270) | Controller cannot resolve RHCOS boot image; BMI creation blocked |
+| BMaaS networking for subnet attachment | [OSAC-1437](https://redhat.atlassian.net/browse/OSAC-1437) | BMI creation requires `network_attachments`; without BMaaS subnet support, workers cannot be moved to the tenant subnet and will not receive DHCP-assigned IPs on the correct network |
 
 The existing BareMetalPool-based static pre-boot pool is removed as part of this work. The `cluster_infra` AAP step that creates BareMetalPool CRs and the scheduled `osac-import-agents` AAP job that discovers and imports hosts are no longer used by CaaS. Any remaining BareMetalPool resources are drained and cleaned up during rollout. The BareMetalPool CRD itself is retained (it serves BMaaS standalone use cases) but CaaS no longer creates or references BareMetalPool resources.
 
@@ -89,7 +92,7 @@ sequenceDiagram
     AAP->>HCP: Create HostedCluster + NodePool
     HCP-->>CO: ClusterDeployment exists
 
-    CO->>CO: Create InfraEnv CR (refs ClusterDeployment)
+    CO->>CO: Verify shared InfraEnv exists
     AS-->>CO: InfraEnv ready (discovery ignition available)
 
     loop For each requested bare-metal worker
@@ -112,14 +115,15 @@ The diagram shows the end-to-end provisioning flow. The controller waits for eac
 **Step-by-step:**
 
 1. The ClusterOrder controller detects `nodeRequests` with bare-metal resource classes by checking the resource class against BareMetalInstanceType definitions.
-2. After AAP creates the HostedCluster and the ClusterDeployment CR exists, the controller creates an `InfraEnv` CR in the cluster's namespace. The InfraEnv references the ClusterDeployment, the pull secret, and the SSH public key from the ClusterOrder spec.
-3. The controller polls the InfraEnv status until `status.bootArtifacts.discoveryIgnitionURL` is populated, then fetches the discovery ignition content from that URL.
-4. For each bare-metal worker requested, the controller calls `BareMetalInstances.Create` on the private API with: `spec.catalog_item` resolved from the resource class, `spec.image` set to the resolved RHCOS DiskImage ID (see RHCOS DiskImage Resolution), `spec.user_data` set to the discovery ignition, `spec.network_attachments` from the ClusterOrder's network attachment configuration, and `metadata.labels["osac.openshift.io/managed-by"] = "caas"`.
-5. The controller updates ClusterOrder status with the BMI IDs in `workers[]`.
-6. BMaaS allocates a host, writes the qcow2 to disk via Ironic, and boots with the discovery ignition. The host registers as an Agent with assisted-service.
-7. The controller watches Agent CRs in the cluster namespace. When a new Agent appears, the controller matches its inventory MAC address against BMI status MAC addresses (`status.host.mac_address`, dependency OSAC-2308/OSAC-3254).
-8. Once correlated, the controller sets the Agent's `clusterDeploymentName` to the cluster's ClusterDeployment and applies the `agentBareMetal` role label so the NodePool's `agentLabelSelector` selects it. This requires the osac-operator to modify `agent-install.openshift.io/v1beta1` Agent resources — a cross-API-group coupling. This is unavoidable: the assisted-service Agent API does not provide an auto-bind mechanism for late-binding agents, so an external controller must set `clusterDeploymentName` and apply labels. The osac-operator's RBAC must include `patch` on `agents` in the `agent-install.openshift.io` API group.
-9. HyperShift installs the Agent as a worker node. The controller monitors NodePool `.status.replicas` to confirm convergence.
+2. After AAP creates the HostedCluster and the ClusterDeployment CR exists, the controller ensures the shared platform-level `InfraEnv` CR exists (see InfraEnv Creation). The InfraEnv has no `clusterRef` — agents register as unbound and the controller explicitly binds them to the correct cluster in step 9.
+3. The controller reads the InfraEnv's `status.bootArtifacts.discoveryIgnitionURL` and fetches the discovery ignition content. The ignition is architecture-neutral (the `assisted-installer-agent` image is a multi-arch manifest), so the same InfraEnv serves hosts of any architecture.
+4. The controller creates a Secret via `Secrets.Create` on the private API, storing the discovery ignition content. The Secret is encrypted at rest via the Vault backend (OSAC-1567). One Secret is created per cluster for lifecycle management (deleted when the cluster is decommissioned), even though the ignition content is identical across clusters since it comes from the shared InfraEnv.
+5. For each bare-metal worker requested, the controller calls `BareMetalInstances.Create` on the private API with: `spec.catalog_item` resolved from the resource class, `spec.image` set to the resolved RHCOS DiskImage ID (see RHCOS DiskImage Resolution), `spec.user_data` referencing the ignition Secret, `spec.network_attachments` built from the Cluster's `ClusterNetworkAttachment` (subnet + security groups) and the node set's HostType (fabric interface), and `metadata.tenant = "system"` (see System Tenant Isolation). The network attachment mapping is a pass-through: the controller reads the Cluster's `ClusterNetworkAttachment` for the subnet and security group references, resolves the fabric interface name from the node set's HostType definition (first interface with role `fabric`), and constructs a `BareMetalNetworkAttachment` with `primary: true`. BMaaS handles the physical networking — moving the host to the tenant subnet VLAN and assigning an IP via fabric DHCP — as part of BMI provisioning (dependency: OSAC-1437). If the host fails to join the tenant network, the agent will not register on the expected subnet, and the existing `AgentRegistrationTimeout` handles this failure mode. API and ingress VIPs are provisioned by the existing AAP template (MetalLB LoadBalancer Services) and are not managed by this controller.
+6. The controller updates ClusterOrder status with the BMI IDs in `workers[]`.
+7. BMaaS allocates a host, writes the qcow2 to disk via Ironic, and boots with the discovery ignition. The host registers as an Agent with assisted-service.
+8. The controller watches Agent CRs in the cluster namespace. When a new Agent appears, the controller matches its inventory MAC address against BMI status MAC addresses (`status.host.mac_address`, dependency OSAC-2308/OSAC-3254).
+9. Once correlated, the controller sets the Agent's `clusterDeploymentName` to the cluster's ClusterDeployment and applies the `agentBareMetal` role label so the NodePool's `agentLabelSelector` selects it. This requires the osac-operator to modify `agent-install.openshift.io/v1beta1` Agent resources — a cross-API-group coupling. This is unavoidable: the assisted-service Agent API does not provide an auto-bind mechanism for late-binding agents, so an external controller must set `clusterDeploymentName` and apply labels. The osac-operator's RBAC must include `patch` on `agents` in the `agent-install.openshift.io` API group.
+10. HyperShift installs the Agent as a worker node. The controller monitors NodePool `.status.replicas` to confirm convergence.
 
 #### Scale-Up
 
@@ -127,10 +131,10 @@ A Tenant User increases `node_sets[].size` for a bare-metal node set. The fulfil
 
 **Step-by-step:**
 
-1. The controller computes `desired - current` where `current` counts workers in any phase except `Deleting`. Workers in `Failed` phase count toward `current` — they are not automatically retried.
-2. The controller re-reads the InfraEnv's `status.bootArtifacts.discoveryIgnitionURL` to fetch fresh ignition. The InfraEnv persists from initial provisioning; if it was deleted (e.g., manual cleanup), the `ensureInfraEnv` phase recreates it.
+1. The controller computes `desired - current` where `current` is `status.currentWorkers` (workers in active phases: `Provisioning`, `WaitingForAgent`, `Binding`, `Ready`). Workers in `Failed` phase do not count toward capacity — new workers are created to fill the gap once their retry backoff expires.
+2. The controller re-reads the shared InfraEnv's `status.bootArtifacts.discoveryIgnitionURL` to fetch fresh ignition.
 3. The controller resolves the RHCOS DiskImage from the NodePool's current release image (not the ClusterOrder's original). This ensures workers added after a cluster upgrade use a compatible boot image.
-4. For each new worker, the controller follows provisioning steps 4-9 from the initial flow.
+4. For each new worker, the controller follows provisioning steps 4-10 from the initial flow (the ignition Secret from step 4 is reused — one per cluster, not per worker).
 5. Partial success is reported: if 3 of 5 new workers succeed and 2 fail, the ClusterOrder status shows 3 additional `Ready` workers and 2 `Failed`. The tenant sees the cluster with the successfully added workers; the failed slots are visible via ClusterOrder conditions and events.
 
 #### Scale-Down
@@ -153,7 +157,7 @@ sequenceDiagram
     CO->>CO: Match unbound Agent to BMI via MAC
     CO->>BMaaS: Delete BareMetalInstance
     BMaaS->>BMaaS: Host cleanup (disk wipe, network reset)
-    CO->>CO: Remove BMI from status.workers
+    CO->>CO: Remove worker from status.workers (after BMI CR gone)
 ```
 
 This diagram shows the scale-down flow. CAPI handles node drain and agent unbinding automatically. The controller reacts to the agent reaching an unbound state and then cleans up the BMI.
@@ -161,18 +165,18 @@ This diagram shows the scale-down flow. CAPI handles node drain and agent unbind
 **Step-by-step:**
 
 1. The controller computes the excess worker count (current minus desired).
-2. The controller decreases NodePool `.spec.replicas` by the excess count.
+2. The controller removes `Failed` workers first — deletes their dead BMIs and removes their `status.workers` entries. If more removals are needed after clearing all failed slots, the controller decreases NodePool `.spec.replicas` by the remaining excess.
 3. CAPI's MachineDeployment controller (used by HyperShift's default Replace upgrade type) manages MachineSets, which select Machines for deletion. CaaS does not control the selection order.
 4. CAPI drains each selected node, then the AgentMachine controller unbinds the Agent (clears `ClusterDeploymentName`, removes labels and ignition refs).
 5. Because BMH resources exist, the Agent enters `UnbindingPendingUserAction`. The BMH agent controller triggers Ironic deprovision (clears `bmh.Spec.Image`, removes the `detached` annotation).
 6. The controller watches for Agents transitioning to any `*-unbound` terminal state (`discovering-unbound`, `known-unbound`, `disconnected-unbound`, `insufficient-unbound`, `disabled-unbound`).
 7. The controller matches the unbound Agent back to a BMI via MAC address.
 8. The controller calls `BareMetalInstances.Delete` on the private API. BMaaS handles full host cleanup (disk wipe, network reset) before returning the host to inventory. CaaS does not independently verify cleanup completion — this is a trust boundary between CaaS and BMaaS. If BMaaS cleanup fails, the host must not be reallocated; this guarantee is BMaaS's responsibility.
-9. The controller removes the entry from `status.workers`.
+9. The controller retains the worker entry in `status.workers` until the BMI CR no longer exists on the hub cluster (confirming terminal deletion). This prevents orphaned hosts — if `Delete` succeeds but cleanup stalls, the controller still has the reference to retry or alert.
 
 #### Cluster Deletion
 
-On ClusterOrder deletion, the controller runs the scale-down flow for all remaining workers (steps 2-9) before allowing the AAP deprovision job to destroy the HostedCluster. The InfraEnv CR is cleaned up automatically by Kubernetes garbage collection via its ownerReference to the ClusterOrder — no explicit deletion is needed. The ClusterOrder's finalizer prevents premature deletion, ensuring all BMIs are cleaned up before the ClusterOrder (and its owned InfraEnv) are removed.
+On ClusterOrder deletion, the controller runs the scale-down flow for all remaining workers (steps 2-9) before allowing the AAP deprovision job to destroy the HostedCluster. The shared InfraEnv is not deleted — it is a platform-level resource that persists across cluster lifecycles. The ClusterOrder's finalizer prevents premature deletion, ensuring all BMIs are cleaned up before the ClusterOrder is removed.
 
 ### API Extensions
 
@@ -180,13 +184,21 @@ On ClusterOrder deletion, the controller runs the scale-down flow for all remain
 
 - `ClusterOrder` (osac-operator): new `workers` status field for tracking CaaS-managed worker resources. No spec changes — `nodeRequests[].resourceClass` already carries the information needed to identify bare-metal node sets.
 
-**New CRs created at runtime (not new CRD definitions):**
+**Existing CRs used (not new CRD definitions):**
 
-- `InfraEnv` (agent-install.openshift.io/v1beta1): one per cluster, created by the controller in the cluster's namespace. Owned by the ClusterOrder via an owner reference for garbage collection.
+- `InfraEnv` (agent-install.openshift.io/v1beta1): a shared platform-level InfraEnv in the `hardware-inventory` namespace. The controller verifies it exists but does not create or own it — it is a deployment prerequisite managed by the Cloud Provider Admin (the same InfraEnv already used by the existing agent import flow).
 
 **Modified behavior of existing resources:**
 
-- `BareMetalInstance` (fulfillment-service): CaaS-created BMIs carry `metadata.labels["osac.openshift.io/managed-by"] = "caas"`. The public `BareMetalInstances.List` API adds an implicit filter excluding BMIs with this label, so they do not appear in tenant listings. The private API returns all BMIs regardless. This change affects the fulfillment-service public server (`baremetal_instances_server.go`), which must inject the exclusion filter.
+- `BareMetalInstance` (fulfillment-service): CaaS-created BMIs are assigned to the builtin `system` tenant. No changes to the public API are required — the existing tenancy logic (`DetermineVisibleTenants`) already excludes the `system` tenant from regular user queries, making CaaS BMIs invisible to tenants automatically.
+
+**Tenant-visible status:** The PRD requires tenant-visible failure conditions. ClusterOrder conditions (`WorkersFailed`, `InfraEnvReady`, `RHCOSImageNotFound`) live on the hub cluster, which tenants cannot access. The existing feedback controller syncs ClusterOrder status to the public Cluster API via the `Signal` RPC. This design extends the feedback controller to translate worker conditions into the tenant-visible Cluster status:
+
+- `WorkersFailed=True` on ClusterOrder → `WORKER_PROVISIONING_FAILED` condition on the public Cluster, with a tenant-safe message (e.g., "2 of 5 worker nodes failed to provision") that omits infrastructure details (no BMI names, MACs, or Ironic errors)
+- Workers in `Failed` with high attempt count → Cluster condition message includes the attempt count and next retry time, so tenants know retries are ongoing
+- All other conditions (`InfraEnvReady=False`, `RHCOSImageNotFound`) → mapped to a generic `WORKER_PROVISIONING_BLOCKED` condition on the Cluster, indicating the cluster cannot provision workers due to an infrastructure issue requiring Cloud Infrastructure Admin intervention
+
+This ensures tenants see provisioning progress and actionable failure messages without exposure to CaaS internals. The condition names and feedback controller extension must align with OSAC-1604 (status reporting improvements) to avoid overlap — this design defines CaaS-specific worker conditions, while OSAC-1604 defines the general status reporting framework.
 
 **Operational impact:** If the osac-operator is down, no new bare-metal workers are provisioned and scale-up/scale-down operations stall. Existing workers continue running — HyperShift manages the cluster independently. On restart, the controller reconciles current state and resumes any pending operations.
 
@@ -202,77 +214,142 @@ This section does not apply. No UI changes are required — CaaS-managed BMIs ar
 type ClusterOrderStatus struct {
     // ... existing fields ...
 
-    // Workers references CaaS-managed worker resources (BareMetalInstance or ComputeInstance).
+    // Aggregate worker counts (aligned with the CAPI MachineDeployment convention).
     // +kubebuilder:validation:Optional
-    Workers []corev1.ObjectReference `json:"workers,omitempty"`
+    DesiredWorkers *int32 `json:"desiredWorkers,omitempty"`
+    // +kubebuilder:validation:Optional
+    CurrentWorkers *int32 `json:"currentWorkers,omitempty"`
+    // +kubebuilder:validation:Optional
+    ReadyWorkers *int32 `json:"readyWorkers,omitempty"`
+
+    // Per-worker lifecycle state.
+    // +kubebuilder:validation:Optional
+    Workers []WorkerStatus `json:"workers,omitempty"`
+}
+
+type WorkerStatus struct {
+    // Name of the worker slot (e.g., "bm-cluster-a-worker-0").
+    Name string `json:"name"`
+    // Kind of the backing resource (BareMetalInstance or ComputeInstance).
+    Kind string `json:"kind"`
+    // ResourceID is the fulfillment-service resource ID.
+    ResourceID string `json:"resourceID,omitempty"`
+    // Phase of the worker lifecycle.
+    // +kubebuilder:validation:Enum=Provisioning;WaitingForAgent;Binding;Ready;Failed;Unbinding;Deleting
+    Phase string `json:"phase"`
+    // AttemptCount tracks how many times this worker slot has been provisioned.
+    // Resets to 0 when a replacement stays Ready beyond MinHealthyDuration.
+    AttemptCount int32 `json:"attemptCount"`
+    // LastFailureReason is a machine-readable reason for the last failure (e.g., AgentRegistrationTimeout).
+    // +kubebuilder:validation:Optional
+    LastFailureReason string `json:"lastFailureReason,omitempty"`
+    // LastFailureMessage is a human-readable description of the last failure.
+    // +kubebuilder:validation:Optional
+    LastFailureMessage string `json:"lastFailureMessage,omitempty"`
+    // LastFailureTime is when the last failure occurred.
+    // +kubebuilder:validation:Optional
+    LastFailureTime *metav1.Time `json:"lastFailureTime,omitempty"`
+    // NextRetryTime is when the controller will attempt the next retry.
+    // +kubebuilder:validation:Optional
+    NextRetryTime *metav1.Time `json:"nextRetryTime,omitempty"`
 }
 ```
 
-Each `corev1.ObjectReference` entry contains `Kind` (e.g., `BareMetalInstance` or `ComputeInstance`), `Namespace`, `Name`, and `APIVersion`, identifying the worker CR on the hub cluster. The controller resolves the fulfillment-service ID from the CR's `osac.openshift.io/baremetalinstance-uuid` label (or the equivalent ComputeInstance label) when it needs to call the private API. Worker lifecycle state (agent correlation, phase tracking) is managed in-memory by the controller and rebuilt from live CR and Agent state on restart — it is not persisted in the ClusterOrder status.
+**Aggregate counts** align with the CAPI MachineDeployment convention: `desiredWorkers` (from `nodeRequests`), `currentWorkers` (non-terminal: Provisioning + WaitingForAgent + Binding + Ready), `readyWorkers` (Ready phase only). This gives tenants, operators, and metering systems a single-glance view of cluster health without inspecting individual workers.
 
-Example: a 5-worker cluster where 3 workers are ready and 2 failed:
+**Per-worker state** is persisted in `workers[]`, not tracked in-memory. Each `WorkerStatus` entry carries the lifecycle phase, retry state, and failure details. The controller updates these fields on each reconciliation cycle. On restart, the controller rebuilds phases from live BMI and Agent state but preserves `attemptCount` and failure history from the persisted status — no dependency on Kubernetes events for retry tracking.
+
+Example: a 5-worker cluster where 3 workers are ready and 2 are retrying:
 
 ```yaml
 status:
   phase: Progressing
+  desiredWorkers: 5
+  currentWorkers: 5
+  readyWorkers: 3
   conditions:
     - type: WorkersFailed
       status: "True"
       reason: ProvisioningFailed
-      message: "2 of 5 bare-metal workers failed: bm-cluster-a-worker-2 (AgentRegistrationTimeout), bm-cluster-a-worker-4 (BMI provisioning error)"
+      message: "2 of 5 bare-metal workers failed provisioning, retrying"
     - type: InfraEnvReady
       status: "True"
   workers:
-    - kind: BareMetalInstance
-      namespace: osac-orders
-      name: bm-cluster-a-worker-0
-      apiVersion: osac.openshift.io/v1alpha1
-    - kind: BareMetalInstance
-      namespace: osac-orders
-      name: bm-cluster-a-worker-1
-      apiVersion: osac.openshift.io/v1alpha1
-    - kind: BareMetalInstance
-      namespace: osac-orders
-      name: bm-cluster-a-worker-2
-      apiVersion: osac.openshift.io/v1alpha1
-    - kind: BareMetalInstance
-      namespace: osac-orders
-      name: bm-cluster-a-worker-3
-      apiVersion: osac.openshift.io/v1alpha1
-    - kind: BareMetalInstance
-      namespace: osac-orders
-      name: bm-cluster-a-worker-4
-      apiVersion: osac.openshift.io/v1alpha1
+    - name: bm-cluster-a-worker-0
+      kind: BareMetalInstance
+      resourceID: "uuid-0"
+      phase: Ready
+      attemptCount: 1
+    - name: bm-cluster-a-worker-1
+      kind: BareMetalInstance
+      resourceID: "uuid-1"
+      phase: Ready
+      attemptCount: 1
+    - name: bm-cluster-a-worker-2
+      kind: BareMetalInstance
+      resourceID: "uuid-2"
+      phase: Failed
+      attemptCount: 2
+      lastFailureReason: AgentRegistrationTimeout
+      lastFailureMessage: "Agent did not register within 30m"
+      lastFailureTime: "2026-08-10T14:30:00Z"
+      nextRetryTime: "2026-08-10T15:00:00Z"
+    - name: bm-cluster-a-worker-3
+      kind: BareMetalInstance
+      resourceID: "uuid-3"
+      phase: Ready
+      attemptCount: 1
+    - name: bm-cluster-a-worker-4
+      kind: BareMetalInstance
+      resourceID: "uuid-4"
+      phase: Failed
+      attemptCount: 3
+      lastFailureReason: BMIProvisioningFailed
+      lastFailureMessage: "Host allocation failed: no available hosts"
+      lastFailureTime: "2026-08-10T14:25:00Z"
+      nextRetryTime: "2026-08-10T14:55:00Z"
 ```
 
-The `workers[]` list always contains all worker references regardless of their individual state. The `WorkersFailed` condition provides the summary — which workers failed and why. The ClusterOrder remains in `Progressing` phase (not `Failed`) because 3 workers are operational. The operator inspects individual BMIs via the private API to diagnose failures.
+The `workers[]` list always contains all worker references regardless of their individual state. The `WorkersFailed` condition provides the aggregate summary. The ClusterOrder remains in `Progressing` phase (not `Failed`) because 3 workers are operational. Per-worker detail (which slot failed, why, when the next retry is) is visible directly in the status.
 
-The controller tracks worker lifecycle internally through phases: `Provisioning` → `WaitingForAgent` → `Binding` → `Ready` (and `Unbinding` → `Deleting` for scale-down). `Failed` is reachable from any active phase and is terminal — the controller does not automatically retry failed workers. Failures are reported via ClusterOrder conditions and Kubernetes events.
+The controller tracks worker lifecycle through phases: `Provisioning` → `WaitingForAgent` → `Binding` → `Ready` (and `Unbinding` → `Deleting` for scale-down). `Failed` is reachable from any active phase.
+
+**Retry behavior:** The API is declarative — the controller retries indefinitely until the desired state is reached. There is no `PermanentlyFailed` state. When a worker enters `Failed`, the controller deletes the failed BMI and creates a replacement with escalating backoff:
+
+| Failure type | Examples | Backoff | Rationale |
+|---|---|---|---|
+| Transient infrastructure | BMaaS API timeout, Ironic temporary error, host allocation contention | Short exponential: 30s, 60s, 120s, capped at 5m | Likely to resolve quickly; fresh host allocation may succeed immediately |
+| Resource availability | No hosts available for the requested BareMetalInstanceType | Long exponential: 5m, 15m, 30m, capped at 30m | Inventory needs time to free up; aggressive retry wastes API calls |
+| Agent registration timeout | Host booted but agent did not register within 30m | Long exponential: 5m, 15m, 30m, capped at 30m | Root cause (bad image URL, broken InfraEnv, network) is unlikely to self-resolve; gives operator time to investigate before next attempt burns another host |
+
+The `attemptCount` is persisted in `WorkerStatus` and survives controller restarts. After the initial escalation period (first 3 attempts), the backoff caps at the maximum for that failure type and the controller continues retrying at that interval. If a replacement succeeds and stays `Ready` for 1 hour (`MinHealthyDuration`), the `attemptCount` resets to 0 — distinguishing a resolved transient issue from a recurring problem.
+
+The `WorkersFailed` condition reports which slots are retrying (with attempt number and next retry time), so operators are alerted and can investigate. For persistent misconfigurations (wrong DiskImage, broken network), the capped backoff ensures the controller does not burn hosts aggressively while still converging once the root cause is fixed.
+
+**Scale-down priority:** When the tenant scales down, the controller removes `Failed` workers first — they have no running node, no bound agent, and only a dead BMI to clean up. Healthy workers are only removed after all failed slots are cleared.
+
+This satisfies the PRD requirement: "CaaS automatically handles provisioning retries and release of failed bare-metal resources, so that transient BMaaS failures do not leave orphaned infrastructure."
 
 #### InfraEnv Creation
 
-The controller creates one InfraEnv per ClusterOrder. The InfraEnv spec:
+The controller ensures a single shared InfraEnv exists at the platform level, rather than creating one per cluster. The InfraEnv spec:
 
 ```yaml
 apiVersion: agent-install.openshift.io/v1beta1
 kind: InfraEnv
 metadata:
-  name: <cluster-order-name>-infraenv
-  namespace: <cluster-namespace>
-  ownerReferences:
-    - apiVersion: osac.openshift.io/v1alpha1
-      kind: ClusterOrder
-      name: <cluster-order-name>
+  name: infraenv
+  namespace: hardware-inventory
 spec:
-  clusterRef:
-    name: <cluster-deployment-name>
-    namespace: <cluster-namespace>
   pullSecretRef:
-    name: <pull-secret-name>
-  sshAuthorizedKey: <from ClusterOrder spec>
+    name: pull-secret
 ```
 
-One InfraEnv per cluster prevents cross-tenant agent races. If two clusters shared an InfraEnv, an agent from cluster A could be mistakenly assigned to cluster B during concurrent scale operations.
+The InfraEnv has no `clusterRef` and no `sshAuthorizedKey` — it generates unbound discovery ignition that is not scoped to any cluster. Agent-to-cluster binding happens explicitly in the correlation phase (step 9), where the controller sets `clusterDeploymentName` on each Agent after MAC-based matching.
+
+**Why a shared InfraEnv:** The discovery ignition is architecture-neutral (`assisted-installer-agent` is a multi-arch manifest) and does not vary by cluster or tenant. The `cpuArchitecture` field on InfraEnv only affects ISO/kernel/rootfs URLs in `status.bootArtifacts`, not the ignition content — and this design uses the ignition-only flow, not ISO download. The InfraEnv's pull secret is a platform-level credential (Cloud Provider Admin's registry credentials for pulling the discovery agent image), separate from the per-cluster pull secret used for OCP release images. The existing OSAC deployment already uses a single `infraenv` in the `hardware-inventory` namespace with a platform-level `pull-secret`.
+
+Agent-to-cluster isolation is enforced by the MAC correlation algorithm (see MAC Address Correlation), which scopes matching to the ClusterOrder's owned BMIs. Cross-tenant agent misassignment is not possible because each BMI carries the `osac.openshift.io/cluster-order` ownership label, and the controller only binds Agents whose MAC matches a BMI owned by the current ClusterOrder.
 
 #### RHCOS DiskImage Resolution
 
@@ -284,13 +361,13 @@ Using the NodePool's current release image rather than the ClusterOrder's origin
 
 The boot image is ephemeral — it exists only to run the discovery agent. The assisted-installer writes the correct RHCOS version (pinned to the release image) to disk during installation. Any Z stream within the same minor version is acceptable for the boot image.
 
-If no matching DiskImage is found for the target OCP version, the controller sets the ClusterOrder condition `RHCOSImageNotFound` and does not proceed with BMI creation. The Cloud Infrastructure Admin must register the missing DiskImage before provisioning can continue.
+If no matching DiskImage is found for the target OCP version, the controller sets the ClusterOrder condition `RHCOSImageNotFound` and does not proceed with BMI creation. If multiple DiskImages match the same version and architecture, the controller sets `RHCOSImageAmbiguous` and does not proceed — the Cloud Infrastructure Admin must ensure exactly one DiskImage exists per OCP version + architecture combination.
 
 If the underlying OCI artifact referenced by the DiskImage is unreachable or the image download fails at Ironic, the BMI enters `Failed` phase. The failure is reported via ClusterOrder conditions.
 
 #### BMI Creation via Private API
 
-For each worker, the controller calls `BareMetalInstances.Create` on the private API. The existing `BareMetalInstanceSpec` proto already has the required fields. The only proto change is a new `source_type` value (`"disk_image"`) on `BareMetalInstanceImage`:
+For each worker, the controller calls `BareMetalInstances.Create` on the private API. The existing `BareMetalInstanceSpec` proto already has the required fields. The `source_type` value `"disk_image"` on `BareMetalInstanceImage` is introduced by the DiskImage integration (OSAC-1270) — this design consumes it but does not own the proto change:
 
 ```protobuf
 // Existing fields in osac.private.v1.BareMetalInstanceSpec used by CaaS
@@ -298,13 +375,13 @@ For each worker, the controller calls `BareMetalInstances.Create` on the private
 message BareMetalInstanceSpec {
   string catalog_item = ...;                                // resolved from nodeRequest.resourceClass → BareMetalInstanceCatalogItem
   optional BareMetalInstanceImage image = ...;              // RHCOS DiskImage reference (see DiskImage Resolution)
-  optional string user_data = ...;                          // discovery ignition fetched from InfraEnv (max 64KB)
+  optional string user_data = ...;                          // Secret reference containing discovery ignition
   repeated BareMetalNetworkAttachment network_attachments = ...;
   // ... other existing fields (ssh_public_key, run_strategy, template_parameters, etc.) omitted
 }
 
 message BareMetalInstanceImage {
-  string source_type = ...;  // existing value "registry"; this design proposes adding "disk_image" for DiskImage references
+  string source_type = ...;  // existing value "registry"; "disk_image" added by OSAC-1270
   string source_ref = ...;   // DiskImage ID resolved for target OCP version + architecture
 }
 ```
@@ -312,54 +389,60 @@ message BareMetalInstanceImage {
 The controller sets the following metadata fields on the created BMI:
 
 - `name`: `"<cluster-order-name>-worker-<index>"`
-- `labels["osac.openshift.io/managed-by"]`: `"caas"` — visibility filter key
 - `labels["osac.openshift.io/cluster-order"]`: `"<order-id>"` — links BMI to parent ClusterOrder
 - `annotations["osac.openshift.io/owner-reference"]`: `"ClusterOrder/<order-id>"`
 
-#### Visibility Filtering
+#### System Tenant Isolation
 
-The public `BareMetalInstances.List` implementation adds an implicit CEL filter clause: `!has(this.metadata.labels["osac.openshift.io/managed-by"])` (or equivalent SQL-level filtering). This ensures CaaS-managed BMIs never appear in tenant API responses. Cloud Provider Admins access CaaS BMIs via the private API or by explicitly filtering with `this.metadata.labels["osac.openshift.io/managed-by"] == "caas"`.
+CaaS-managed BMIs are created under the builtin `system` tenant (`metadata.tenant = "system"`) rather than the cluster's tenant. The `system` tenant is a fulfillment-service builtin (migration 48) that is excluded from `DetermineVisibleTenants` — objects under it are invisible to all regular users without any additional filtering logic. This provides automatic tenant isolation: CaaS-managed BMIs never appear in tenant API responses (List, Get, Update, Delete) because the tenancy layer excludes them before any server-level filtering runs.
 
-The `BareMetalInstances.Get`, `Update`, and `Delete` methods on the public API also reject requests for CaaS-managed BMIs with `NotFound`, preventing tenants from interacting with infrastructure they should not see. The `NotFound` response is indistinguishable from a genuinely non-existent BMI — a tenant cannot determine whether a given ID refers to a CaaS-managed instance or simply does not exist, preventing information disclosure about hidden infrastructure.
+This is semantically correct: CaaS-managed BMIs are platform infrastructure, not tenant resources. The tenant ordered a cluster with N workers — they did not order N individual BareMetalInstances. Ownership is traceable via the `osac.openshift.io/owner-reference` annotation, which links each BMI to its parent ClusterOrder (which belongs to the real tenant).
 
-Cloud Provider Admins who need to debug CaaS-managed workers (ssh, console, restart — per PRD user story) use the private API, which returns all BMIs regardless of the `managed-by` label.
+**No changes to the public API** are required — no label-based filter injection in List, no NotFound interception in Get/Update/Delete, no reserved-label validation in Create/Update. The existing tenancy logic handles everything.
 
-The public API rejects `Create` and `Update` requests that set `osac.openshift.io/managed-by` to a reserved value (`caas`). This prevents tenants from hiding their own resources by self-applying the label, which would break audit trail integrity.
+**Metering:** CaaS resource attribution is at the Cluster level (which belongs to the real tenant), not at the BMI level. Worker count is derived from the ClusterOrder status, not from querying BMIs by tenant.
+
+**Cloud Provider Admin access:** Admins debug CaaS-managed workers via the private API (which has unrestricted tenant access) or by querying the `system` tenant explicitly. Per-cluster lookups use the `osac.openshift.io/cluster-order` label.
 
 #### MAC Address Correlation
 
-Agent-to-BMI matching uses MAC addresses. When a BMI reaches `Running` state, its status includes the allocated host's MAC address (exact field path TBD — depends on OSAC-2308/OSAC-3254, which add inventory metadata to BareMetalInstance status; the field does not exist in the current proto). When an Agent registers, its inventory includes NIC MAC addresses at `status.inventory.interfaces[].macAddress`. The controller matches by finding the Agent whose inventory contains a MAC matching a BMI's status MAC.
+Agent-to-BMI matching uses MAC addresses scoped to the cluster's namespace and ClusterOrder. When a BMI reaches `Running` state, its status includes the allocated host's MAC address (exact field path TBD — depends on OSAC-2308/OSAC-3254, which add inventory metadata to BareMetalInstance status; the field does not exist in the current proto). When an Agent registers, its inventory includes NIC MAC addresses at `status.inventory.interfaces[].macAddress`.
 
-The controller maintains an in-memory index of pending (uncorrelated) BMIs and their MACs. On each Agent watch event, it checks for a match. If no match is found within a configurable timeout (default: 30 minutes), the controller sets the worker phase to `Failed` with reason `AgentRegistrationTimeout`.
+The correlation algorithm requires a unique match across three dimensions before binding:
+1. **Namespace:** The Agent must be in the same namespace as the ClusterOrder's cluster
+2. **Ownership:** The candidate BMI must carry the `osac.openshift.io/cluster-order` label matching the current ClusterOrder
+3. **MAC match:** The Agent's inventory MAC must match the BMI's status MAC
+
+If zero candidates match, the controller continues watching. If multiple candidates match (should not happen — MACs are unique per host), the controller logs an error and does not bind, preventing ambiguous correlation. If no match is found within a configurable timeout (default: 30 minutes), the controller sets the worker phase to `Failed` with reason `AgentRegistrationTimeout`.
 
 #### Minimum MCE Version
 
-The MGMT-24903 fix (persistent-boot day-2 installs) is merged to assisted-service master ([PR #10717](https://github.com/openshift/assisted-service/pull/10717), 2026-07-29) and assisted-installer-agent master ([PR #1568](https://github.com/openshift/assisted-installer-agent/pull/1568), 2026-07-30). The fix is not yet in a tagged release (post-v2.55.0). The design requires a MCE version shipping these commits. Without them, workers fail to install because `osImageURL` is stripped from the ignition config. The controller does not implement a workaround — the deployment prerequisite documentation must specify the minimum MCE version.
+The MGMT-24903 fix (persistent-boot day-2 installs) is merged to assisted-service master ([PR #10717](https://github.com/openshift/assisted-service/pull/10717), 2026-07-29) and assisted-installer-agent master ([PR #1568](https://github.com/openshift/assisted-installer-agent/pull/1568), 2026-07-30). The fix ships in MCE 5.0. Without it, workers fail to install because `osImageURL` is stripped from the ignition config. The controller does not implement a workaround — MCE >= 5.0 is a deployment prerequisite.
 
 #### Controller Reconciliation Structure
 
 The bare-metal worker management integrates into the existing ClusterOrder controller as a new reconciliation phase, invoked after the AAP provisioning job creates the HostedCluster:
 
-1. **ensureInfraEnv** — list InfraEnvs owned by this ClusterOrder (via ownerReference); create one if none exists; wait for ignition readiness.
+1. **ensureInfraEnv** — verify the shared platform-level InfraEnv exists and has generated ignition; fail with `InfraEnvReady=False` if not.
 2. **reconcileWorkers** — compare desired count (from `nodeRequests`) with current `workers` count. Create or delete BMIs as needed.
 3. **correlateAgents** — watch Agents, match to BMIs via MAC, label for NodePool.
 4. **reconcileNodePoolReplicas** — set NodePool replicas to match the number of correlated agents.
 
 Each phase is idempotent. The controller re-enters from the top on each reconciliation cycle and progresses through completed phases without repeating side effects (BMI creation is guarded by checking `status.workers` for existing entries).
 
+**State rebuild on restart:** Worker lifecycle state (`phase`, `attemptCount`, failure details) is persisted in `ClusterOrder.status.workers[]` and survives controller restarts. On restart, the controller re-derives each worker's phase from live BMI and Agent state to detect changes that occurred while the controller was down — e.g., a BMI that transitioned to `Running` or an Agent that registered. For each entry in `status.workers[]`, the controller: (1) looks up the BMI via the private API using `resourceID`, (2) reads the BMI's MAC from status, (3) lists Agents in the cluster namespace and matches by MAC, (4) updates the phase if live state has progressed — e.g., BMI running with no matching Agent → `WaitingForAgent`; BMI running with bound Agent in NodePool → `Ready`; BMI gone → stale entry, remove. The `attemptCount` and failure history are preserved from the persisted status, not re-derived. For typical cluster sizes (3-50 workers), this is a handful of API calls per restart.
+
 All four phases are handled within the ClusterOrder controller rather than split across separate controllers because they share sequential dependencies and ClusterOrder status state. The InfraEnv must exist before BMIs can be created, BMIs must be provisioned before agents can be correlated, and agents must be correlated before NodePool replicas can be set. Splitting these into independent controllers would require coordination mechanisms (shared status fields, cross-controller watches) that add complexity without benefit — the ClusterOrder is the single natural owner of the full bare-metal worker lifecycle.
 
 ### Security Considerations
 
-CaaS-managed BMIs are created in the tenant's context via the private API. The private API bypasses tenant-scoped OPA policies because it operates with system-level credentials. The BMIs carry the tenant's `metadata.tenant` field for attribution but are not visible to the tenant through the public API (label-based filtering).
+CaaS-managed BMIs are created under the builtin `system` tenant via the private API. The `system` tenant is excluded from `DetermineVisibleTenants`, so these BMIs are invisible to all regular users without any additional filtering. The private API bypasses tenant-scoped OPA policies because it operates with system-level credentials. Ownership is traceable via the `osac.openshift.io/owner-reference` annotation linking each BMI to its parent ClusterOrder (which belongs to the real tenant).
 
-The discovery ignition passed as `user_data` contains the InfraEnv's pull secret and cluster endpoint information. The `user_data` field is immutable (enforced by the proto `IMMUTABLE` field behavior annotation). The ignition is scoped to a single cluster's InfraEnv — it cannot be used to register agents against a different cluster.
+The discovery ignition contains the InfraEnv's pull secret and the assisted-service endpoint URL (both platform-level, not cluster-specific). It is stored as an OSAC Secret (OSAC-1567) encrypted at rest via the Vault backend, and referenced from the BMI's `user_data` field. The `user_data` field is immutable (enforced by the proto `IMMUTABLE` field behavior annotation). The ignition comes from the shared platform-level InfraEnv and is not cluster-scoped — agent-to-cluster binding is enforced by the MAC correlation algorithm, not by the ignition content. The Secret is deleted when the cluster is decommissioned (owned by the ClusterOrder lifecycle).
 
 No changes to authentication or authorization flows are required. The existing OPA policies enforce tenant isolation for all public API access. The osac-operator authenticates to the private API using a token file mounted from a Kubernetes Secret (`OSAC_FULFILLMENT_TOKEN_FILE`), following the same pattern used by the existing feedback controllers for Signal RPCs.
 
 Tenants interact only through the fulfillment-service API. They do not have K8s API access to the hub cluster — ClusterOrder, InfraEnv, and Agent CRs are not tenant-readable. The `Workers` references in ClusterOrder status are visible only to platform operators with hub cluster access.
-
-The `user_data` field (which carries discovery ignition containing pull secrets) is not encrypted at application level in PostgreSQL. This is a platform-wide gap affecting all resources with `user_data`, not specific to CaaS. Infrastructure-level encryption (LUKS on PVs) is expected but not enforced by the fulfillment-service.
 
 The private API token (`OSAC_FULFILLMENT_TOKEN_FILE`) authenticates as `service-account-osac-controller`, an admin service account with unrestricted access to all API methods across all tenants. This is an existing platform-wide credential used by all osac-operator controllers (feedback, compute instance, networking). This design does not widen its scope — it adds BMI Create/Delete to a token that already has full admin access.
 
@@ -367,22 +450,22 @@ The private API token (`OSAC_FULFILLMENT_TOKEN_FILE`) authenticates as `service-
 
 | Failure Mode | What Happens | Recovery | Tenant Observes |
 |---|---|---|---|
-| InfraEnv creation fails | Controller retries on next reconciliation cycle (controller-runtime requeue) | Automatic retry with exponential backoff | ClusterOrder stuck in `Progressing` with condition `InfraEnvNotReady` |
+| Shared InfraEnv missing or not ready | Controller sets `InfraEnvReady=False`, requeues | Cloud Provider Admin must ensure InfraEnv exists in `hardware-inventory` namespace | Cluster stuck in `PROGRESSING` with `WORKER_PROVISIONING_BLOCKED` condition |
 | InfraEnv ignition not generated | Controller polls InfraEnv status with 30s requeue | Automatic; investigate assisted-service if persistent | Same as above |
-| BMI creation fails (private API error) | Worker phase set to `Failed` | No automatic retry. Failure reported via ClusterOrder condition `WorkersFailed` | ClusterOrder condition `WorkersFailed` with message |
-| BMI provisioning fails (host allocation or Ironic error) | BMI enters `Failed` phase, worker phase set to `Failed` | No automatic retry. Failure reported via ClusterOrder condition `WorkersFailed` and event | ClusterOrder shows degraded worker count |
-| Agent does not register within timeout | Worker phase set to `Failed`, reason `AgentRegistrationTimeout` | No automatic retry. Operator investigates (check InfraEnv, image URL, BMI status) | ClusterOrder condition indicates degraded workers |
+| BMI creation fails (private API error) | Worker phase set to `Failed`, `attemptCount` incremented | Controller deletes the failed BMI and retries with escalating backoff (capped at 5m). Retries indefinitely | Cluster shows `WORKER_PROVISIONING_FAILED` with attempt count |
+| BMI provisioning fails (host allocation or Ironic error) | BMI enters `Failed` phase, worker phase set to `Failed` | Controller deletes the failed BMI and retries with escalating backoff. Each attempt allocates a fresh host | Cluster shows degraded worker count during retries |
+| Agent does not register within timeout | Worker phase set to `Failed`, reason `AgentRegistrationTimeout` | Controller deletes the timed-out BMI and retries with escalating backoff (capped at 30m) | Cluster shows `WORKER_PROVISIONING_FAILED` |
 | MAC correlation finds no match | Agent remains uncorrelated | Controller logs a warning and continues watching. If all BMIs are correlated and extra agents exist, they are ignored | No direct tenant impact |
-| Agent binding to NodePool fails | Agent not installed as worker | assisted-service reports failure in Agent conditions; controller reflects in worker phase | ClusterOrder shows degraded worker count |
-| Scale-down: Agent unbinding times out | Agent stuck in `unbinding-pending-user-action` longer than 30 minutes | Controller logs warning, sets worker phase to `Failed`. Manual intervention required to investigate Ironic deprovision failure | Node count mismatch visible in ClusterOrder status |
-| BMI deletion fails | BMI stuck in `Deleting` (e.g., AAP deprovision job fails with `blockDeletionOnFailure: true`) | Controller retries delete periodically. Alerting notifies operators | Scale-down appears incomplete in ClusterOrder status |
+| Agent binding to NodePool fails | Agent not installed as worker | assisted-service reports failure in Agent conditions; controller reflects in worker phase | Cluster shows degraded worker count |
+| Scale-down: Agent unbinding times out | Agent stuck in `unbinding-pending-user-action` longer than 30 minutes | Controller logs warning, sets worker phase to `Failed`. Manual intervention required to investigate Ironic deprovision failure | Node count mismatch visible in Cluster status |
+| BMI deletion fails | BMI stuck in `Deleting` (e.g., AAP deprovision job fails with `blockDeletionOnFailure: true`) | Controller retries delete periodically. Alerting notifies operators | Scale-down appears incomplete in Cluster status |
 | Controller restart mid-reconciliation | Controller resumes from current state on restart | Idempotent reconciliation logic rebuilds in-memory state from CRD status and re-queries BMI/Agent state | Temporary stall, no data loss |
 
 ### RBAC / Tenancy
 
 No new RBAC roles are introduced. The osac-operator's service account already has permissions to create CRs in cluster namespaces and call the private API.
 
-CaaS-managed BMIs carry `metadata.tenant` (set by the private API from the ClusterOrder's tenant context) and `metadata.labels["osac.openshift.io/managed-by"] = "caas"`. The tenant isolation metadata is present but the BMIs are not visible to the tenant — the public API filters them out. The `osac.openshift.io/cluster-order` label links BMIs to their parent ClusterOrder, enabling Cloud Provider Admin queries across clusters.
+CaaS-managed BMIs carry `metadata.tenant = "system"` (the builtin system tenant). The existing tenancy logic makes them invisible to all regular users — no label-based filtering is needed. The `osac.openshift.io/cluster-order` label links BMIs to their parent ClusterOrder, enabling Cloud Provider Admin queries via the private API.
 
 Tenant-owned BMaaS workflows are unaffected. A tenant creating their own BareMetalInstance through the public API sees only their own instances, as before.
 
@@ -402,13 +485,14 @@ Per-ClusterOrder metrics would create unbounded label cardinality at scale. Metr
 
 | Event | Type | Reason | When |
 |---|---|---|---|
-| InfraEnv created | Normal | `InfraEnvCreated` | Controller creates the InfraEnv CR |
+| InfraEnv verified | Normal | `InfraEnvReady` | Shared InfraEnv found and ignition available |
 | Worker created | Normal | `WorkerCreated` | Controller creates a worker resource via private API |
 | Agent correlated | Normal | `AgentCorrelated` | MAC match found between Agent and worker resource |
 | Worker joined | Normal | `WorkerReady` | Worker installed as cluster node |
 | Agent registration timeout | Warning | `AgentRegistrationTimeout` | No Agent registered within the timeout window |
 | Worker provisioning failed | Warning | `WorkerFailed` | Worker resource entered `Failed` phase |
 | Worker deleted | Normal | `WorkerDeleted` | Controller deleted a worker resource during scale-down |
+| Ignition size warning | Warning | `DiscoveryIgnitionSizeWarning` | Fetched ignition exceeds 48KB (75% of 64KB limit) |
 
 ### Risks and Mitigations
 
@@ -423,19 +507,19 @@ Per-ClusterOrder metrics would create unbounded label cardinality at scale. Metr
 
 ### Drawbacks
 
-This design tightly couples the osac-operator to the fulfillment-service private API for BMI lifecycle management. The controller becomes a gRPC client of the fulfillment-service, adding a synchronous dependency in the reconciliation path. If the fulfillment-service is unavailable, worker provisioning and deprovisioning stall. The alternative — creating BMI CRs directly on the hub cluster — would avoid this dependency but lose the audit trail and visibility filtering that the fulfillment-service provides. The coupling is justified because the private API is the canonical path for all BMI operations, and the fulfillment-service is a core dependency that the osac-operator already communicates with for Signal RPCs and other operations.
+This design tightly couples the osac-operator to the fulfillment-service private API for BMI lifecycle management. The controller becomes a gRPC client of the fulfillment-service, adding a synchronous dependency in the reconciliation path. If the fulfillment-service is unavailable, worker provisioning and deprovisioning stall. The alternative — creating BMI CRs directly on the hub cluster — would avoid this dependency but lose the audit trail and system tenant isolation that the fulfillment-service provides. The coupling is justified because the private API is the canonical path for all BMI operations, and the fulfillment-service is a core dependency that the osac-operator already communicates with for Signal RPCs and other operations.
 
-The MAC-based Agent correlation is inherently racy: if two BMIs in different clusters boot on the same VLAN and an Agent's MAC matches a BMI from a different cluster, the correlation is wrong. The one-InfraEnv-per-cluster design prevents this for Agents (each Agent is scoped to its InfraEnv's ClusterDeployment), but the MAC lookup must still be scoped to Agents in the correct namespace.
+The shared InfraEnv means Agents are not auto-scoped to a cluster, so MAC-based correlation could theoretically match an Agent to a BMI from a different cluster if two BMIs on the same VLAN share a MAC. The three-dimension scoping (namespace, ownership label, MAC match) described in the MAC Address Correlation section prevents this — each controller only considers BMIs owned by its own ClusterOrder, making cross-cluster misassignment impossible even with shared infrastructure.
 
 ## Alternatives (Not Implemented)
 
 ### BareMetalPool-Based Provisioning (Current Approach)
 
-Create a BareMetalPool per ClusterOrder and let the bare-metal-fulfillment-operator manage BMI creation. **Rejected** because BareMetalPool groups BMIs with a shared profile — CaaS needs per-instance ignition (each cluster has a different InfraEnv). The Pool abstraction does not support per-BMI `image` and `user_data` configuration. The PoC validated direct BMI creation; adding a pooling abstraction that does not fit the use case adds complexity without benefit.
+Create a BareMetalPool per ClusterOrder and let the bare-metal-fulfillment-operator manage BMI creation. **Rejected** because BareMetalPool groups BMIs with a shared profile — CaaS needs per-instance configuration (different DiskImage, network attachments, user_data per cluster). The Pool abstraction does not support per-BMI `image` and `user_data` configuration. The PoC validated direct BMI creation; adding a pooling abstraction that does not fit the use case adds complexity without benefit.
 
 ### Direct CR Creation on Hub Cluster
 
-Have the controller (or AAP role) create BareMetalInstance CRs directly on the hub cluster, bypassing the fulfillment-service. This is what the current `cluster_infra` AAP step does with BareMetalPool CRs. **Rejected** because: (a) BMIs would not appear in the fulfillment-service database, breaking audit and observability; (b) the label-based visibility filtering requires fulfillment-service cooperation; (c) the private API is the canonical path for BMI lifecycle, and the PRD explicitly requires it.
+Have the controller (or AAP role) create BareMetalInstance CRs directly on the hub cluster, bypassing the fulfillment-service. This is what the current `cluster_infra` AAP step does with BareMetalPool CRs. **Rejected** because: (a) BMIs would not appear in the fulfillment-service database, breaking audit and observability; (b) system tenant isolation requires BMIs to be fulfillment-service records; (c) the private API is the canonical path for BMI lifecycle, and the PRD explicitly requires it.
 
 ### AAP-Orchestrated BMI Creation
 
@@ -449,19 +533,20 @@ Replace the controller-based flow with a new AAP role that calls the private API
 - ClusterOrder controller: `reconcileWorkers` calls `BareMetalInstances.Delete` for excess BMIs when desired count is less than current count.
 - ClusterOrder controller: `correlateAgents` matches an Agent to a BMI when their MAC addresses match.
 - ClusterOrder controller: `correlateAgents` does not match Agents from a different namespace.
-- ClusterOrder controller: `ensureInfraEnv` creates an InfraEnv with the correct ClusterDeployment reference and owner reference.
+- ClusterOrder controller: `ensureInfraEnv` verifies the shared platform-level InfraEnv exists and has generated ignition.
 - ClusterOrder controller: worker phase transitions correctly through `Provisioning` → `WaitingForAgent` → `Binding` → `Ready`.
 - ClusterOrder controller: worker phase transitions to `Failed` after agent registration timeout.
 - ClusterOrder controller: reconciliation is idempotent — re-running with the same state produces no new API calls.
-- Visibility filtering: public `BareMetalInstances.List` excludes BMIs with `osac.openshift.io/managed-by` label.
-- Visibility filtering: public `BareMetalInstances.Get` returns `NotFound` for CaaS-managed BMIs.
+- System tenant isolation: CaaS-managed BMIs under `system` tenant are not returned by public `BareMetalInstances.List` for any regular tenant.
+- System tenant isolation: public `BareMetalInstances.Get` returns `NotFound` for system-tenant BMIs when called by a regular tenant.
+- RBAC: osac-operator's ClusterRole includes `patch` on `agents` in the `agent-install.openshift.io` API group.
 
 ### Integration Tests
 
-- Create a ClusterOrder with bare-metal node requests in a kind cluster. Verify InfraEnv CR is created with correct spec. Verify BMI creation calls reach the fulfillment-service (mocked private API). Verify ClusterOrder status reflects `workers` entries.
+- Create a ClusterOrder with bare-metal node requests in a kind cluster with a pre-existing shared InfraEnv. Verify BMI creation calls reach the fulfillment-service (mocked private API). Verify ClusterOrder status reflects `workers` entries.
 - Simulate Agent registration by creating Agent CRs with matching MAC addresses. Verify correlation and labeling.
 - Simulate scale-down by decreasing `nodeRequests`. Verify NodePool replicas decrease and BMI delete is called for the excess workers.
-- Verify ClusterOrder deletion cleans up all BMIs and the InfraEnv before removing the finalizer.
+- Verify ClusterOrder deletion cleans up all BMIs before removing the finalizer (shared InfraEnv is not deleted).
 
 ### E2E Tests
 
@@ -469,7 +554,7 @@ Replace the controller-based flow with a new AAP role that calls the private API
 - Scale-up: increase node count on an existing cluster. Verify new workers are provisioned and join.
 - Scale-down: decrease node count. Verify workers are drained, agents unbound, BMIs deleted.
 - Cluster deletion: delete a cluster with bare-metal workers. Verify all BMIs are cleaned up.
-- Visibility: verify `osac list baremetalinstances` as a tenant user does not return CaaS-managed instances.
+- System tenant isolation: verify `osac list baremetalinstances` as a tenant user does not return CaaS-managed instances (system tenant).
 - Pool removal: verify no BareMetalPool CRs are created during CaaS cluster provisioning. Verify the `cluster_infra` AAP step no longer references BareMetalPool.
 
 Note: full E2E tests require a BMaaS-capable test environment with physical or simulated bare-metal hosts. Initial E2E coverage may be limited to API-level verification with mocked BMaaS responses.
@@ -490,17 +575,16 @@ The BareMetalPool-based pre-boot pool is removed immediately — there is no coe
 
 Downgrade requires:
 1. Scale down all bare-metal workers on affected clusters (the controller manages cleanup).
-2. Delete any InfraEnv CRs created by the controller.
-3. Re-deploy the `cluster_infra` AAP step and scheduled `osac-import-agents` job for BareMetalPool management.
-4. Revert the osac-operator to the previous version.
+2. Re-deploy the `cluster_infra` AAP step and scheduled `osac-import-agents` job for BareMetalPool management.
+3. Revert the osac-operator to the previous version.
 
 The ClusterOrder CRD gains a new status field (`workers`). On downgrade, the older controller ignores this field. No data migration is needed because the field is status-only (the controller rebuilds it from live state on startup).
 
 ## Version Skew Strategy
 
-The osac-operator (controller) and fulfillment-service (private API) must be upgraded together or the operator first. The controller calls `BareMetalInstances.Create` with existing fields (`image`, `user_data`). The only proto change is a new `source_type` value (`"disk_image"`) on `BareMetalInstanceImage`. If the fulfillment-service is at an older version that does not recognize this value, BMI creation may fail with a validation error — the fulfillment-service must be upgraded first or at the same time as the operator.
+The osac-operator (controller) and fulfillment-service (private API) must be upgraded together or the operator first. The controller calls `Secrets.Create` and `BareMetalInstances.Create` with existing fields. The `source_type: "disk_image"` value is introduced by the DiskImage integration (OSAC-1270), a listed dependency — the fulfillment-service must have OSAC-1270 implemented before CaaS bare-metal provisioning is enabled, so there is no version skew scenario for this value.
 
-The visibility filtering (label-based exclusion in public `List`) requires the fulfillment-service to be upgraded. If the operator is upgraded first, CaaS-managed BMIs are created with the label but remain visible in tenant listings until the fulfillment-service is updated. This is a cosmetic issue during the upgrade window, not a functional failure.
+CaaS-managed BMIs are assigned to the builtin `system` tenant, which already exists in the fulfillment-service database (migration 48). No fulfillment-service changes are required for tenant isolation — the existing tenancy logic excludes the `system` tenant from regular user queries. There is no version skew risk for visibility.
 
 ## Support Procedures
 
@@ -512,7 +596,7 @@ The visibility filtering (label-based exclusion in public `List`) requires the f
 
 **Disabling the feature:**
 - Set the cluster template to exclude bare-metal resource classes. Existing clusters with bare-metal workers continue running — the controller does not deprovision workers unless instructed (scale-down or delete).
-- To force-remove CaaS BMIs: delete them via the private API and remove the corresponding entries from `status.workers[]` on the ClusterOrder. The workers are removed from the cluster but hosts must be manually cleaned.
+- To force-remove CaaS BMIs: delete them via the private API. The controller removes `status.workers[]` entries automatically once the BMI CRs are gone. If entries are stuck, patch the ClusterOrder status to remove them manually. Hosts must be manually cleaned if BMaaS deprovision failed.
 
 **Recovery:**
 - The controller is designed for idempotent reconciliation. Restarting the osac-operator pod causes the controller to rebuild state from the ClusterOrder status, re-query BMI and Agent CRs, and resume any pending operations. No manual consistency repair is needed.
@@ -530,6 +614,8 @@ Documentation updates required:
 
 ## Provenance
 
-Authored: draft @ design 0.7.1 - b8b3f86, workspace fix/containerfile-podman-wrapper @ 38af260
+Committed: commit @ design 0.8.0 - a605aa5, workspace design/OSAC-2135 @ 9fd309d (dirty)
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"design","workflow_version":"0.7.1","ai_workflows":"b8b3f86","source_repo":"38af260","source_repo_branch":"fix/containerfile-podman-wrapper","commits_behind_main":0,"commits_ahead_main":324,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+> Authoring phases not recorded this session (commit-time snapshot only).
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"design","workflow_version":"0.8.0","ai_workflows":"a605aa5","source_repo":"9fd309d (dirty)","source_repo_branch":"design/OSAC-2135","commits_behind_main":0,"commits_ahead_main":641,"main_ref":"main","phases":["commit","commit","commit"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->


### PR DESCRIPTION
## Design: CaaS Bare-Metal Worker Node Provisioning

**Jira:** [OSAC-2135](https://redhat.atlassian.net/browse/OSAC-2135)
**PRD:** [prd.md](enhancements/OSAC-2135-caas-bare-metal-worker-provisioning/prd.md)

### Summary

Replaces the static BareMetalPool-based agent pre-boot pool with on-demand bare-metal worker provisioning. The ClusterOrder controller creates individual BareMetalInstances via the fulfillment-service private API, each booting a pre-registered RHCOS DiskImage with cluster-specific discovery ignition. Agents register, are correlated to BMIs via MAC address, and join the HyperShift-managed cluster as worker nodes. CaaS-managed BMIs are hidden from tenant APIs via label-based visibility filtering.

### Requesting Review On

- **DiskImage integration (OSAC-2540/OSAC-1270):** The design proposes a CaaS-specific label (`osac.openshift.io/ocp-version`) on DiskImage resources for version-based lookup. This label is not part of the DiskImage PRD — alignment needed.
- **MAC address dependency (OSAC-2308/OSAC-3254):** Exact field path for MAC in BMI status is TBD. Agent-to-BMI correlation is blocked until this ships.
- **Visibility filtering mechanism:** Public API excludes CaaS-managed BMIs via `managed-by: caas` label. Requires fulfillment-service changes (`baremetal_instances_server.go`).
- **BareMetalPool removal:** The `cluster_infra` AAP step and the existing pool-based flow are removed entirely — no coexistence period. Upgrade procedure includes AAP job queue drain.
- **New `source_type` value (`disk_image`):** Proto schema change on `BareMetalInstanceImage` — version skew implications documented.

### Documents
- `design.md` — technical design document

### How to Review
- Comment inline on specific sections
- Approve when the design accurately reflects a viable implementation approach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-demand bare-metal worker provisioning for CaaS clusters.
  * Added worker status and lifecycle tracking in cluster order details.
  * Added support for worker scaling, upgrades, recovery, and cleanup.
  * Added visibility into provisioning progress, failures, retries, and readiness.

* **Documentation**
  * Documented provisioning workflows, failure handling, monitoring, security, operational procedures, and testing coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->