### PR TITLE
fix: add missing node_set to CaaS billing_dimensions example

### DIFF
--- a/enhancements/OSAC-985-metering-and-usage-tracking/design.md
+++ b/enhancements/OSAC-985-metering-and-usage-tracking/design.md
@@ -475,12 +475,13 @@ stateDiagram-v2
   "cluster_template": "ocp-ci-small",
   "release_image": "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64",
   "component": "worker",
+  "node_set": "gpu-h100",
   "host_type": "ci-worker",
   "node_count": 3
 }
 ```
 
-Control plane uses `"component": "control_plane"`, `"host_type": "_control_plane"`, `"node_count": 1`.
+Control plane uses `"component": "control_plane"`, `"node_set": "_control_plane"`, `"host_type": "_control_plane"`, `"node_count": 1`.
 
 **MaaS `billing_dimensions`:**
 


### PR DESCRIPTION
## Summary

The CaaS `billing_dimensions` JSON example in the metering design doc was missing the `node_set` field. This field exists in the implementation (osac#172) and is validated by E2E tests (osac-test-infra#349).

Added `node_set` to both the worker and control plane examples.

Flagged by @masayag during review of osac-test-infra#349.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added worker node-set details to CaaS billing dimensions.
  * Documented the control-plane node set for billing and usage tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->