### PR TITLE
OSAC-3793: PRD - Billing - Catalog Pricing Integration

### DIFF
--- a/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
+++ b/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
@@ -12,10 +12,11 @@ Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem, BareMetalInstance
 
 ## In Scope
 
-- **Catalog items display per-unit price** from the tenant's active pricing plan. Prices reflect the tenant's plan-specific rates, not a single base rate.
+- **Assigned catalog items display per-unit price** from the tenant's active pricing plan. Pricing is shown only for catalog items assigned/available to the requesting user's context (tenant/project). Prices reflect the tenant's plan-specific rates, not a single base rate.
 - **Graceful degradation** — when the billing system is unavailable, catalog items render without pricing rather than failing. Tenants can still browse and provision; they just don't see prices.
 - **API, CLI, and UI surfaces** — pricing is visible on catalog items across all three surfaces. The UI shows formatted prices (e.g., "$0.26/hr" for a 4-core, 8 GiB VM).
 - **All catalog item types** — ComputeInstanceCatalogItem, ClusterCatalogItem, and BareMetalInstanceCatalogItem.
+- **Visibility alignment with catalog assignment** — pricing follows the same hierarchical visibility model as catalog items (global → tenant → project).
 
 ## Out of Scope
 
@@ -31,7 +32,7 @@ Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem, BareMetalInstance
 
 ### Tenant Admin / Tenant User
 
-- As a Tenant Admin or Tenant User, I want to see the price of a catalog item (e.g., "$0.26/hr" for a VM template) before provisioning a resource, so that I can make cost-informed decisions.
+- As a Tenant Admin or Tenant User, I want to see the price of a catalog item available to my context (e.g., "$0.26/hr" for a VM template) before provisioning a resource, so that I can make cost-informed decisions about approved offerings.
 
 ## Assumptions
 
@@ -39,17 +40,31 @@ Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem, BareMetalInstance
 
 - OSAC-3538 (Catalog Items v2) is operational — catalog items use the new structured field model, and the legacy field_definitions approach has been replaced. This PRD assumes the v2 field governance model throughout.
 
-- Catalog items exist for the services being priced. The billing integration does not create catalog items but relies on their existence.
+- OSAC-2474 (Catalog Item Assignment) is operational — the hierarchical assignment model (global → tenant → project) determines catalog item visibility, and pricing respects this same visibility model.
+
+- Catalog items exist for the services being priced. The billing integration does not create catalog items but relies on their existence and assignment.
 
 - The billing system's API supports querying prices by resource type and pricing plan at catalog display time. A short propagation delay after pricing changes in the billing system is acceptable.
 
 ## Dependencies
+
+- **OSAC-2474 — Catalog Item Assignment to Tenants and Projects:** Provides the hierarchical catalog item assignment model. Must be operational before pricing can respect catalog item visibility rules.
 
 - **OSAC-3538 — Catalog Items v2 Field Governance Redesign:** Provides the new structured field model for catalog items. Must be operational before pricing can be integrated with the catalog item schema.
 
 - **OSAC-3784 — Billing Integration MVP:** Provides the billing provider adapter and pricing plan infrastructure. Must be operational before catalog pricing can query the billing system for prices.
 
 - **OSAC Catalog (OSAC-1531, OSAC-2452):** Catalog items must exist for the services being priced.
+
+## Open Questions
+
+Questions for reviewers to resolve during PR review. Once answered, the resolution will be incorporated into the relevant section above and the entry removed.
+
+### 1. Implementation sequencing with OSAC-2474
+
+- **Owner:** Product team, Engineering team
+- **Impact:** Dependencies, delivery timeline
+- **Question:** Should catalog pricing respect assignment visibility from day one, or should it initially work independently and be aligned later? This affects whether OSAC-2474 is a hard blocker or parallel development is possible.
 
 ---
 
@@ -60,4 +75,4 @@ Final: revise @ prd 0.8.0 - a605aa5, workspace HEAD @ a2c2e18 (dirty)
 
 > Context changed between draft and revise.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"a605aa5","source_repo":"a2c2e18 (dirty)","source_repo_branch":"HEAD","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["draft","revise"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"a605aa5","source_repo":"a2c2e18 (dirty)","source_repo_branch":"HEAD","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["draft","revise","revise"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
+++ b/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
@@ -4,72 +4,64 @@
 |-------------|----------------------|
 | Author(s)   | Moti Asayag          |
 | Jira        | [OSAC-3793](https://redhat.atlassian.net/browse/OSAC-3793) |
-| Date        | 2026-08-20           |
+| Date        | 2026-08-23           |
 
 ## Problem Statement
 
-Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem, BareMetalInstanceCatalogItem) display no pricing information. A catalog item maps to a service whose provisioned resource is composed of billable components — the metered resource type (for example, a VMaaS instance type) plus any non-metered components such as a paid add-on operator, a bundled software license, or a setup fee. Tenants browsing the catalog cannot see what any of these will cost before provisioning. Without pricing at browse time, cost-informed decisions require tenants to provision first and check their billing dashboard afterward — or to consult a pricing document outside OSAC. This defeats the purpose of a self-service catalog and increases the risk of unexpected charges.
+VMaaS and CaaS catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem) display no pricing information. A catalog item maps to a service whose provisioned resource is composed of billable components — the metered resource type (for example, a VMaaS instance type) plus any non-metered components such as a paid add-on operator, a bundled software license, or a setup fee. Tenants browsing the catalog cannot see what any of these will cost before provisioning. Without pricing at browse time, cost-informed decisions require tenants to provision first and check their billing dashboard afterward — or to consult a pricing document outside OSAC. This defeats the purpose of a self-service catalog and increases the risk of unexpected charges.
 
 ## In Scope
 
-- **Display-time price enrichment of catalog items** — when a catalog item is displayed, OSAC enriches it with the price of the billable components of the resource it would provision, resolved against the requesting tenant's effective pricing plan (or the default plan when the tenant has no specific assignment). Pricing is presented only for catalog items assigned/available to the requesting user's context (tenant/project) and reflects that tenant's plan-specific rate cards, not a single base rate. Prices are read live from the billing system at display time; they are not stored on the catalog item.
+- **Display-time price enrichment of VMaaS and CaaS catalog items** — when a ComputeInstanceCatalogItem or ClusterCatalogItem is displayed, it is enriched with the price of the billable components of the resource it would provision, resolved against the requesting tenant's effective pricing plan (or the default plan when the tenant has no specific assignment). Prices always reflect the billing system's current rates, subject to the same bounded processing latency as OSAC-3784.
 - **Metered and non-metered billable components are both priced** — the display shows the metered per-unit rate for the item's resource type (for example, "$0.26/hr" for a Small instance type) and itemizes any non-metered billable component charges attached to the resource (for example, a paid add-on operator, a bundled license, or a one-time setup fee), so the tenant sees the full cost picture rather than the usage rate alone. Amounts are shown in the billing account's base currency; the dollar figures here are illustrative.
-- **Graceful degradation on transient unavailability** — when the billing system is unreachable, catalog items render without pricing rather than failing. Tenants can still browse and provision; they just don't see prices. This covers transient outages and is not a substitute for rate coverage: a billable component that has no rate is a coverage gap OSAC-3784 requires be surfaced to the Cloud Provider Admin, not a silent steady state. This feature degrades gracefully as a fallback but does not treat a missing rate as normal.
+- **Graceful degradation on transient unavailability** — when the billing system is unreachable, catalog items render without pricing rather than failing. Tenants can still browse and provision; they just don't see prices. This covers transient outages and is not a substitute for rate coverage: a billable component that has no rate is a coverage gap OSAC-3784 requires be surfaced to the Cloud Provider Admin, not a silent steady state.
 - **API, CLI, and UI surfaces** — enriched pricing is available on catalog items across all three surfaces. The UI shows formatted prices, including the per-unit rate and any itemized non-metered charges.
-- **All catalog item types** — ComputeInstanceCatalogItem, ClusterCatalogItem, and BareMetalInstanceCatalogItem.
-- **Visibility alignment with catalog assignment** — pricing follows the same hierarchical visibility model as catalog items (global → tenant → project). A catalog list price (a plan rate) is distinct from incurred-cost visibility: showing a user the rate for an offering they can browse is not the same as exposing another project's actual charges, which OSAC-3784 scopes by project membership.
+- **Visibility alignment with catalog assignment** — pricing follows the same hierarchical visibility model as catalog items (global → tenant → project) and is shown only for items the requesting user can browse. List prices are tenant-scoped: the same for every project and user in the tenant. A list price is not incurred-cost visibility; OSAC-3784 scopes actual charges by project membership.
+- **Cloud Provider Admin preview is tenant-contextual** — when a Cloud Provider Admin previews catalog prices, the amounts are the list prices that tenant would see (that tenant's effective plan). This verifies tenant-facing display; it is not a second, provider-specific price list.
 
 ## Out of Scope
 
-- **Caching pricing data in OSAC's database** — prices are fetched live from the billing system; OSAC does not maintain a local pricing cache, and catalog items carry no cost metadata.
+- **Independently maintained catalog prices** — catalog items do not carry a price that an admin edits in OSAC independently of the billing system. The amounts shown always come from billing rates.
 - **Price comparison across templates** — tenants cannot compare prices side-by-side across multiple catalog items in a single view.
 - **Total-cost projection** — the display shows per-unit rates and itemized non-metered charges for a catalog item; it does not project total spend for a configured or running resource over time. Estimated cost of deployed resources is OSAC-3784's Tenant User cost view.
-- **Multi-perspective / context-driven pricing** — the catalog shows a single price per context: the requesting tenant's plan-specific rate. It does not expose the provider's own cost basis or margin, nor a separate per-end-user price. Different tenants may see different prices because they hold different pricing plans, but within a context there is one price. Per-user cost attribution is Out of Scope in OSAC-3784.
+- **Multi-perspective / context-driven pricing** — the catalog does not expose the provider's cost basis or margin, nor a separate per-end-user price. Cloud Provider Admin preview uses the selected tenant's plan (see In Scope), not a second price list. Per-user cost attribution remains Out of Scope in OSAC-3784.
 - **Field governance for pricing fields** — pricing information is always visible (not locked/hidden) when available. Advanced field governance behaviors for pricing follow in a separate feature.
+- **BMaaS catalog pricing** — price enrichment of BareMetalInstanceCatalogItem is [OSAC-3795](https://redhat.atlassian.net/browse/OSAC-3795).
+- **MaaS catalog pricing** — price enrichment of MaasCatalogItem (including per-token prices) is [OSAC-3794](https://redhat.atlassian.net/browse/OSAC-3794).
+- **Non-catalog billable resources** — this feature does not show list prices for resources that are not catalog items (for example standalone instance types, storage, or ExternalIPs). Incurred-cost views and rate-card management for those remain OSAC-3784.
 
 ## User Stories
 
 ### Cloud Provider Admin
 
-- As a Cloud Provider Admin, I want catalog items to display the price of their billable components — the metered per-unit rate for the resource type and any non-metered component charges — drawn from the tenant's effective pricing plan, so that tenants see accurate, plan-specific pricing for approved offerings when browsing the catalog.
+- As a Cloud Provider Admin, I want to preview the list price a given tenant would see for an approved VMaaS or CaaS catalog item, so that I can confirm plan-specific rates before tenants provision.
 
 ### Tenant Admin / Tenant User
 
-- As a Tenant Admin or Tenant User, I want to see the price of a catalog item available to my context before provisioning — the per-unit rate (e.g., "$0.26/hr" for a Small instance type) together with any non-metered charges such as an add-on or setup fee — so that I can make cost-informed decisions about approved offerings.
+- As a Tenant Admin or Tenant User, I want to see the price of a VMaaS or CaaS catalog item available to my context before provisioning — the per-unit rate (e.g., "$0.26/hr" for a Small instance type) together with any non-metered charges such as an add-on or setup fee — so that I can make cost-informed decisions about approved offerings.
 
 ## Assumptions
 
-- OSAC-3784 (Billing Integration MVP) is operational — the billing provider adapter is deployed, pricing plans with rate cards keyed to billable components are configured (with a default plan for unassigned tenants), and the billing system is the pricing source of truth. OSAC-3784 explicitly delegates catalog price enrichment for display to this feature. This PRD uses OSAC-3784's glossary for shared billing terms (billable component, billable dimension, rate card, pricing plan, resource type, service).
-
-- OSAC-3538 (Catalog Items v2) is operational — catalog items use the new structured field model, and the legacy field_definitions approach has been replaced. This PRD assumes the v2 field governance model throughout. Consistent with that day-1 governance model, the catalog carries no cost metadata; price is resolved from billing at display time.
-
-- OSAC-2474 (Catalog Item Assignment) is operational — the hierarchical assignment model (global → tenant → project) determines catalog item visibility, and pricing respects this same visibility model.
-
-- Catalog list prices are tenant-scoped: rate cards are resolved from the tenant's effective pricing plan and are the same for all projects and users within the tenant. This concerns list prices shown at browse time, not incurred-cost visibility, which OSAC-3784 scopes by project membership.
-
-- The billing system has configured rates for the billable components of resources available through catalog items. Per OSAC-3784's no-gaps contract, missing rates are surfaced to the Cloud Provider Admin; where a rate is nonetheless unavailable at display time, the affected component renders without a price (graceful degradation).
-
-- Catalog items exist for the services being priced. This feature does not create catalog items but relies on their existence and assignment.
-
-- The billing system's API supports querying prices for a resource type's billable components by pricing plan at catalog display time. A short propagation delay after pricing changes in the billing system is acceptable (a bounded processing latency, consistent with OSAC-3784).
+- The billing system can return current rates for a catalog offering's billable components at browse time. A short delay after a pricing change is acceptable (bounded processing latency, consistent with OSAC-3784).
+- VMaaS and CaaS catalog offerings have rates in the tenant's effective (or default) plan. Missing rates are a coverage gap OSAC-3784 surfaces to the Cloud Provider Admin; this feature only omits the affected component's price on the catalog display.
 
 ## Dependencies
 
-- **OSAC-2474 — Catalog Item Assignment to Tenants and Projects:** Provides the hierarchical catalog item assignment model. Must be operational before pricing can respect catalog item visibility rules.
+- **OSAC-2474 — Catalog Item Assignment to Tenants and Projects:** Provides the hierarchical catalog item assignment model. Must be operational before pricing can follow catalog item visibility.
 
-- **OSAC-3538 — Catalog Items v2 Field Governance Redesign:** Provides the new structured field model for catalog items and establishes that the catalog carries no cost metadata (price is resolved from billing at display time). Must be operational before pricing can be integrated with the catalog item schema.
+- **OSAC-3538 — Catalog Items v2 Field Governance Redesign:** Provides the v2 field model for catalog items. Must be operational before this feature can show billing rates on catalog items without an independently maintained catalog price.
 
-- **OSAC-3784 — Billing Integration MVP:** Provides the billing provider adapter, pricing plans, and rate cards keyed to billable components, and is the pricing source of truth. OSAC-3784 delegates catalog price enrichment for display to this feature (reciprocal scope handshake). Must be operational before catalog pricing can query the billing system for prices.
+- **OSAC-3784 — Billing Integration MVP:** Provides pricing plans, rate cards keyed to billable components, and the billing system as pricing source of truth. OSAC-3784 delegates catalog price enrichment for display to this feature. Must be operational before catalog items can show prices. Shared billing terms follow OSAC-3784's glossary (billable component, billable dimension, rate card, pricing plan, resource type, service).
 
-- **OSAC Catalog (OSAC-1531, OSAC-2452):** Catalog items must exist for the services being priced.
+- **OSAC Catalog (OSAC-1531, OSAC-2452):** VMaaS and CaaS catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem) must exist for the services being priced.
 
 ---
 
 ## Provenance
 
 Authored: draft @ prd 0.8.0 - a605aa5, workspace feat/add-osac-metering-documentation @ 514565f (3 behind origin/main)
-Final: respond @ prd 0.8.0 - 7efcedb, workspace HEAD @ 155acfa
+Final: revise @ prd 0.8.0 - 7efcedb, workspace HEAD @ 155acfa
 
-> Context changed between draft and respond.
+> Context changed between draft and revise.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"155acfa","source_repo_branch":"HEAD","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["draft","revise","revise","revise","respond"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"155acfa","source_repo_branch":"HEAD","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["draft","revise","revise","revise","respond","revise"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
+++ b/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
@@ -8,20 +8,20 @@
 
 ## Problem Statement
 
-Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem) display no pricing information. Tenants browsing the catalog cannot see what a resource will cost before provisioning it. Without pricing in the catalog, cost-informed decisions require tenants to provision first and check their billing dashboard afterward — or to consult a pricing document outside OSAC. This defeats the purpose of a self-service catalog and increases the risk of unexpected charges.
+Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem, BareMetalInstanceCatalogItem) display no pricing information. Tenants browsing the catalog cannot see what a resource will cost before provisioning it. Without pricing in the catalog, cost-informed decisions require tenants to provision first and check their billing dashboard afterward — or to consult a pricing document outside OSAC. This defeats the purpose of a self-service catalog and increases the risk of unexpected charges.
 
 ## In Scope
 
 - **Catalog items display per-unit price** from the tenant's active pricing plan. Prices reflect the tenant's plan-specific rates, not a single base rate.
 - **Graceful degradation** — when the billing system is unavailable, catalog items render without pricing rather than failing. Tenants can still browse and provision; they just don't see prices.
 - **API, CLI, and UI surfaces** — pricing is visible on catalog items across all three surfaces. The UI shows formatted prices (e.g., "$0.26/hr" for a 4-core, 8 GiB VM).
-- **VMaaS and CaaS catalog items** — ComputeInstanceCatalogItem and ClusterCatalogItem. Pricing for BareMetalInstanceCatalogItem follows when BMaaS billing (OSAC-3795) lands.
+- **All catalog item types** — ComputeInstanceCatalogItem, ClusterCatalogItem, and BareMetalInstanceCatalogItem.
 
 ## Out of Scope
 
 - **Caching pricing data in OSAC's database** — prices are fetched from the billing system; OSAC does not maintain a local pricing cache.
 - **Price comparison across templates** — tenants cannot compare prices side-by-side across multiple catalog items in a single view.
-- **Pricing for BareMetalInstanceCatalogItem** — follows when BMaaS billing (OSAC-3795) lands and the billing system has BMaaS pricing plans configured.
+- **Field governance for pricing fields** — pricing information is always visible (not locked/hidden) when available. Advanced field governance behaviors for pricing follow in a separate feature.
 
 ## User Stories
 
@@ -37,11 +37,15 @@ Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem) display no pricin
 
 - OSAC-3784 (Billing Integration MVP) is operational — the billing provider adapter is deployed, pricing plans with rate cards are configured, and the billing system is the pricing source of truth.
 
-- Catalog items exist for the services being priced. The billing integration does not create catalog items but relies on their existence (OSAC-1531, OSAC-2452).
+- OSAC-3538 (Catalog Items v2) is operational — catalog items use the new structured field model, and the legacy field_definitions approach has been replaced. This PRD assumes the v2 field governance model throughout.
+
+- Catalog items exist for the services being priced. The billing integration does not create catalog items but relies on their existence.
 
 - The billing system's API supports querying prices by resource type and pricing plan at catalog display time. A short propagation delay after pricing changes in the billing system is acceptable.
 
 ## Dependencies
+
+- **OSAC-3538 — Catalog Items v2 Field Governance Redesign:** Provides the new structured field model for catalog items. Must be operational before pricing can be integrated with the catalog item schema.
 
 - **OSAC-3784 — Billing Integration MVP:** Provides the billing provider adapter and pricing plan infrastructure. Must be operational before catalog pricing can query the billing system for prices.
 
@@ -52,5 +56,8 @@ Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem) display no pricin
 ## Provenance
 
 Authored: draft @ prd 0.8.0 - a605aa5, workspace feat/add-osac-metering-documentation @ 514565f (3 behind origin/main)
+Final: revise @ prd 0.8.0 - a605aa5, workspace HEAD @ a2c2e18 (dirty)
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"a605aa5","source_repo":"514565f","source_repo_branch":"feat/add-osac-metering-documentation","commits_behind_main":3,"commits_ahead_main":0,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+> Context changed between draft and revise.
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"a605aa5","source_repo":"a2c2e18 (dirty)","source_repo_branch":"HEAD","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["draft","revise"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
+++ b/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
@@ -13,8 +13,8 @@ Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem, BareMetalInstance
 ## In Scope
 
 - **Assigned catalog items display per-unit price** from the tenant's active pricing plan. Pricing is shown only for catalog items assigned/available to the requesting user's context (tenant/project). Prices reflect the tenant's plan-specific rates, not a single base rate.
-- **Graceful degradation** — when the billing system is unavailable, catalog items render without pricing rather than failing. Tenants can still browse and provision; they just don't see prices.
-- **API, CLI, and UI surfaces** — pricing is visible on catalog items across all three surfaces. The UI shows formatted prices (e.g., "$0.26/hr" for a 4-core, 8 GiB VM).
+- **Graceful degradation** — when pricing data is unavailable (billing system unreachable or missing rate data), catalog items render without pricing rather than failing. Tenants can still browse and provision; they just don't see prices.
+- **API, CLI, and UI surfaces** — pricing is visible on catalog items across all three surfaces. The UI shows formatted prices (e.g., "$0.26/hr" for a Small VM instance type).
 - **All catalog item types** — ComputeInstanceCatalogItem, ClusterCatalogItem, and BareMetalInstanceCatalogItem.
 - **Visibility alignment with catalog assignment** — pricing follows the same hierarchical visibility model as catalog items (global → tenant → project).
 
@@ -32,7 +32,7 @@ Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem, BareMetalInstance
 
 ### Tenant Admin / Tenant User
 
-- As a Tenant Admin or Tenant User, I want to see the price of a catalog item available to my context (e.g., "$0.26/hr" for a VM template) before provisioning a resource, so that I can make cost-informed decisions about approved offerings.
+- As a Tenant Admin or Tenant User, I want to see the price of a catalog item available to my context (e.g., "$0.26/hr" for a Small instance type) before provisioning a resource, so that I can make cost-informed decisions about approved offerings.
 
 ## Assumptions
 
@@ -41,6 +41,10 @@ Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem, BareMetalInstance
 - OSAC-3538 (Catalog Items v2) is operational — catalog items use the new structured field model, and the legacy field_definitions approach has been replaced. This PRD assumes the v2 field governance model throughout.
 
 - OSAC-2474 (Catalog Item Assignment) is operational — the hierarchical assignment model (global → tenant → project) determines catalog item visibility, and pricing respects this same visibility model.
+
+- Pricing rates are tenant-scoped and applied uniformly across all projects within the tenant. All users within a tenant see the same pricing regardless of project assignment.
+
+- The billing system has configured rates for all resources available through catalog items. Catalog items without corresponding billing rates display gracefully without pricing.
 
 - Catalog items exist for the services being priced. The billing integration does not create catalog items but relies on their existence and assignment.
 
@@ -55,16 +59,6 @@ Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem, BareMetalInstance
 - **OSAC-3784 — Billing Integration MVP:** Provides the billing provider adapter and pricing plan infrastructure. Must be operational before catalog pricing can query the billing system for prices.
 
 - **OSAC Catalog (OSAC-1531, OSAC-2452):** Catalog items must exist for the services being priced.
-
-## Open Questions
-
-Questions for reviewers to resolve during PR review. Once answered, the resolution will be incorporated into the relevant section above and the entry removed.
-
-### 1. Implementation sequencing with OSAC-2474
-
-- **Owner:** Product team, Engineering team
-- **Impact:** Dependencies, delivery timeline
-- **Question:** Should catalog pricing respect assignment visibility from day one, or should it initially work independently and be aligned later? This affects whether OSAC-2474 is a hard blocker or parallel development is possible.
 
 ---
 

--- a/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
+++ b/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
@@ -4,59 +4,62 @@
 |-------------|----------------------|
 | Author(s)   | Moti Asayag          |
 | Jira        | [OSAC-3793](https://redhat.atlassian.net/browse/OSAC-3793) |
-| Date        | 2026-08-09           |
+| Date        | 2026-08-20           |
 
 ## Problem Statement
 
-Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem, BareMetalInstanceCatalogItem) display no pricing information. Tenants browsing the catalog cannot see what a resource will cost before provisioning it. Without pricing in the catalog, cost-informed decisions require tenants to provision first and check their billing dashboard afterward — or to consult a pricing document outside OSAC. This defeats the purpose of a self-service catalog and increases the risk of unexpected charges.
+Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem, BareMetalInstanceCatalogItem) display no pricing information. A catalog item maps to a service whose provisioned resource is composed of billable components — the metered resource type (for example, a VMaaS instance type) plus any non-metered components such as a paid add-on operator, a bundled software license, or a setup fee. Tenants browsing the catalog cannot see what any of these will cost before provisioning. Without pricing at browse time, cost-informed decisions require tenants to provision first and check their billing dashboard afterward — or to consult a pricing document outside OSAC. This defeats the purpose of a self-service catalog and increases the risk of unexpected charges.
 
 ## In Scope
 
-- **Assigned catalog items display per-unit price** from the tenant's active pricing plan. Pricing is shown only for catalog items assigned/available to the requesting user's context (tenant/project). Prices reflect the tenant's plan-specific rates, not a single base rate.
-- **Graceful degradation** — when pricing data is unavailable (billing system unreachable or missing rate data), catalog items render without pricing rather than failing. Tenants can still browse and provision; they just don't see prices.
-- **API, CLI, and UI surfaces** — pricing is visible on catalog items across all three surfaces. The UI shows formatted prices (e.g., "$0.26/hr" for a Small VM instance type).
+- **Display-time price enrichment of catalog items** — when a catalog item is displayed, OSAC enriches it with the price of the billable components of the resource it would provision, resolved against the requesting tenant's effective pricing plan (or the default plan when the tenant has no specific assignment). Pricing is presented only for catalog items assigned/available to the requesting user's context (tenant/project) and reflects that tenant's plan-specific rate cards, not a single base rate. Prices are read live from the billing system at display time; they are not stored on the catalog item.
+- **Metered and non-metered billable components are both priced** — the display shows the metered per-unit rate for the item's resource type (for example, "$0.26/hr" for a Small instance type) and itemizes any non-metered billable component charges attached to the resource (for example, a paid add-on operator, a bundled license, or a one-time setup fee), so the tenant sees the full cost picture rather than the usage rate alone. Amounts are shown in the billing account's base currency; the dollar figures here are illustrative.
+- **Graceful degradation on transient unavailability** — when the billing system is unreachable, catalog items render without pricing rather than failing. Tenants can still browse and provision; they just don't see prices. This covers transient outages and is not a substitute for rate coverage: a billable component that has no rate is a coverage gap OSAC-3784 requires be surfaced to the Cloud Provider Admin, not a silent steady state. This feature degrades gracefully as a fallback but does not treat a missing rate as normal.
+- **API, CLI, and UI surfaces** — enriched pricing is available on catalog items across all three surfaces. The UI shows formatted prices, including the per-unit rate and any itemized non-metered charges.
 - **All catalog item types** — ComputeInstanceCatalogItem, ClusterCatalogItem, and BareMetalInstanceCatalogItem.
-- **Visibility alignment with catalog assignment** — pricing follows the same hierarchical visibility model as catalog items (global → tenant → project).
+- **Visibility alignment with catalog assignment** — pricing follows the same hierarchical visibility model as catalog items (global → tenant → project). A catalog list price (a plan rate) is distinct from incurred-cost visibility: showing a user the rate for an offering they can browse is not the same as exposing another project's actual charges, which OSAC-3784 scopes by project membership.
 
 ## Out of Scope
 
-- **Caching pricing data in OSAC's database** — prices are fetched from the billing system; OSAC does not maintain a local pricing cache.
+- **Caching pricing data in OSAC's database** — prices are fetched live from the billing system; OSAC does not maintain a local pricing cache, and catalog items carry no cost metadata.
 - **Price comparison across templates** — tenants cannot compare prices side-by-side across multiple catalog items in a single view.
+- **Total-cost projection** — the display shows per-unit rates and itemized non-metered charges for a catalog item; it does not project total spend for a configured or running resource over time. Estimated cost of deployed resources is OSAC-3784's Tenant User cost view.
+- **Multi-perspective / context-driven pricing** — the catalog shows a single price per context: the requesting tenant's plan-specific rate. It does not expose the provider's own cost basis or margin, nor a separate per-end-user price. Different tenants may see different prices because they hold different pricing plans, but within a context there is one price. Per-user cost attribution is Out of Scope in OSAC-3784.
 - **Field governance for pricing fields** — pricing information is always visible (not locked/hidden) when available. Advanced field governance behaviors for pricing follow in a separate feature.
 
 ## User Stories
 
 ### Cloud Provider Admin
 
-- As a Cloud Provider Admin, I want catalog items to display the per-unit price from the tenant's assigned pricing plan, so that tenants see accurate, plan-specific pricing when browsing the catalog.
+- As a Cloud Provider Admin, I want catalog items to display the price of their billable components — the metered per-unit rate for the resource type and any non-metered component charges — drawn from the tenant's effective pricing plan, so that tenants see accurate, plan-specific pricing for approved offerings when browsing the catalog.
 
 ### Tenant Admin / Tenant User
 
-- As a Tenant Admin or Tenant User, I want to see the price of a catalog item available to my context (e.g., "$0.26/hr" for a Small instance type) before provisioning a resource, so that I can make cost-informed decisions about approved offerings.
+- As a Tenant Admin or Tenant User, I want to see the price of a catalog item available to my context before provisioning — the per-unit rate (e.g., "$0.26/hr" for a Small instance type) together with any non-metered charges such as an add-on or setup fee — so that I can make cost-informed decisions about approved offerings.
 
 ## Assumptions
 
-- OSAC-3784 (Billing Integration MVP) is operational — the billing provider adapter is deployed, pricing plans with rate cards are configured, and the billing system is the pricing source of truth.
+- OSAC-3784 (Billing Integration MVP) is operational — the billing provider adapter is deployed, pricing plans with rate cards keyed to billable components are configured (with a default plan for unassigned tenants), and the billing system is the pricing source of truth. OSAC-3784 explicitly delegates catalog price enrichment for display to this feature. This PRD uses OSAC-3784's glossary for shared billing terms (billable component, billable dimension, rate card, pricing plan, resource type, service).
 
-- OSAC-3538 (Catalog Items v2) is operational — catalog items use the new structured field model, and the legacy field_definitions approach has been replaced. This PRD assumes the v2 field governance model throughout.
+- OSAC-3538 (Catalog Items v2) is operational — catalog items use the new structured field model, and the legacy field_definitions approach has been replaced. This PRD assumes the v2 field governance model throughout. Consistent with that day-1 governance model, the catalog carries no cost metadata; price is resolved from billing at display time.
 
 - OSAC-2474 (Catalog Item Assignment) is operational — the hierarchical assignment model (global → tenant → project) determines catalog item visibility, and pricing respects this same visibility model.
 
-- Pricing rates are tenant-scoped and applied uniformly across all projects within the tenant. All users within a tenant see the same pricing regardless of project assignment.
+- Catalog list prices are tenant-scoped: rate cards are resolved from the tenant's effective pricing plan and are the same for all projects and users within the tenant. This concerns list prices shown at browse time, not incurred-cost visibility, which OSAC-3784 scopes by project membership.
 
-- The billing system has configured rates for all resources available through catalog items. Catalog items without corresponding billing rates display gracefully without pricing.
+- The billing system has configured rates for the billable components of resources available through catalog items. Per OSAC-3784's no-gaps contract, missing rates are surfaced to the Cloud Provider Admin; where a rate is nonetheless unavailable at display time, the affected component renders without a price (graceful degradation).
 
-- Catalog items exist for the services being priced. The billing integration does not create catalog items but relies on their existence and assignment.
+- Catalog items exist for the services being priced. This feature does not create catalog items but relies on their existence and assignment.
 
-- The billing system's API supports querying prices by resource type and pricing plan at catalog display time. A short propagation delay after pricing changes in the billing system is acceptable.
+- The billing system's API supports querying prices for a resource type's billable components by pricing plan at catalog display time. A short propagation delay after pricing changes in the billing system is acceptable (a bounded processing latency, consistent with OSAC-3784).
 
 ## Dependencies
 
 - **OSAC-2474 — Catalog Item Assignment to Tenants and Projects:** Provides the hierarchical catalog item assignment model. Must be operational before pricing can respect catalog item visibility rules.
 
-- **OSAC-3538 — Catalog Items v2 Field Governance Redesign:** Provides the new structured field model for catalog items. Must be operational before pricing can be integrated with the catalog item schema.
+- **OSAC-3538 — Catalog Items v2 Field Governance Redesign:** Provides the new structured field model for catalog items and establishes that the catalog carries no cost metadata (price is resolved from billing at display time). Must be operational before pricing can be integrated with the catalog item schema.
 
-- **OSAC-3784 — Billing Integration MVP:** Provides the billing provider adapter and pricing plan infrastructure. Must be operational before catalog pricing can query the billing system for prices.
+- **OSAC-3784 — Billing Integration MVP:** Provides the billing provider adapter, pricing plans, and rate cards keyed to billable components, and is the pricing source of truth. OSAC-3784 delegates catalog price enrichment for display to this feature (reciprocal scope handshake). Must be operational before catalog pricing can query the billing system for prices.
 
 - **OSAC Catalog (OSAC-1531, OSAC-2452):** Catalog items must exist for the services being priced.
 
@@ -65,8 +68,8 @@ Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem, BareMetalInstance
 ## Provenance
 
 Authored: draft @ prd 0.8.0 - a605aa5, workspace feat/add-osac-metering-documentation @ 514565f (3 behind origin/main)
-Final: revise @ prd 0.8.0 - a605aa5, workspace HEAD @ a2c2e18 (dirty)
+Final: respond @ prd 0.8.0 - 7efcedb, workspace HEAD @ 155acfa
 
-> Context changed between draft and revise.
+> Context changed between draft and respond.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"a605aa5","source_repo":"a2c2e18 (dirty)","source_repo_branch":"HEAD","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["draft","revise","revise"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"155acfa","source_repo_branch":"HEAD","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["draft","revise","revise","revise","respond"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
+++ b/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
@@ -18,6 +18,7 @@ VMaaS and CaaS catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem) di
 - **API, CLI, and UI surfaces** — enriched pricing is available on catalog items across all three surfaces. The UI shows formatted prices, including the per-unit rate and any itemized non-metered charges.
 - **Visibility alignment with catalog assignment** — pricing follows the same hierarchical visibility model as catalog items (global → tenant → project) and is shown only for items the requesting user can browse. List prices are tenant-scoped: the same for every project and user in the tenant. A list price is not incurred-cost visibility; OSAC-3784 scopes actual charges by project membership.
 - **Cloud Provider Admin preview is tenant-contextual** — when a Cloud Provider Admin previews catalog prices, the amounts are the list prices that tenant would see (that tenant's effective plan). This verifies tenant-facing display; it is not a second, provider-specific price list.
+- **Displayed price reflects the catalog item's default configuration** — the browse-time price is computed from the catalog item's default field values. With Catalog Items v2 (OSAC-3538), a catalog item may expose editable billable fields (for example, the instance type); if a tenant overrides an editable billable field at provisioning, the actual charge may differ from the displayed price. The UI signals this — for example a "price may vary" indicator — when the displayed item has editable billable fields.
 
 ## Out of Scope
 
@@ -29,6 +30,7 @@ VMaaS and CaaS catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem) di
 - **BMaaS catalog pricing** — price enrichment of BareMetalInstanceCatalogItem is [OSAC-3795](https://redhat.atlassian.net/browse/OSAC-3795).
 - **MaaS catalog pricing** — price enrichment of MaasCatalogItem (including per-token prices) is [OSAC-3794](https://redhat.atlassian.net/browse/OSAC-3794).
 - **Non-catalog billable resources** — this feature does not show list prices for resources that are not catalog items (for example standalone instance types, storage, or ExternalIPs). Incurred-cost views and rate-card management for those remain OSAC-3784.
+- **Pre-provisioning price preview for the catalog-less API path** — with Catalog Items v2 (OSAC-3538), a catalog item is optional for API provisioning. When a tenant provisions directly through the API without selecting a catalog item, there is no catalog display and therefore no pre-provisioning price preview. This path is now a first-class provisioning flow rather than an edge case; closing the preview gap for it is expected to be addressed by OSAC-3784.
 
 ## User Stories
 
@@ -60,8 +62,8 @@ VMaaS and CaaS catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem) di
 ## Provenance
 
 Authored: draft @ prd 0.8.0 - a605aa5, workspace feat/add-osac-metering-documentation @ 514565f (3 behind origin/main)
-Final: revise @ prd 0.8.0 - 7efcedb, workspace HEAD @ 155acfa
+Final: revise @ prd 0.8.0 - 7efcedb, workspace HEAD @ 6e8f396 (2 behind origin/main)
 
 > Context changed between draft and revise.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"155acfa","source_repo_branch":"HEAD","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["draft","revise","revise","revise","respond","revise"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"6e8f396","source_repo_branch":"HEAD","commits_behind_main":2,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise","revise","revise","respond","revise","revise"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
+++ b/enhancements/OSAC-3793-billing-catalog-pricing-integration/prd.md
@@ -1,0 +1,56 @@
+# Billing - Catalog Pricing Integration
+
+| Field       | Value                |
+|-------------|----------------------|
+| Author(s)   | Moti Asayag          |
+| Jira        | [OSAC-3793](https://redhat.atlassian.net/browse/OSAC-3793) |
+| Date        | 2026-08-09           |
+
+## Problem Statement
+
+Catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem) display no pricing information. Tenants browsing the catalog cannot see what a resource will cost before provisioning it. Without pricing in the catalog, cost-informed decisions require tenants to provision first and check their billing dashboard afterward — or to consult a pricing document outside OSAC. This defeats the purpose of a self-service catalog and increases the risk of unexpected charges.
+
+## In Scope
+
+- **Catalog items display per-unit price** from the tenant's active pricing plan. Prices reflect the tenant's plan-specific rates, not a single base rate.
+- **Graceful degradation** — when the billing system is unavailable, catalog items render without pricing rather than failing. Tenants can still browse and provision; they just don't see prices.
+- **API, CLI, and UI surfaces** — pricing is visible on catalog items across all three surfaces. The UI shows formatted prices (e.g., "$0.26/hr" for a 4-core, 8 GiB VM).
+- **VMaaS and CaaS catalog items** — ComputeInstanceCatalogItem and ClusterCatalogItem. Pricing for BareMetalInstanceCatalogItem follows when BMaaS billing (OSAC-3795) lands.
+
+## Out of Scope
+
+- **Caching pricing data in OSAC's database** — prices are fetched from the billing system; OSAC does not maintain a local pricing cache.
+- **Price comparison across templates** — tenants cannot compare prices side-by-side across multiple catalog items in a single view.
+- **Pricing for BareMetalInstanceCatalogItem** — follows when BMaaS billing (OSAC-3795) lands and the billing system has BMaaS pricing plans configured.
+
+## User Stories
+
+### Cloud Provider Admin
+
+- As a Cloud Provider Admin, I want catalog items to display the per-unit price from the tenant's assigned pricing plan, so that tenants see accurate, plan-specific pricing when browsing the catalog.
+
+### Tenant Admin / Tenant User
+
+- As a Tenant Admin or Tenant User, I want to see the price of a catalog item (e.g., "$0.26/hr" for a VM template) before provisioning a resource, so that I can make cost-informed decisions.
+
+## Assumptions
+
+- OSAC-3784 (Billing Integration MVP) is operational — the billing provider adapter is deployed, pricing plans with rate cards are configured, and the billing system is the pricing source of truth.
+
+- Catalog items exist for the services being priced. The billing integration does not create catalog items but relies on their existence (OSAC-1531, OSAC-2452).
+
+- The billing system's API supports querying prices by resource type and pricing plan at catalog display time. A short propagation delay after pricing changes in the billing system is acceptable.
+
+## Dependencies
+
+- **OSAC-3784 — Billing Integration MVP:** Provides the billing provider adapter and pricing plan infrastructure. Must be operational before catalog pricing can query the billing system for prices.
+
+- **OSAC Catalog (OSAC-1531, OSAC-2452):** Catalog items must exist for the services being priced.
+
+---
+
+## Provenance
+
+Authored: draft @ prd 0.8.0 - a605aa5, workspace feat/add-osac-metering-documentation @ 514565f (3 behind origin/main)
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"a605aa5","source_repo":"514565f","source_repo_branch":"feat/add-osac-metering-documentation","commits_behind_main":3,"commits_ahead_main":0,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->


### PR DESCRIPTION
## PRD: Billing - Catalog Pricing Integration

**Jira:** [OSAC-3793](https://redhat.atlassian.net/browse/OSAC-3793)

### Summary

Enriches OSAC catalog items (ComputeInstanceCatalogItem, ClusterCatalogItem) with live per-unit pricing from the billing system, so tenants see plan-specific prices when browsing templates before provisioning. Extension of [OSAC-3784](https://redhat.atlassian.net/browse/OSAC-3784) (Billing Integration MVP) — requires the billing adapter and pricing plans to be operational.

### Requesting Review On

- Scope: VMaaS and CaaS catalog items only (BMaaS deferred to [OSAC-3795](https://redhat.atlassian.net/browse/OSAC-3795)) — is this the right boundary?
- Graceful degradation behavior when billing system is unavailable
- Tenant-specific pricing (prices reflect the tenant's assigned pricing plan, not a base rate)
- Relationship with [OSAC-3784](https://redhat.atlassian.net/browse/OSAC-3784) — this PRD assumes the MVP is operational

### How to Review

- Comment inline on specific sections
- This PRD should be reviewed alongside [OSAC-3784: Billing Integration MVP](https://github.com/osac-project/enhancement-proposals/pull/199) — the two are designed to play well together
- Approve when the PRD accurately reflects the agreed requirements
