### PR TITLE
NO-ISSUE: Networking Design updates

### DIFF
--- a/enhancements/OSAC-1433-default-networking/design.md
+++ b/enhancements/OSAC-1433-default-networking/design.md
@@ -20,33 +20,15 @@ superseded-by:
 
 # Default Networking — Simplified Resource Creation
 
-This enhancement provides default networking resources (including dual-stack subnets and NATGateway) at tenant onboarding, optional network_attachments with defaults, auto ExternalIP provisioning, and auto-cleanup on deletion.
+Default networking provides automatic resource provisioning at tenant onboarding (including dual-stack subnets and NATGateway), optional network_attachments with defaults, auto ExternalIP provisioning, and auto-cleanup on deletion.
 
 ## Summary
 
-This enhancement is an expansion of the [Unified Networking EP](/enhancements/OSAC-1433-unified-networking/design.md), providing default networking automation and simplified resource creation. When a tenant is created, the system automatically provisions a default VirtualNetwork, IPv4 Subnet, IPv6 Subnet, SecurityGroup, and NATGateway based on NetworkClass configuration (dual-stack). Resources (ComputeInstance, Cluster, BaremetalInstance) can omit network_attachments and use tenant defaults. Auto ExternalIP modes enable fully connected resources in a single API call. See [PRD](prd.md) for detailed requirements.
+This document is a per-service expansion of the [Unified Networking EP](/enhancements/OSAC-1433-unified-networking/design.md), providing default networking automation and simplified resource creation. When a tenant is created, the system provisions a default VirtualNetwork, IPv4 Subnet, IPv6 Subnet, SecurityGroup, and NATGateway based on NetworkClass configuration (dual-stack). Resources (ComputeInstance, Cluster, BaremetalInstance) can omit network_attachments and use tenant defaults. Auto ExternalIP modes enable fully connected resources in a single API call. See [PRD](prd.md) for detailed requirements.
 
 ## Motivation
 
-Creating a reachable resource in OSAC requires 6+ sequential API calls: VirtualNetwork, Subnet, SecurityGroup, the resource itself, ExternalIP, and ExternalIPAttachment. Every tenant must understand the full networking resource model before provisioning their first VM, cluster, or bare-metal server. This friction slows onboarding, increases the chance of misconfiguration, and makes OSAC harder to adopt compared to platforms where a single create command produces a reachable instance.
-
-### What Already Works
-
-- Tenant controller exists and reconciles Tenant resources
-- VirtualNetwork, Subnet, SecurityGroup CRDs and controllers are implemented
-- ExternalIP and ExternalIPAttachment provisioning works end-to-end
-- NATGateway resource is implemented (OSAC-1676)
-- NetworkClass resource exists with defaults configuration
-- Resource creation with explicit network_attachments works for all three resource types
-
-### What's Missing
-
-- No default networking resources at tenant onboarding
-- No default CIDR or SecurityGroup rules configuration on NetworkClass
-- network_attachments field is required — no defaults applied when omitted
-- No auto ExternalIP allocation mode
-- No auto-cleanup of auto-provisioned resources on parent deletion
-- No tenant READY condition gating on default networking readiness
+A reachable resource in OSAC requires networking resources: VirtualNetwork, Subnet, SecurityGroup, the resource itself, ExternalIP, and ExternalIPAttachment. Default networking eliminates this friction — a single create command produces a reachable instance by leveraging tenant defaults provisioned at onboarding.
 
 ### Goals
 
@@ -54,7 +36,7 @@ Creating a reachable resource in OSAC requires 6+ sequential API calls: VirtualN
 - Default networking resources (VN, IPv4 Subnet, IPv6 Subnet, SG, NATGateway) provisioned at tenant onboarding (dual-stack)
 - Optional network_attachments field on all resource types
 - Auto ExternalIP mode for inbound connectivity
-- Auto-cleanup of auto-provisioned resources on deletion
+- Auto-cleanup of auto-created resources on deletion
 - Tenant-scoped default resources (visible, editable, lifecycle-managed by tenant)
 
 ### Non-Goals
@@ -66,7 +48,7 @@ Creating a reachable resource in OSAC requires 6+ sequential API calls: VirtualN
 
 ## Proposal
 
-This enhancement adds three main capabilities: default networking (including NATGateway) at tenant onboarding, optional network_attachments with auto-population, and auto ExternalIP provisioning.
+The design covers three capabilities: default networking (including NATGateway) at tenant onboarding, optional network_attachments with auto-population, and auto ExternalIP provisioning.
 
 ### Workflow Description
 
@@ -150,7 +132,7 @@ This enhancement adds three main capabilities: default networking (including NAT
      - Reads `auto_external_ip_attachment: true`
      - Auto-selects ExternalIPPool (READY, most available capacity, IPv4 family)
      - Creates ExternalIP + ExternalIPAttachment in the same DB transaction — both start in **Pending** state. Pool capacity is decremented atomically.
-     - Both labeled `osac.openshift.io/auto-provisioned: "true"`. ExternalIP also labeled `osac.openshift.io/auto-provisioned-for: <resource-id>` for orphan cleanup.
+     - Both labeled `osac.openshift.io/auto-created: "true"`. ExternalIP also labeled `osac.openshift.io/auto-created-for: <resource-id>` for orphan cleanup.
    - ComputeInstance CR created with `auto_external_ip_attachment: true`
    - osac-operator reconciles ExternalIP (fabric manager allocates address → Allocated), then VM provisioning, then ExternalIPAttachment controller activates once ExternalIP is Allocated AND `compute_network_attachment_statuses` is populated with the primary attachment's `ip_address`
    - See [Unified Networking — Auto-provisioning lifecycle](/enhancements/OSAC-1433-unified-networking/design.md#external-access-same-for-all-resource-types) for the full two-phase flow
@@ -173,7 +155,7 @@ This enhancement adds three main capabilities: default networking (including NAT
      - Reads `auto_external_ip_attachment: true`
      - Auto-selects ExternalIPPool (same algorithm)
      - Creates two ExternalIPs + two ExternalIPAttachments in the same DB transaction — all start in **Pending** state. Pool capacity decremented atomically.
-     - All labeled `osac.openshift.io/auto-provisioned: "true"`
+     - All labeled `osac.openshift.io/auto-created: "true"`
    - osac-operator ExternalIP controller dispatches to fabric manager → ExternalIPs transition to Allocated (external addresses assigned)
    - Cluster provisioning proceeds — MetalLB allocates internal VIPs from its IPAddressPool. Template discovers VIPs and writes to ClusterOrder status (`apiEndpoint`, `ingressEndpoint`).
    - ExternalIPAttachment controllers activate once ExternalIP is Allocated AND ClusterOrder `apiEndpoint`/`ingressEndpoint` are populated → creates DNAT: external IP → internal VIP
@@ -185,16 +167,16 @@ This enhancement adds three main capabilities: default networking (including NAT
 
 #### Auto-Cleanup on Deletion
 
-10. **Tenant User deletes resource with auto-provisioned ExternalIP:**
+10. **Tenant User deletes resource with auto-created ExternalIP:**
     ```bash
     osac delete computeinstance my-vm
     ```
     - osac-operator ComputeInstance controller finalizer:
-      - Queries ExternalIPAttachment and ExternalIP labeled `osac.openshift.io/auto-provisioned: "true"` referencing this ComputeInstance
+      - Queries ExternalIPAttachment and ExternalIP labeled `osac.openshift.io/auto-created: "true"` referencing this ComputeInstance
       - Deletes ExternalIPAttachment first (DNAT rule removed)
       - Deletes ExternalIP second (IP returned to pool)
       - If cleanup fails permanently (after retries): finalizer is removed, parent resource deleted, orphaned resources left in cluster
-    - **Manually created resources are NOT cleaned up** — if tenant created ExternalIP/ExternalIPAttachment explicitly (not labeled auto-provisioned), they persist after parent deletion
+    - **Manually created resources are NOT cleaned up** — if tenant created ExternalIP/ExternalIPAttachment explicitly (not labeled auto-created), they persist after parent deletion
     - **Default networking resources (VN, Subnet, SG, NATGateway) are NOT cleaned up** — they are tenant-scoped and shared across resources
 
 11. **Tenant Admin inspects and customizes default resources:**
@@ -271,11 +253,11 @@ metadata:
     osac.openshift.io/default: "true"
 ```
 
-All auto-provisioned resources (ExternalIP, ExternalIPAttachment created by auto_external_ip_attachment=true) receive label:
+All auto-created resources (ExternalIP, ExternalIPAttachment created by auto_external_ip_attachment=true) receive label:
 ```yaml
 metadata:
   labels:
-    osac.openshift.io/auto-provisioned: "true"
+    osac.openshift.io/auto-created: "true"
 ```
 
 #### Operator CRD (osac-operator)
@@ -368,7 +350,7 @@ type ClusterSpec struct {
 | Component | Responsibility |
 |-----------|---------------|
 | fulfillment-service | Validate NetworkClass defaults, **create default VN/IPv4 Subnet/IPv6 Subnet/SG/NATGateway at tenant onboarding** (via its own API), populate network_attachments defaults, auto-provision ExternalIP, track DefaultNetworkingReady condition, return error on capacity exhaustion |
-| osac-operator resource controllers | Clean up auto-provisioned ExternalIP and ExternalIPAttachment via finalizer |
+| osac-operator resource controllers | Clean up auto-created ExternalIP and ExternalIPAttachment via finalizer |
 | osac-operator networking controllers | Reconcile default networking resources (same as manually created resources) |
 | osac-installer | Configure NetworkClass defaults in setup.sh and installation overlays |
 
@@ -384,11 +366,11 @@ type ClusterSpec struct {
 #### Auto-Provisioned Resource Lifecycle
 
 - **Creation:** fulfillment-service creates ExternalIP or ExternalIPAttachment when auto_external_ip_attachment=true
-- **Labeling:** All auto-provisioned resources labeled `osac.openshift.io/auto-provisioned: "true"`
-- **Cleanup:** Parent resource finalizer deletes auto-provisioned ExternalIP/ExternalIPAttachment on parent deletion
+- **Labeling:** All auto-created resources labeled `osac.openshift.io/auto-created: "true"`
+- **Cleanup:** Parent resource finalizer deletes auto-created ExternalIP/ExternalIPAttachment on parent deletion
 - **Cleanup order:** ExternalIPAttachment → ExternalIP → parent resource removal
 - **Cleanup failure:** If cleanup fails permanently (after retries), finalizer is removed, parent deleted, orphaned ExternalIP/ExternalIPAttachment left in cluster (manual cleanup required)
-- **Manual resources NOT cleaned up:** If tenant created ExternalIP/ExternalIPAttachment explicitly (not labeled auto-provisioned), they persist after parent deletion
+- **Manual resources NOT cleaned up:** If tenant created ExternalIP/ExternalIPAttachment explicitly (not labeled auto-created), they persist after parent deletion
 
 #### Prerequisite Ordering for Clusters
 
@@ -410,9 +392,9 @@ Note: the external IPs (from ExternalIPPool) and internal VIPs (from MetalLB IPA
 
 #### Tenant Isolation
 
-All default and auto-provisioned resources inherit tenant annotation from parent:
+All default and auto-created resources inherit tenant annotation from parent:
 - `osac.openshift.io/tenant` annotation propagated from Tenant to default VN/Subnet/SG/NATGateway
-- `osac.openshift.io/tenant` annotation propagated from ComputeInstance/Cluster/BaremetalInstance to auto-provisioned ExternalIP/ExternalIPAttachment
+- `osac.openshift.io/tenant` annotation propagated from ComputeInstance/Cluster/BaremetalInstance to auto-created ExternalIP/ExternalIPAttachment
 - OPA policies enforce tenant-scoped list/get/update/delete
 
 #### CIDR Overlap Across Tenants
@@ -452,14 +434,14 @@ This feature inherits the existing security model:
 
 - **Transient failure:** Parent finalizer retries cleanup (exponential backoff)
 - **Permanent failure:** After N retries, finalizer is removed, parent resource deleted, orphaned ExternalIP/ExternalIPAttachment left in cluster
-- **Manual cleanup required:** Tenant Admin or Cloud Provider Admin manually deletes orphaned resources (identified by label `osac.openshift.io/auto-provisioned: "true"` with no parent reference)
+- **Manual cleanup required:** Tenant Admin or Cloud Provider Admin manually deletes orphaned resources (identified by label `osac.openshift.io/auto-created: "true"` with no parent reference)
 
 ### RBAC / Tenancy
 
-No RBAC or tenancy changes. All new resources (default networking, auto-provisioned ExternalIP) inherit tenant isolation:
+No RBAC or tenancy changes. All new resources (default networking, auto-created ExternalIP) inherit tenant isolation:
 - `osac.openshift.io/tenant` annotation propagated from parent to all child resources
 - OPA policies enforce tenant-scoped list/get/update/delete
-- Tenant User can view and manage default and auto-provisioned resources via standard API
+- Tenant User can view and manage default and auto-created resources via standard API
 - Cloud Infrastructure Admin configures NetworkClass defaults (global, applies to all tenants)
 
 ### Observability and Monitoring
@@ -474,7 +456,7 @@ New Kubernetes events on Tenant:
 
 New Kubernetes events on ComputeInstance/Cluster/BaremetalInstance:
 - `NetworkAttachmentsPopulated`: network_attachments field populated with tenant defaults
-- `AutoExternalIPCreated`: ExternalIP and ExternalIPAttachment auto-provisioned
+- `AutoExternalIPCreated`: ExternalIP and ExternalIPAttachment auto-created
 
 No new metrics or alerts (existing provisioning duration and failure rate metrics apply).
 
@@ -553,7 +535,7 @@ Resolved: Return error, no resource persisted.
 - fulfillment-service: capacity exhaustion error (return error, resource not persisted)
 - fulfillment-service: default resource creation at tenant onboarding (VN, IPv4 Subnet, IPv6 Subnet, SG, NATGateway with default label)
 - fulfillment-service: DefaultNetworkingReady condition tracking (true when all defaults including both Subnets and NATGateway READY via feedback, false when any failed)
-- osac-operator resource controllers: auto-provisioned resource cleanup (delete ExternalIPAttachment → ExternalIP on parent deletion)
+- osac-operator resource controllers: auto-created resource cleanup (delete ExternalIPAttachment → ExternalIP on parent deletion)
 
 ### Integration Tests
 
@@ -562,7 +544,7 @@ Resolved: Return error, no resource persisted.
 - E2E: create ComputeInstance without network_attachments, verify defaults populated in spec
 - E2E: create ComputeInstance with `--external-ip-attachment`, verify auto ExternalIP + ExternalIPAttachment created, DNAT rule functional
 - E2E: create Cluster with `--external-ip-attachment`, verify two ExternalIPs created BEFORE provisioning, cluster VIPs match
-- E2E: delete ComputeInstance with auto-provisioned resources, verify ExternalIPAttachment and ExternalIP cleaned up
+- E2E: delete ComputeInstance with auto-created resources, verify ExternalIPAttachment and ExternalIP cleaned up
 - E2E: create ComputeInstance with explicit network_attachments, verify defaults NOT applied
 - E2E: create ComputeInstance with `--external-ip-attachment` when pool exhausted, verify error returned, resource not persisted
 - E2E: Tenant Admin modifies default SecurityGroup rules, verify changes take effect
@@ -617,13 +599,13 @@ Minor version upgrades (`x.N → x.N+1`):
 If `N+1` upgrade fails or cluster is misbehaving:
 - Manual rollback: update fulfillment-service and osac-operator images to `N`
 - Existing Tenants with default networking resources: default resources remain (no impact)
-- Existing resources with auto-provisioned ExternalIP: `N` server does not recognize auto_external_ip_attachment field, auto-provisioned resources remain (manual cleanup required if not needed)
+- Existing resources with auto-created ExternalIP: `N` server does not recognize auto_external_ip_attachment field, auto-created resources remain (manual cleanup required if not needed)
 - New resource creation with auto_external_ip_attachment=true will fail (field not recognized)
 
 Acceptable downgrade steps:
-- Existing resources continue to function (default networking and auto-provisioned resources persist)
+- Existing resources continue to function (default networking and auto-created resources persist)
 - New resources must use explicit networking (auto_external_ip_attachment=true not supported)
-- Manually delete orphaned auto-provisioned resources if not needed (identified by label `osac.openshift.io/auto-provisioned: "true"`)
+- Manually delete orphaned auto-created resources if not needed (identified by label `osac.openshift.io/auto-created: "true"`)
 
 ## Version Skew Strategy
 
@@ -676,7 +658,7 @@ kubectl describe tenant acme-corp -n <namespace>
 
 ### Symptom: Auto-provisioned ExternalIP not cleaned up after resource deletion
 
-**Detection:** `kubectl get externalip` shows orphaned ExternalIP labeled `osac.openshift.io/auto-provisioned: "true"` with no parent
+**Detection:** `kubectl get externalip` shows orphaned ExternalIP labeled `osac.openshift.io/auto-created: "true"` with no parent
 
 **Cause:** Finalizer cleanup failed permanently
 

--- a/enhancements/OSAC-1433-unified-networking/design.md
+++ b/enhancements/OSAC-1433-unified-networking/design.md
@@ -25,10 +25,9 @@ superseded-by:
 
 ## Summary
 
-This enhancement describes the technical design for the OSAC unified
-networking architecture. For the problem statement, gaps analysis, and
-requirements, see the companion
-[Requirements Document (PRD)](prd.md).
+This document describes the technical design for the OSAC unified
+networking architecture. For the problem statement and requirements,
+see the companion [Requirements Document (PRD)](prd.md).
 
 OSAC runs VMs on OpenShift using KubeVirt, which encapsulates each VM in a
 pod. Pod networking is managed by OVN-Kubernetes, meaning VMs live inside an
@@ -80,10 +79,11 @@ OSAC networking is handled by two managers:
 
 - **K8s Manager** (optional) — handles everything needed to make VMs part of
   the fabric: creates the K8s overlay (e.g., CUDN with LocalNet) and bridges
-  it to the fabric segment. Also creates MetalLB IPAddressPool CRs at subnet
-  creation time for CaaS VIP allocation. Needed for deployments that host
-  both VMs and BMs and require multi-tenancy across all. Once VMs are on the fabric, the fabric manager handles them
-  identically to bare-metal servers.
+  it to the fabric segment. Needed for deployments that host VMs — once VMs
+  are on the fabric, the fabric manager handles them identically to
+  bare-metal servers. MetalLB IPAddressPool CRs for CaaS VIP allocation are
+  created by the Subnet controller at subnet creation time (gated on
+  `NetworkClass.spec.vip_prefix_length`), independent of the k8sManager.
 
 #### Why Two Managers?
 
@@ -266,7 +266,7 @@ Forwarding) instances to route between the OVN overlay and the fabric. Each
 tenant VN maps to a VRF on the host, which peers with the fabric via BGP.
 VMs are reachable from the fabric via L3 routing through the VRF. See the
 [CUDN with VRF-lite setup guide](/docs/networking/setup-bpg-vrf-lite) for
-a working lab example.
+a working example.
 
 **DPU-based bridging.** SmartNICs (DPUs) offload the OVN-to-fabric bridging
 to hardware. The DPU handles packet encapsulation/decapsulation between OVN
@@ -359,15 +359,14 @@ manager handles ExternalIP allocation — one pool serves all resource types.
 
 This section shows how the unified networking API works from the tenant's
 perspective. The flows are the same regardless of which fabric manager or
-K8s manager the provider has deployed. Annotations mark what is **new** or
-**changed** compared to the current design.
+K8s manager the provider has deployed.
 
 #### Provider Setup
 
 1. Provider deploys hosting cluster(s) and fabric controller
-2. Provider creates NetworkClass for the deployment (**new** — provider-only,
+2. Provider creates NetworkClass for the deployment (provider-only,
    tenants never see it)
-3. Provider creates ExternalIPPool (**renamed** from PublicIPPool):
+3. Provider creates ExternalIPPool:
 
 ```bash
 osac admin create externalippool \
@@ -501,10 +500,10 @@ all resources equally — there is no VM-vs-BM distinction.
 #### External Access (Same for All Resource Types)
 
 Since all resources are on the fabric, external access operations are
-uniform. There is no VM-vs-BM distinction (**changed** — the current design
-has separate K8s-side steps for VMs).
+uniform. There is no VM-vs-BM distinction — the fabric manager handles
+DNAT and SNAT identically for all resource types.
 
-**Allocate ExternalIP:** (**renamed** from PublicIP)
+**Allocate ExternalIP:**
 
 ```bash
 osac create externalip --pool external-pool-1 --name my-ip
@@ -623,7 +622,7 @@ precondition checks and requeue:
 |-------------|----------------------|---------------------|
 | ComputeInstance | `compute_network_attachment_statuses` populated with primary attachment's `ip_address` | Feedback controller reads KubeVirt VMI network status, writes `ComputeNetworkAttachmentStatus` per attachment |
 | Cluster | `status.apiEndpoint` or `status.ingressEndpoint` populated on ClusterOrder CR | MetalLB allocates VIP from IPAddressPool, template discovers and writes to ClusterOrder status |
-| BaremetalInstance | `status.networkAttachmentStatuses[].ipAddress` populated for the primary interface | Operator queries fabric manager's DHCP lease API via dispatcher (`query_dhcp_lease` role) after provisioning completes; matches port MAC to assigned IP; operator writes to CR status |
+| BaremetalInstance | `status.networkAttachmentStatuses[].ipAddress` populated for the primary interface | Operator queries fabric manager's DHCP lease API via dispatcher (`query_dhcp_lease` role) after provisioning completes; matches port MAC (from the BareMetalHost `osac.openshift.io/interface-macs` annotation) to assigned IP; operator writes to CR status |
 
 The controller uses the existing requeue pattern: if the precondition
 is not met, it returns `ctrl.Result{RequeueAfter: interval}` and
@@ -634,7 +633,7 @@ targets.
 *IP discovery — DHCP-based host networking:*
 
 All host-side IP assignment uses DHCP. The fabric's DHCP server (managed
-by the fabric manager as part of the V-Net infrastructure) assigns IPs
+by the fabric manager as part of the network segment infrastructure) assigns IPs
 to hosts when they boot on the subnet. OSAC does not pre-allocate IPs
 or configure host-side networking — DHCP handles IP address, gateway,
 prefix, and DNS automatically.
@@ -650,27 +649,47 @@ IP discovery mechanism per service type:
 |---------|-----------------|-------------------|-------------|
 | VMaaS | KubeVirt VMI `status.interfaces[].ipAddress` | osac-operator feedback controller → Signal RPC → fulfillment-service | `ComputeInstanceStatus.compute_network_attachment_statuses[].ip_address` |
 | CaaS | Agent CR network status | osac-operator feedback controller → Signal RPC → fulfillment-service | `ClusterOrderStatus.nodeSets[].agents[].ipAddress` (operator-internal) |
-| BMaaS | Operator queries fabric manager's DHCP lease API via dispatcher (`query_dhcp_lease` role) after provisioning completes; matches port MAC to DHCP-assigned IP (see [BMaaS OQ#4 — Resolved](/enhancements/OSAC-1437-bmaas-networking/design.md#4-how-is-the-hosts-runtime-ip-discovered-after-network-reconfiguration)) | bare-metal-fulfillment-operator dispatches `query_dhcp_lease` → writes to CR status → feedback controller → Signal RPC → fulfillment-service | `BareMetalInstanceStatus.network_attachment_statuses[].ip_address` |
+| BMaaS | Operator queries fabric manager's DHCP lease API via dispatcher (`query_dhcp_lease` role) after provisioning completes; matches port MAC — from the BareMetalHost `osac.openshift.io/interface-macs` annotation — to the DHCP-assigned IP, falling back to server name for named fabric servers (see [BMaaS OQ#4 — Resolved](/enhancements/OSAC-1437-bmaas-networking/design.md#4-how-is-the-hosts-runtime-ip-discovered-after-network-reconfiguration)) | bare-metal-fulfillment-operator dispatches `query_dhcp_lease` → writes to CR status → feedback controller → Signal RPC → fulfillment-service | `BareMetalInstanceStatus.network_attachment_statuses[].ip_address` |
 
-The fabric manager's `create_network_attachment` role is switch-side
-only — it adds the host's port to the V-Net. The role is generic: it
-first checks if the port is already on a V-Net (e.g., a parking
-network for CaaS pre-booted agents) — if so, removes it — then adds
-the port to the target V-Net. This handles both BMaaS (server not on
-any V-Net) and CaaS (agent moving from parking to tenant V-Net) with
-the same role. The role is idempotent: if the port is already on the
-target V-Net, the role is a no-op. The role only removes and re-adds
-the port when the current V-Net differs from the target. Once on the
-V-Net, the host receives an IP from the fabric's DHCP server
-automatically. On deletion, `delete_network_attachment` removes the
-port from the tenant V-Net and returns it to the parking network
-(CaaS) or leaves it detached (BMaaS).
+The fabric manager's `move_network_attachment` role is switch-side
+only — it moves a host's fabric port from one network segment to another
+(`from_vnet_name` → `to_vnet_name`, either side optional). Attach and
+detach are the **same primitive**: on provision the port moves from a
+**provisioning network** to the tenant subnet's network segment; on deletion it
+moves back to the provisioning network. The role operates purely against the
+fabric (no Subnet CR lookup) and is keyed on plain segment names, so the caller
+resolves a `subnetRef` → tenant segment name and supplies the provisioning
+network name from configuration. Detach is a no-op if the port is not on the
+named segment, so re-runs and unexpected states are safe.
+
+One role handles both BMaaS (fabric NIC on the provisioning network while the
+server is idle so it has internet during metal3 inspection) and CaaS (agent
+moving from a provisioning network to the tenant network). The **timing** of the
+move differs per service:
+
+- **BMaaS:** Move happens **POST-provisioning** (provision on the provisioning
+  network → move to tenant network → reboot so the OS re-DHCPs on the tenant
+  network). This achieves isolation-until-ready: the tenant cannot reach the
+  server during imaging/first-boot.
+- **CaaS:** Move happens **BEFORE provisioning** (agents are pre-booted on the
+  provisioning network, so the port is moved to the tenant network before cluster
+  creation begins; no in-deploy switch needed).
+
+Once on the tenant network, the host receives an IP from the fabric's DHCP server
+automatically. A single AAP job template serves both directions, deriving onboard
+(provisioning network → tenant) vs. offboard (tenant → provisioning network) from
+the resource's `deletionTimestamp`. See [BMaaS — Provisioning Network and Port
+Moves](/enhancements/OSAC-1437-bmaas-networking/design.md#provisioning-network-and-port-moves).
 
 IP discovery for BMaaS is a separate dispatcher call. After
 `reconcileProvisioning` completes and the host has received a DHCP
 lease, the operator dispatches `query_dhcp_lease` — this role queries
 the fabric manager's DHCP lease API for the subnet and matches the
 server's port MAC address to find the corresponding DHCP-assigned IP.
+Bare-metal hosts are not named fabric servers, so the lease is matched
+by NIC MAC, which the operator supplies from the host's
+`osac.openshift.io/interface-macs` BareMetalHost annotation; named
+fabric servers such as CaaS agents fall back to matching by server name.
 
 *NATGateway controller preconditions:*
 
@@ -689,10 +708,10 @@ address.
 
 *Auto-provisioned resource labeling:*
 
-All auto-provisioned resources receive the label
-`osac.openshift.io/auto-provisioned: "true"`. Auto-provisioned
+All auto-created resources receive the label
+`osac.openshift.io/auto-created: "true"`. Auto-provisioned
 ExternalIPs also receive a parent-resource label
-`osac.openshift.io/auto-provisioned-for: <resource-id>` so that the
+`osac.openshift.io/auto-created-for: <resource-id>` so that the
 cleanup logic can find orphaned ExternalIPs directly, even if the
 intermediate ExternalIPAttachment has already been deleted.
 
@@ -701,13 +720,13 @@ intermediate ExternalIPAttachment has already been deleted.
 The parent resource's finalizer uses a phased requeue approach to
 ensure correct ordering:
 
-1. Query ExternalIPAttachments labeled `auto-provisioned` targeting
+1. Query ExternalIPAttachments labeled `auto-created` targeting
    this resource. Issue delete for each. Requeue.
 2. On next reconcile: check if all ExternalIPAttachments are fully
    deleted (including their own finalizers completing the DNAT rule
    removal). If not, requeue.
 3. Once all ExternalIPAttachments are gone: query ExternalIPs labeled
-   `auto-provisioned-for: <this-resource>`. Issue delete for each.
+   `auto-created-for: <this-resource>`. Issue delete for each.
    Requeue.
 4. On next reconcile: check if all ExternalIPs are fully deleted. If
    not, requeue.
@@ -716,7 +735,7 @@ ensure correct ordering:
 
 If cleanup fails permanently (after N retries): finalizer is removed,
 parent resource deleted, orphaned resources left in cluster. Orphaned
-resources are identifiable by the `auto-provisioned-for` label.
+resources are identifiable by the `auto-created-for` label.
 
 **Enable outbound NAT (SNAT):**
 
@@ -974,7 +993,7 @@ message BareMetalInstanceStatus {
 }
 ```
 
-IP discovered after DHCP assignment on the tenant V-Net. After
+IP discovered after DHCP assignment on the tenant network. After
 `reconcileProvisioning` completes, the operator dispatches
 `query_dhcp_lease` to the fabric manager's DHCP lease API, matching
 the server's port MAC address to find the assigned IP (see
@@ -1076,7 +1095,7 @@ attachment determines:
 
 **IP assignment:** All resource types receive IPs via DHCP. For VMs,
 OVN provides DHCP on the CUDN overlay. For BM servers and CaaS agents,
-the fabric's DHCP server assigns IPs on the V-Net. The provisioning
+the fabric's DHCP server assigns IPs on the network segment. The provisioning
 template does NOT configure host-side networking (no static IP, gateway,
 or DNS configuration) — DHCP handles it automatically.
 
@@ -1117,11 +1136,15 @@ template roles create DNS records. A DNS API is a separate enhancement.
 
 #### BM-Only Deployments
 
-If a NetworkClass has no k8sManager, the deployment does not support VMs or CaaS
-clusters. ComputeInstance creation is rejected if the target NetworkClass
-has no k8sManager — there is no K8s overlay to place the VM on. Cluster
-creation is also rejected — without a k8sManager, there is no MetalLB
-IPAddressPool for VIP allocation on the hosting cluster.
+If a NetworkClass has no k8sManager, the deployment does not support VMs.
+ComputeInstance creation is rejected if the target NetworkClass has no
+k8sManager — there is no K8s overlay to place the VM on.
+
+CaaS clusters work without a k8sManager. MetalLB IPAddressPool creation
+is handled by the Subnet controller (gated on
+`NetworkClass.spec.vip_prefix_length`), not by the k8sManager. BM-only
+CaaS deployments provision clusters with fabric-level networking and
+MetalLB VIP allocation without requiring a K8s overlay.
 
 #### CIDR Overlap
 
@@ -1142,10 +1165,10 @@ VirtualNetwork at creation time.
 
 This design requires K8s-to-fabric connectivity in every deployment that
 hosts VMs. The k8sManager must bridge the OVN overlay to the physical
-fabric for VMs to participate. It is also required for CaaS clusters, where
-it creates MetalLB IPAddressPool CRs at subnet creation time for API and
-ingress VIP allocation. In BM-only deployments without CaaS, the
-k8sManager is not needed and the design reduces to fabric-manager-only.
+fabric for VMs to participate. In deployments without VMs (BM-only, with
+or without CaaS), the k8sManager is not needed and the design reduces to
+fabric-manager-only. MetalLB IPAddressPool creation for CaaS VIP
+allocation is handled by the Subnet controller, not the k8sManager.
 
 The trade-off is justified by infrastructure-agnostic subnets: any resource
 type on any subnet, uniform security enforcement via the fabric, and no

--- a/enhancements/OSAC-1433-unified-networking/design.md
+++ b/enhancements/OSAC-1433-unified-networking/design.md
@@ -1062,6 +1062,60 @@ All fields are immutable after creation.
 
 ### Implementation Details
 
+#### Deletion Dependency Guards
+
+When the API layer (fulfillment-service) soft-deletes networking resources,
+it accepts the delete as soon as child resources are themselves soft-deleted.
+On the operator side, each controller triggers its AAP deprovision job when
+it sees a `deletionTimestamp`. If a parent and its children are deleted
+near-simultaneously, the parent's deprovision job fires before children
+have been fully removed from the infrastructure backend, causing the backend
+to reject the parent deletion.
+
+To prevent unnecessary failed jobs and backoff delays, each parent
+controller gates its deprovision on the complete removal of child CRs.
+The controller lists child CRs referencing the parent before triggering the
+AAP deprovision job. If any children still exist on the cluster (regardless
+of their own deletion state), the controller requeues with a short interval
+(10 seconds) instead of dispatching a doomed job.
+
+| Controller | Gate deprovision on |
+|---|---|
+| VirtualNetwork | No Subnet, SecurityGroup, or NATGateway CRs with `spec.virtualNetwork` referencing this VNet |
+| Subnet | No ComputeInstance CRs with `spec.networkAttachments[].subnetRef` referencing this Subnet; no BareMetalInstance CRs with `spec.networkAttachments[].subnetRef` referencing this Subnet (see [BMaaS Networking](/enhancements/OSAC-1437-bmaas-networking/design.md)) |
+| ExternalIP | No ExternalIPAttachment or NATGateway CRs with `spec.externalIP` referencing this EIP |
+| ExternalIPPool | No ExternalIP CRs with `spec.pool` referencing this pool |
+
+The full dependency chain (delete order, leaf first):
+
+```text
+ComputeInstance / BareMetalInstance (leaf)
+  must be gone before --> Subnet
+  must be gone before --> ExternalIPAttachment (via auto-cleanup)
+
+ExternalIPAttachment
+  must be gone before --> ExternalIP
+
+NATGateway
+  must be gone before --> ExternalIP
+  must be gone before --> VirtualNetwork
+
+SecurityGroup
+  must be gone before --> VirtualNetwork
+
+Subnet
+  must be gone before --> VirtualNetwork
+
+ExternalIP
+  must be gone before --> ExternalIPPool
+
+VirtualNetwork (delete last)
+```
+
+This is the same pattern used during provisioning (e.g., the NATGateway
+controller gates provisioning on ExternalIP readiness and VirtualNetwork
+readiness) -- applied symmetrically to the deprovision path.
+
 #### NATGateway Scope
 
 One NATGateway per VirtualNetwork. All subnets in the VN use the gateway.

--- a/enhancements/OSAC-1433-unified-networking/design.md
+++ b/enhancements/OSAC-1433-unified-networking/design.md
@@ -1178,6 +1178,21 @@ k8sManager creates a K8s overlay on each hosting cluster and bridges it to
 the fabric segment. VMs on different hosting clusters share the same subnet
 via the fabric.
 
+#### Hub Selection (CR Placement)
+
+The fulfillment-controller creates K8s CRs on a registered hub cluster.
+All networking resources (VirtualNetwork, Subnet, SecurityGroup,
+ExternalIPPool, ExternalIP, ExternalIPAttachment, NATGateway) select a
+hub randomly from the available hubs. Hub selection is sticky — once a
+resource is assigned to a hub via `status.hub`, subsequent reconciliations
+reuse the same hub.
+
+This design assumes a single-hub deployment. Multi-hub resource placement
+(affinity between related resources, cross-hub CR visibility) is deferred
+as a future design concern. The fabric spans all hosting clusters, so
+AAP-dispatched operations reach the same infrastructure regardless of
+which hub triggers them.
+
 #### Cross-VN Communication
 
 VirtualNetworks are isolated. Cross-VN communication (VN Peering) is a

--- a/enhancements/OSAC-1435-vmaas-networking/design.md
+++ b/enhancements/OSAC-1435-vmaas-networking/design.md
@@ -169,7 +169,7 @@ ComputeInstance already participates in the networking API. Today's flow:
    - **Default networking resources (VN, Subnet, SG, NATGateway) are NOT cleaned up** — they are tenant-scoped and shared across resources.
    - osac-operator triggers `osac-delete-compute-instance` AAP job
    - Template deletes KubeVirt VM + DataVolume
-   - No `delete_network_attachment` call (VM was on overlay, not switch port)
+   - No `move_network_attachment` call — the VM lives on the CUDN overlay, not a fabric switch port, so it is never parked or port-moved (the port-move primitive and parking apply only to fabric-attached BM servers and CaaS agents)
 
 10. **Delete networking resources:**
     - Each networking resource controller triggers its delete AAP job

--- a/enhancements/OSAC-1436-caas-networking/design.md
+++ b/enhancements/OSAC-1436-caas-networking/design.md
@@ -18,41 +18,21 @@ superseded-by:
 
 # CaaS Networking — Cluster Networking via OSAC Networking API
 
-This enhancement extends the unified networking API to support CaaS-specific requirements: tenant-controlled cluster node networking via VirtualNetwork + Subnet attachments, BM-based node sets with fabric interface resolution, MetalLB VIP provisioning, and auto-provisioned external access (ExternalIP + ExternalIPAttachment) for cluster API and ingress endpoints.
+CaaS networking provides tenant-controlled cluster node networking via VirtualNetwork + Subnet attachments, BM-based node sets with fabric interface resolution, MetalLB VIP provisioning, and auto-provisioned external access (ExternalIP + ExternalIPAttachment) for cluster API and ingress endpoints.
 
 ## Summary
 
-This enhancement is an expansion of the [Unified Networking EP](/enhancements/OSAC-1433-unified-networking/design.md), providing the detailed per-service flow for this service type. The unified EP defines the shared architecture (NetworkClass, dispatcher, infrastructure-agnostic subnets, resource hierarchy); this document defines how this specific service consumes that architecture.
+This document is a per-service expansion of the [Unified Networking EP](/enhancements/OSAC-1433-unified-networking/design.md). The unified EP defines the shared architecture (NetworkClass, dispatcher, infrastructure-agnostic subnets, resource hierarchy); this document defines how CaaS consumes that architecture.
 
-Cluster provisioning currently uses inline networking logic in the CaaS template — all VLAN creation, SNAT, DNAT, IP allocation, DNS, and MetalLB configuration happens in step collections with zero tenant control. This enhancement moves networking lifecycle to the OSAC Networking API, enables tenants to place clusters on shared or isolated VirtualNetworks, and introduces a VIP feedback loop for cluster API/ingress endpoints to enable auto-provisioned external access. See [PRD](prd.md) for detailed requirements.
+Cluster provisioning uses the OSAC Networking API for all networking lifecycle — tenants place clusters on their VirtualNetworks via `network_attachment`, the operator handles agent selection and port moves, and a VIP feedback loop enables auto-provisioned external access for cluster API and ingress endpoints. See [PRD](prd.md) for detailed requirements.
 
 ## Motivation
 
-Cluster provisioning today follows this flow:
-
-1. Tenant creates Cluster with template + node_sets + pull_secret (no networking parameters)
-2. fulfillment-service creates ClusterOrder CR
-3. osac-operator ClusterOrder controller triggers AAP workflow
-4. AAP workflow calls the CaaS template which dispatches to `{{ network_steps_collection }}.cluster_infra` and `{{ network_steps_collection }}.external_access`:
-   - **Netris**: selects agents, creates server cluster, allocates NAT IP, creates SNAT/DNAT, DNS, MetalLB
-   - **agentless_net**: allocates VLAN, configures switch ports, creates L3 router namespace, SNAT, DNAT, DNS, MetalLB
-
-### What Already Works
-
-- HyperShift HostedCluster + NodePool creation works
-- ClusterOrder CR exists with spec/status fields
-- AAP workflow integration (`osac-create-hosted-cluster-workflow`) works
-- Step collections (`netris.steps`, `agentless_net.steps`) provision working networking
-
-### What's Missing
-
-- CaaS template does ALL networking — none goes through the OSAC Networking API
-- Tenants have no control over which VirtualNetwork or Subnet their cluster nodes use
-- Tenants cannot place two clusters in the same VN or isolate them in separate VNs
-- `network_steps_collection` env var selects the ENTIRE networking backend deployment-wide
-- Step collections duplicate functionality that should be in the networking API
-- No VIP feedback loop (cluster VIPs are provisioned in the template but not synced to fulfillment-service)
-- No auto external access (tenant must manually create ExternalIP + ExternalIPAttachment for API/ingress)
+Clusters require tenant-controlled networking to enable:
+- Placing clusters on shared or isolated VirtualNetworks
+- Automatic agent port configuration (provisioning network → tenant network) during cluster creation
+- VIP feedback loop for cluster API/ingress endpoints to enable DNAT via ExternalIPAttachment
+- Auto external access (ExternalIP + ExternalIPAttachment) for single-call cluster provisioning with inbound connectivity
 
 ### Goals
 
@@ -65,18 +45,23 @@ Cluster provisioning today follows this flow:
 
 ### Agent Pool Model
 
-The current assumption is that **pre-booted Assisted Installer agents** are ready in a pool, waiting to be assigned to clusters. These agents sit on a **parking network** — a fabric-manager-managed V-Net that provides basic connectivity (DHCP, PXE, management access) while agents are idle. The parking network V-Net ID is a **deployment-level configuration** (e.g., AAP group_var `parking_vnet_id`), not a per-cluster or per-tenant parameter.
+**Pre-booted Assisted Installer agents** are ready in a pool, waiting to be assigned to clusters. These agents sit on a **provisioning network** — a fabric-manager-managed network segment that provides basic connectivity (DHCP, PXE, management access) while agents are idle. The provisioning network segment name is a **deployment-level configuration** (an AAP group_var, mirroring BMaaS's `netris_bm_provisioning_vnet`), not a per-cluster or per-tenant parameter.
 
 When an agent is selected for a cluster:
-1. The agent's port is **moved from the parking network to the tenant's subnet V-Net** (via `create_network_attachment`)
+1. The agent's port is **moved from the provisioning network to the tenant's subnet network segment** (via the generic `move_network_attachment` role — `from_vnet_name` = provisioning, `to_vnet_name` = tenant)
 2. The agent receives a new IP from the tenant subnet's DHCP server
-3. After cluster deletion, the agent's port is **returned to the parking network** (via `delete_network_attachment`)
+3. After cluster deletion, the agent's port is **returned to the provisioning network** (the reverse move — `from_vnet_name` = tenant, `to_vnet_name` = provisioning)
 
-This differs from BMaaS, where servers start with no network attachment and are placed directly on the tenant V-Net. For CaaS, the `create_network_attachment` role must handle the transition: check if the port is already on a network (parking V-Net), remove it, then add to the target V-Net. The `delete_network_attachment` role reverses this: remove from tenant V-Net, return to parking V-Net.
+**Generic role behavior:** The `move_network_attachment` role is keyed on plain network segment names — it detaches the port from `from_vnet_name` (if set), then attaches it to `to_vnet_name` (if set). Detach is a no-op when the port is not on the named segment, so re-runs and unexpected states are safe. This one role serves both CaaS and BMaaS, but the **timing** differs:
 
-**Generic role behavior:** The `create_network_attachment` role works identically for both CaaS and BMaaS by always checking if the given port is already part of a V-Net. If yes, remove it first. Then add to the target V-Net. This means:
-- **CaaS:** agent on parking V-Net → remove from parking → add to tenant V-Net
-- **BMaaS:** server not on any V-Net → nothing to remove → add to tenant V-Net
+- **CaaS:** Move happens **BEFORE provisioning** (agents are pre-booted on the
+  provisioning network, so the port is moved to the tenant network before cluster
+  creation begins; no in-deploy switch needed). Agent on provisioning network →
+  detach provisioning network → attach tenant network → cluster provisioning.
+- **BMaaS:** Move happens **POST-provisioning** (provision on the provisioning
+  network → move to tenant network → reboot so the OS re-DHCPs on the tenant
+  network). This achieves isolation-until-ready for bare-metal servers; CaaS does
+  not require this since agents are pre-booted and idle until assigned.
 
 **Future consideration:** The agent pool model may evolve toward on-demand agent booting during cluster provisioning (no pre-booted pool). The design should accommodate this by not assuming agents are pre-existing — the `reconcileAgentSelection` step abstracts agent discovery, and the networking flow works regardless of whether the agent was pre-booted or just provisioned.
 
@@ -137,21 +122,21 @@ These steps are identical to VMaaS/BMaaS — the networking API is uniform.
       - Subnet exists, is Ready
       - SecurityGroups exist, are Ready, belong to same VN
     - For each node_set: resolves `host_type` → HostType → picks first interface with role `fabric` and stores as `fabric_interface` on the node set definition in the ClusterOrder spec
-    - If `auto_external_ip_attachment == true`: auto-selects ExternalIPPool, creates two ExternalIPs (API + ingress, each labeled `osac.openshift.io/auto-provisioned: "true"` and `osac.openshift.io/auto-provisioned-for: <cluster-id>`) and two ExternalIPAttachments (labeled `osac.openshift.io/auto-provisioned: "true"`) — all in the same DB transaction, all starting in **Pending** state. Pool capacity is decremented atomically; if the pool is exhausted, the API call fails and no resources are persisted. The ExternalIPAttachments transition to Ready once VIPs are populated (see Phase 3). See [Unified Networking — Auto-provisioning lifecycle](/enhancements/OSAC-1433-unified-networking/design.md#external-access-same-for-all-resource-types) for the shared two-phase flow and phased requeue cleanup pattern.
+    - If `auto_external_ip_attachment == true`: auto-selects ExternalIPPool, creates two ExternalIPs (API + ingress, each labeled `osac.openshift.io/auto-created: "true"` and `osac.openshift.io/auto-created-for: <cluster-id>`) and two ExternalIPAttachments (labeled `osac.openshift.io/auto-created: "true"`) — all in the same DB transaction, all starting in **Pending** state. Pool capacity is decremented atomically; if the pool is exhausted, the API call fails and no resources are persisted. The ExternalIPAttachments transition to Ready once VIPs are populated (see Phase 3). See [Unified Networking — Auto-provisioning lifecycle](/enhancements/OSAC-1433-unified-networking/design.md#external-access-same-for-all-resource-types) for the shared two-phase flow and phased requeue cleanup pattern.
     - Creates Cluster record with empty `api_endpoint` / `ingress_endpoint`
     - Creates ClusterOrder CR with enriched `network_attachment` in spec
 
 6. **osac-operator ClusterOrder controller:**
     - Creates namespace, ServiceAccount, RoleBindings (same as today)
 
-    **a. `reconcileAgentSelection` (NEW — replaces template-side agent selection):**
+    **a. `reconcileAgentSelection`:**
     - For each node_set: selects suitable agents from inventory based on `host_type`, availability, and labels
     - Labels and reserves selected agents for this cluster
     - Stores selected agent references on ClusterOrder status
 
-    **b. `reconcileNetworking` (NEW — runs after agent selection, before provisioning):**
-    - **Operator dispatches switch-side config:** For each agent across all node sets, dispatcher calls `osac.templates.{{ fabric_manager }}.create_network_attachment` passing `host_name` (agent's Netris server name), `logical_interface_name` (fabric_interface from the agent's node set definition), `subnet_ref`. The role checks if the port is already on a V-Net (parking network) — if so, removes it first — then adds the port to the tenant's subnet V-Net. Agents receive new IPs from the tenant subnet's DHCP server. See [Agent Pool Model](#agent-pool-model).
-    - **Per-agent IP discovery:** After switch port configuration moves agent ports to the tenant V-Net, agents receive new IPs from the tenant subnet's DHCP server. The Assisted Installer Agent CR reports network status including the assigned IP in `status.inventory.interfaces[].ipv4Addresses[]`. The operator watches for this field to be updated after the port move and populates `AgentStatus.IPAddress` on the ClusterOrder status. The feedback controller then syncs these IPs to the fulfillment-service. If the Agent CR does not report an IP within a configurable timeout (default: 5 minutes after port move), the operator sets a `NetworkingIPDiscoveryTimeout` condition on the ClusterOrder and requeues, preventing indefinite blocking.
+    **b. `reconcileNetworking` (runs after agent selection, before provisioning):**
+    - **Operator dispatches switch-side config:** For each agent across all node sets, dispatcher calls `osac.templates.{{ fabric_manager }}.move_network_attachment` passing `host_name` (agent's fabric server name), `logical_interface_name` (fabric_interface from the agent's node set definition), `from_vnet_name` (the provisioning network) and `to_vnet_name` (the tenant's subnet network segment, resolved from `subnet_ref`). The move playbook waits for the target network segment to reach active state (fabric converged) before returning success. Agents receive new IPs from the tenant subnet's DHCP server. See [Agent Pool Model](#agent-pool-model).
+    - **Per-agent IP discovery:** After switch port configuration moves agent ports to the tenant network, agents receive new IPs from the tenant subnet's DHCP server. The Assisted Installer Agent CR reports network status including the assigned IP in `status.inventory.interfaces[].ipv4Addresses[]`. The operator watches for this field to be updated after the port move and populates `AgentStatus.IPAddress` on the ClusterOrder status. The feedback controller then syncs these IPs to the fulfillment-service. If the Agent CR does not report an IP within a configurable timeout (default: 5 minutes after port move), the operator sets a `NetworkingIPDiscoveryTimeout` condition on the ClusterOrder and requeues, preventing indefinite blocking.
     - Network attachments must be Ready before provisioning proceeds
 
     **c. Triggers AAP workflow** (same as today, but template is simpler):
@@ -209,7 +194,7 @@ These steps are identical to VMaaS/BMaaS — the networking API is uniform.
 #### Deletion (reverse order)
 
 12. **Delete Cluster:**
-    - **Auto-provisioned cleanup (osac-operator ClusterOrder controller):** Phased requeue: deletes ExternalIPAttachments first (by target reference), waits, then deletes ExternalIPs (by `auto-provisioned-for` label), waits, then proceeds. See [Unified Networking — Auto-provisioned resource cleanup](/enhancements/OSAC-1433-unified-networking/design.md#external-access-same-for-all-resource-types).
+    - **Auto-provisioned cleanup (osac-operator ClusterOrder controller):** Phased requeue: deletes ExternalIPAttachments first (by target reference), waits, then deletes ExternalIPs (by `auto-created-for` label), waits, then proceeds. See [Unified Networking — Auto-provisioned resource cleanup](/enhancements/OSAC-1433-unified-networking/design.md#external-access-same-for-all-resource-types).
     - **Manually created resources are NOT cleaned up** — tenant manages their lifecycle. Manually created ExternalIPAttachments transition back to detached / Pending.
     - **Default networking resources (VN, Subnet, SG, NATGateway) are NOT cleaned up** — tenant-scoped and shared.
     - ClusterOrder controller triggers AAP delete workflow
@@ -218,7 +203,7 @@ These steps are identical to VMaaS/BMaaS — the networking API is uniform.
       - Deletes HyperShift HostedCluster + NodePools
       - DNS cleanup
       - No switch port cleanup — template doesn't handle networking
-    - ClusterOrder controller `reconcileNetworking` (delete): dispatcher calls `delete_network_attachment` per BM node (passing host_name, logical_interface_name from the agent's node set definition, subnet_ref, and `parking_vnet_id` from deployment configuration). The role removes the port from the tenant's subnet V-Net and **returns it to the parking network** — the agent is back in the idle pool. See [Agent Pool Model](#agent-pool-model).
+    - ClusterOrder controller `reconcileNetworking` (delete): dispatcher calls `move_network_attachment` per BM node (passing host_name, logical_interface_name from the agent's node set definition, `from_vnet_name` = the tenant's subnet network segment resolved from subnet_ref, and `to_vnet_name` = the provisioning network name from deployment configuration). The role removes the port from the tenant's subnet segment and **returns it to the provisioning network** — the agent is back in the idle pool. See [Agent Pool Model](#agent-pool-model).
     - ClusterOrder controller `reconcileAgentCleanup` (delete): removes operator-set reservation labels from agents, making them available for future clusters.
     - Removes ClusterOrder finalizer
 
@@ -227,7 +212,7 @@ These steps are identical to VMaaS/BMaaS — the networking API is uniform.
     - Delete NATGateway → fabric manager removes SNAT rule
     - Delete ExternalIPs → fabric manager releases IPs
     - Delete SecurityGroup → fabric manager removes ACL rules
-    - Delete Subnet → dispatcher calls both managers: fabric manager removes V-Net segment, k8s_manager removes CUDN overlay + MetalLB IPAddressPool from hosting clusters
+    - Delete Subnet → dispatcher calls both managers: fabric manager removes network segment, k8s_manager removes CUDN overlay + MetalLB IPAddressPool from hosting clusters
     - Delete VirtualNetwork → fabric manager removes tenant segment
 
 ### HostType and Interface Resolution
@@ -260,7 +245,7 @@ The tenant provides a single `ClusterNetworkAttachment` with `subnet` only — n
     {name: "mgmt-0", role: "management"}]
    ```
 3. fulfillment-service picks the first interface with role `fabric` → `data-0`, stores as `fabric_interface` on the node set definition
-4. Operator calls `create_network_attachment` with `interface=data-0` per node
+4. Operator calls `move_network_attachment` with `interface=data-0` per node (provisioning → tenant network)
 
 For v0.2: **CaaS supports BM node sets only.** VM-based cluster node sets are architecturally possible (the HostType BM-vs-VM discriminator and CUDN overlay support it) but are deferred — the HyperShift ↔ CUDN integration for VM worker nodes is not in scope.
 
@@ -290,7 +275,7 @@ Roles are conventions, not enforced enums. The CaaS template defaults to role `f
 
 - `ClusterNetworkAttachment` proto message on ClusterSpec
 - `api_endpoint` / `ingress_endpoint` status fields on Cluster and ClusterOrder
-- Operator handles agent selection and network attachment (dispatcher calls `create_network_attachment` / `delete_network_attachment` for BM nodes before/after provisioning)
+- Operator handles agent selection and network attachment (dispatcher calls `move_network_attachment` for BM nodes before/after provisioning — provisioning → tenant on create, tenant → provisioning on delete)
 - Template provisions MetalLB VIPs and writes them to ClusterOrder status
 - VIP feedback loop: ClusterOrder → fulfillment-service → Cluster → ExternalIPAttachment controller
 - ExternalIPAttachment Pending → Ready lifecycle for cluster targets
@@ -360,7 +345,7 @@ type NodeSetStatus struct {
 
 type AgentStatus struct {
     AgentName string `json:"agentName"`           // Agent CR name (for NodePool targeting)
-    HostName  string `json:"hostName"`            // Netris server name (for dispatcher)
+    HostName  string `json:"hostName"`            // fabric server name (for dispatcher)
     SubnetRef string `json:"subnetRef,omitempty"`
     IPAddress string `json:"ipAddress,omitempty"` // Discovered by operator's reconcileNetworking: watches Agent CR network status after DHCP assignment, populates here; feedback controller syncs to fulfillment-service
 }
@@ -405,12 +390,12 @@ Migration adds to clusters table:
 | osac-operator ClusterOrder feedback controller | Watch ClusterOrder status, Signal fulfillment-service when VIPs/IPs appear |
 | osac-operator ExternalIPAttachment controller | Read ClusterOrder `apiEndpoint`/`ingressEndpoint` (MetalLB-allocated, template-discovered) from status, create DNAT via fabric_manager |
 | AAP template (ocp_4_17_small) | Create HostedCluster+NodePools (with pre-selected agents), provision MetalLB VIPs, write VIPs to ClusterOrder status, host-side networking handled by DHCP — no agent selection logic |
-| fabric_manager (Ansible role) | create_network_attachment (V-Net port attachment), delete_network_attachment (V-Net port removal), create/delete_external_ip_attachment (DNAT), create/delete_nat_gateway (SNAT) |
+| fabric_manager (Ansible role) | move_network_attachment (generic port move: detach from/attach to, used for both provisioning → tenant and tenant → provisioning), create/delete_external_ip_attachment (DNAT), create/delete_nat_gateway (SNAT) |
 | k8s_manager (Ansible role) | create/delete_subnet (CUDN overlay) — called at subnet creation, NOT at cluster creation |
 
 #### Auto-Provisioned Resource Lifecycle
 
-- Labeled `osac.openshift.io/auto-provisioned: "true"`
+- Labeled `osac.openshift.io/auto-created: "true"`
 - Parent resource finalizer deletes in order: ExternalIPAttachment → ExternalIP
 - On permanent cleanup failure: finalizer removed, parent deleted, orphaned resources left for manual cleanup
 
@@ -447,7 +432,7 @@ This feature inherits the existing security model:
 No RBAC or tenancy changes. All new resources (Cluster with new fields, auto-provisioned ExternalIP/ExternalIPAttachment) inherit tenant isolation from parent:
 - `osac.openshift.io/tenant` annotation propagated from Cluster to auto-created resources
 - OPA policies enforce tenant-scoped list/get/update/delete
-- Tenant User can view and manage auto-provisioned resources (labeled `osac.openshift.io/auto-provisioned: "true"`) via standard API
+- Tenant User can view and manage auto-provisioned resources (labeled `osac.openshift.io/auto-created: "true"`) via standard API
 
 ### Observability and Monitoring
 
@@ -517,11 +502,11 @@ Instead of implementing VIP feedback loop, require tenants to manually create Ex
 
 ### ~~1. How does the operator select agents?~~ — Resolved
 
-Resolved: The operator queries Agent CRs directly via K8s API — selects by host_type label match and availability, labels selected agents with `osac.openshift.io/cluster-order: <name>` to reserve them. This is the current approach but may evolve as the agent management model changes.
+Resolved: The operator queries Agent CRs directly via K8s API — selects by host_type label match and availability, labels selected agents with `osac.openshift.io/cluster-order: <name>` to reserve them. This may evolve as the agent management model changes.
 
 ### ~~2. NMState NNCP configuration~~ — Resolved
 
-Resolved: DHCP handles host-side networking for CaaS agents. NMState NNCP configuration is no longer needed — agents receive their IP, gateway, and DNS from the fabric's DHCP server when they boot on the V-Net. The template does not configure static networking.
+Resolved: DHCP handles host-side networking for CaaS agents. NMState NNCP configuration is no longer needed — agents receive their IP, gateway, and DNS from the fabric's DHCP server when they boot on the network segment. The template does not configure static networking.
 
 ### ~~3. MetalLB IP pools~~ — Resolved
 
@@ -626,7 +611,7 @@ If `N+1` upgrade fails or cluster is misbehaving:
 Acceptable downgrade steps:
 - Delete Clusters using new field
 - Re-create using old flow (no network_attachment field)
-- Manually delete orphaned auto-provisioned resources (ExternalIP, ExternalIPAttachment labeled `osac.openshift.io/auto-provisioned: "true"`)
+- Manually delete orphaned auto-provisioned resources (ExternalIP, ExternalIPAttachment labeled `osac.openshift.io/auto-created: "true"`)
 
 ## Version Skew Strategy
 
@@ -665,7 +650,7 @@ kubectl describe cluster <name> -n <namespace>
 
 ### Symptom: Auto-provisioned ExternalIP not cleaned up after Cluster deletion
 
-**Detection:** `kubectl get externalip` shows orphaned ExternalIP labeled `osac.openshift.io/auto-provisioned: "true"` with no parent
+**Detection:** `kubectl get externalip` shows orphaned ExternalIP labeled `osac.openshift.io/auto-created: "true"` with no parent
 
 **Cause:** Finalizer cleanup failed permanently
 
@@ -700,7 +685,7 @@ Consequences:
 
 - AAP execution environment with `osac.templates.ocp_4_17_small` role updated (remove cluster_infra/external_access, add MetalLB VIP provisioning)
 - k8s_manager Ansible role (OSAC-1511 or OSAC-1717) for CUDN overlay provisioning
-- fabric_manager Ansible role with `create_network_attachment` / `delete_network_attachment` (OSAC-2081)
+- fabric_manager Ansible role with the generic `move_network_attachment` primitive (OSAC-2081); a provisioned provisioning network segment for the idle agent pool
 - Integration test environment with CUDN or EVPN fabric
 - HostType test data with NetworkInterface fields
 
@@ -726,7 +711,7 @@ Consequences:
 | Cluster provisioning flow (operator side) | OSAC-2049 | New |
 | CLI --network-attachment for Cluster | OSAC-2076 | New |
 | Integration test | OSAC-2078 | New |
-| Fabric manager create/delete_network_attachment role | OSAC-2081 (Netris BM) | New |
+| Fabric manager `move_network_attachment` role (generic port move) | OSAC-2081 (Netris BM) | New |
 | HostType: add NetworkInterface fields (name, role, description) | Not tracked | **GAP** |
 | Remove cluster_infra / external_access step collection dispatch | Not tracked | **GAP** |
 | Remove NETWORK_STEPS_COLLECTION dependency | Not tracked | **GAP** |

--- a/enhancements/OSAC-1437-bmaas-networking/design.md
+++ b/enhancements/OSAC-1437-bmaas-networking/design.md
@@ -19,27 +19,17 @@ superseded-by:
 
 # BMaaS Networking — Switch Port Configuration and Tenant-Defined Interface Mapping
 
-This enhancement extends the unified networking API to support BMaaS-specific requirements: multi-NIC BaremetalInstance provisioning with tenant-specified physical interface mapping, switch port configuration via dispatcher, IP address feedback through CR status, and auto-provisioned external access (ExternalIP).
+BMaaS networking provides multi-NIC BaremetalInstance provisioning with tenant-specified physical interface mapping, switch port configuration via dispatcher, IP address feedback through CR status, and auto-provisioned external access (ExternalIP).
 
 ## Summary
 
-This enhancement is an expansion of the [Unified Networking EP](/enhancements/OSAC-1433-unified-networking/design.md), providing the detailed per-service flow for this service type. The unified EP defines the shared architecture (NetworkClass, dispatcher, infrastructure-agnostic subnets, resource hierarchy); this document defines how this specific service consumes that architecture.
+This document is a per-service expansion of the [Unified Networking EP](/enhancements/OSAC-1433-unified-networking/design.md). The unified EP defines the shared architecture (NetworkClass, dispatcher, infrastructure-agnostic subnets, resource hierarchy); this document defines how BMaaS consumes that architecture.
 
-BaremetalInstance currently has NO networking fields. The bare-metal-fulfillment-operator allocates hosts from inventory (Ironic or Metal3) but does not configure switch ports or integrate with the OSAC Networking API. This enhancement introduces `BareMetalNetworkAttachment` with explicit `interface` and `primary` fields, adds `reconcileNetworking` phase to the operator, and enables IP address feedback via CR status for DNAT rule creation. See [PRD](prd.md) for detailed requirements.
+BaremetalInstance supports `BareMetalNetworkAttachment` with explicit `interface` and `primary` fields. The bare-metal-fulfillment-operator's `reconcileNetworking` phase configures switch ports via dispatcher, and IP address feedback via CR status enables DNAT rule creation. See [PRD](prd.md) for detailed requirements.
 
 ## Motivation
 
-BaremetalInstance does NOT participate in the networking API today. Current flow:
-
-1. Tenant creates BaremetalInstance with template + template_parameters (no networking parameters)
-2. fulfillment-service creates BaremetalInstance CR on hub (sets TemplateID, TemplateParameters, RunStrategy, labels, annotations)
-3. bare-metal-fulfillment-operator BareMetalInstance controller:
-   - `reconcileInventory`: FindFreeHost → AssignHost (Ironic or Metal3 backend). Populates HostClass and NetworkClass from inventory.
-   - `reconcileProvisioning`: triggers AAP job via `RunProvisioningLifecycle` — full CR serialized as payload. Template does BM-specific provisioning (OS install, user-data).
-   - `reconcilePower`: manages power state (Ironic/Metal3 API).
-   - Updates CR status (phase, conditions).
-4. osac-operator feedback controller: watches CR status changes, fires Signal RPC to fulfillment-service.
-5. fulfillment-service syncs status back to its database.
+Bare-metal servers require explicit switch port configuration to participate in the OSAC Networking API. Unlike VMs (which live inside an OVN overlay bridged to the fabric), BM servers connect directly to the physical fabric — each NIC's switch port must be moved between network segments during the provisioning lifecycle.
 
 ### Architecture: Two Operators on One CR
 
@@ -49,48 +39,74 @@ fulfillment-service → creates BaremetalInstance CR → hub cluster
     bare-metal-fulfillment-operator ─────────────────────┤ (provisioning)
       - reconcileInventory (Ironic/Metal3)               │
       - reconcileProvisioning (AAP)                      │
+      - reconcileNetworking (dispatcher)                 │
+      - reconcileReboot (handoff)                        │
+      - reconcileIPDiscovery (DHCP lease query)          │
       - reconcilePower (Ironic/Metal3)                   │
-      - finalizers: inventory, baremetalinstance          │
+      - finalizers: inventory, baremetalinstance,         │
+        baremetalinstance-networking                      │
                                                          │
-    osac-operator ───────────────────────────────────────┘ (feedback only)
+    osac-operator ───────────────────────────────────────┘ (feedback + cleanup)
       - BareMetalInstanceFeedbackReconciler
       - fires Signal RPC on status change
       - finalizer: baremetalinstance-feedback (removed last)
+      - BareMetalInstance cleanup controller (auto ExternalIP)
 ```
 
-### What Already Works
-
-- Two-operator architecture is stable (bare-metal-fulfillment-operator for provisioning, osac-operator for feedback)
-- Inventory assignment (host allocation from Ironic/Metal3)
-- OS provisioning via AAP templates
-- Power management via Ironic/Metal3 API
-- Status feedback to fulfillment-service
-
-### What's Missing
-
-- BaremetalInstance spec has no `network_attachments` field
-- No switch port configuration during BM provisioning
-- No integration with the OSAC Networking API
-- The `NetworkClass` field populated from inventory is stored but unused. This is a static config string (e.g., "openstack") set at operator startup — NOT the OSAC NetworkClass CRD. This field should be removed entirely from the BareMetalInstance spec (it is unused per reviewer feedback).
-- No ExternalIPAttachment support for `baremetal_instance` target
-- No IP address feedback mechanism (ExternalIPAttachment controller needs BM's IP to create DNAT rules)
-
 ### Goals
+
+**Core Design Goals (G1–G5):**
+
+- **G1 — OS-agnostic host networking.** All host addressing via DHCP; no per-OS host-side config. Corollary: exactly one default route at any moment.
+- **G2 — Provisioning connectivity.** During inspect + deploy the server can reach its image source and the Ironic conductor.
+- **G3 — Correct, minimal final state.** After provisioning: attached to exactly the tenant network segment(s), single default route, no residual provisioning network.
+- **G4 — Isolated until ready.** The tenant reaches the server only after it is fully provisioned and in its final network state; provisioning traffic is never exposed to the tenant.
+- **G5 — Achievable on stock metal3 + fabric manager today.**
+
+**Implementation Goals:**
 
 - Multi-NIC support with explicit physical interface mapping (tenant specifies interface name from HostType)
 - Resource-specific attachment message (`BareMetalNetworkAttachment`) with `interface` and `primary` fields
 - Optional `network_attachments` field — populate with tenant defaults when omitted
 - Auto ExternalIP attachment (`auto_external_ip_attachment`) for single-call inbound connectivity
-- bare-metal-fulfillment-operator `reconcileNetworking` phase: dispatcher calls `create_network_attachment` per interface to configure switch ports
-- IP discovery after provisioning: operator queries fabric manager's DHCP lease API via dispatcher (`query_dhcp_lease` role), matches port MAC to DHCP-assigned IP, writes to CR status, feedback controller syncs to fulfillment-service, ExternalIPAttachment controller reads primary IP for DNAT
+- bare-metal-fulfillment-operator `reconcileNetworking` phase: dispatcher moves each interface's fabric port onto the tenant subnet's network segment (provisioning network → tenant) via the generic `move_network_attachment` role
+- Provisioning network: an idle (unassigned) server keeps its fabric NIC on an OSAC-owned provisioning network (DHCP + gateway + SNAT) so it has internet during metal3 inspection; provisioning moves the port provisioning network → tenant, deletion moves it tenant → provisioning network (see [Provisioning Network and Port Moves](#provisioning-network-and-port-moves))
+- IP discovery after provisioning: operator queries fabric manager's DHCP lease API via dispatcher (`query_dhcp_lease` role), matches the port MAC (resolved from the BareMetalHost `osac.openshift.io/interface-macs` annotation) to the DHCP-assigned IP, writes to CR status, feedback controller syncs to fulfillment-service, ExternalIPAttachment controller reads primary IP for DNAT
 - HostType resource with structured NetworkInterface list (name, role, description)
 - Remove unused `networkClass` field from BareMetalInstance spec entirely (unused per reviewer feedback)
+
+### The Three Network Planes
+
+BMaaS involves three planes; this design owns only the data-plane ones. Do not conflate them.
+
+| Plane | Carries | OS sees it? | Fabric-managed? | Owned by |
+|-------|---------|-------------|-----------------|----------|
+| **BMC / OOB** | Redfish/IPMI: power, virtual-media | Depends on wiring (dedicated port: no; shared-LOM: yes, own VLAN) | Not for now (separate mgmt network) | metal3 (prerequisite) |
+| **Provisioning network** | host DHCP, image download, IPA→conductor callback | Yes (in-band, fabric NIC) | **Yes** | this design |
+| **Tenant network** | tenant workload | Yes (fabric NIC after handoff) | Yes | this design |
+
+"OOB" refers only to the BMC plane. The provisioning network is **in-band** (the OS/IPA uses it) — never call it OOB.
+
+**Note on terminology:** In the current code and configuration, the provisioning network is identified as `netris_bm_parking_vnet`. This identifier is retained for deployment stability; the docs-only rename to "provisioning network" clarifies its purpose without requiring immediate config changes.
+
+#### Connectivity Paths
+
+| Path | Network |
+|------|---------|
+| Ironic → BMC (power/virtual-media) | mgmt/BMC network; conductor routes to BMC IPs |
+| IPA → Ironic (callback) | provisioning network |
+| Image download | provisioning network → local mirror (or internet) |
+| Tenant DHCP + lease discovery | tenant network (fabric manager) |
+| Fabric-port network move | fabric manager |
+
+Ironic reaching two planes at once is ordinary **multi-homing**: the conductor host has a NIC/route to each network; it listens on all interfaces for inbound callbacks and the kernel selects egress NIC + source IP per destination. Which network carries the callback is set by the metal3 **`Provisioning` CR** (`provisioningNetwork`, `provisioningIP`/`provisioningInterface`, `virtualMediaViaExternalNetwork`), and each BMC address is per-host on the `BareMetalHost` (`spec.bmc.address`) — none of this is OSAC operator code.
 
 ### Non-Goals
 
 - CaaS or VMaaS networking (this EP covers BMaaS only)
 - Dispatcher infrastructure implementation (deferred to Unified Networking EP implementation)
-- Fabric manager implementation (Netris create/delete_network_attachment roles deferred to OSAC-2081)
+- Creating the provisioning network (network segment + DHCP + gateway + SNAT) and the initial per-server attach — a deployment prerequisite handled by the fabric infrastructure / deployment infrastructure, not the operator (see [Provisioning Network and Port Moves](#provisioning-network-and-port-moves))
+- Re-provision handoff reset: NetworkHandoffComplete is never reset after initial provisioning, so an in-place re-provision (config-version change after Ready) would run over the tenant network (deferred to long-term design)
 
 ## Proposal
 
@@ -201,6 +217,12 @@ Same as VMaaS/CaaS — the networking API is uniform.
      --external-ip-attachment --name my-server
    ```
 
+   After provisioning completes, `osac get baremetalinstance` shows the discovered internal IP:
+   ```
+   ID          NAME       CATALOG ITEM   STATE    INTERNAL IP
+   01a0...     my-server  ci-bm-default  RUNNING  10.100.0.2
+   ```
+
 5. **fulfillment-service:**
    - If `network_attachments` omitted: populates with tenant's default Subnet + default SecurityGroup (see [Default Networking PRD](/enhancements/OSAC-1433-default-networking)). The system selects the first interface with role `fabric` from the HostType as the default interface for the single attachment (matching PRD FR-5).
    - Validates:
@@ -212,7 +234,7 @@ Same as VMaaS/CaaS — the networking API is uniform.
      - If >1 attachment without `interface`, reject (explicit interface required when multi-homed)
      - Number of attachments ≤ number of available interfaces on template
      - If multiple attachments, exactly one is `primary`; if single attachment, `primary` is implicit
-   - If `auto_external_ip_attachment == true`: auto-selects ExternalIPPool (READY, most available capacity, matching IP family), creates ExternalIP (labeled `osac.openshift.io/auto-provisioned: "true"` and `osac.openshift.io/auto-provisioned-for: <baremetal-instance-id>`) + ExternalIPAttachment (labeled `osac.openshift.io/auto-provisioned: "true"`) in the same DB transaction — both start in **Pending** state. The ExternalIPAttachment references the BaremetalInstance but does not yet have a DNAT target IP (the BM's IP is unknown until `reconcileNetworking` runs). Pool capacity is decremented atomically; if the pool is exhausted, the API call fails and no resources are persisted (including the BaremetalInstance). See [Unified Networking — Auto-provisioning lifecycle](/enhancements/OSAC-1433-unified-networking/design.md#external-access-same-for-all-resource-types) for the shared two-phase flow.
+   - If `auto_external_ip_attachment == true`: auto-selects ExternalIPPool (READY, most available capacity, matching IP family), creates ExternalIP (labeled `osac.openshift.io/auto-created: "true"` and `osac.openshift.io/auto-created-for: <baremetal-instance-id>`) + ExternalIPAttachment (labeled `osac.openshift.io/auto-created: "true"`) in the same DB transaction — both start in **Pending** state. The ExternalIPAttachment references the BaremetalInstance but does not yet have a DNAT target IP (the BM's IP is unknown until `reconcileNetworking` runs). Pool capacity is decremented atomically; if the pool is exhausted, the API call fails and no resources are persisted (including the BaremetalInstance). See [Unified Networking — Auto-provisioning lifecycle](/enhancements/OSAC-1433-unified-networking/design.md#external-access-same-for-all-resource-types) for the shared two-phase flow.
    - Creates BaremetalInstance CR with `network_attachments` in spec
 
 6. **bare-metal-fulfillment-operator BareMetalInstance controller:**
@@ -221,20 +243,27 @@ Same as VMaaS/CaaS — the networking API is uniform.
       - FindFreeHost → AssignHost (Ironic/Metal3)
       - Populates HostClass from inventory
 
-   b. **`reconcileNetworking` (NEW — runs after inventory, before provisioning):**
-      - Reads `network_attachments` from the CR spec
-      - **Operator dispatches switch-side config:** For each attachment, dispatcher calls `osac.templates.{{ fabric_manager }}.create_network_attachment` passing `host_name` (Netris server name from ExternalHostID), `logical_interface_name` (interface name from HostType), `subnet_ref`. The fabric manager adds the server's port to the subnet's V-Net. The host will receive an IP from the fabric's DHCP server once it boots on the V-Net.
-      - Network attachments must be Ready before provisioning proceeds
-
-   c. `reconcileProvisioning` (runs after networking):
+   b. `reconcileProvisioning` (runs after inventory):
       - Triggers AAP job via `RunProvisioningLifecycle`
       - Template does OS provisioning (PXE boot, user-data, etc.)
-      - Host-side networking is handled by DHCP — the template does NOT configure static IPs, gateway, or DNS. The host receives its IP automatically when it boots on the V-Net.
+      - Server stays on the provisioning network during this phase
+      - Host-side networking is handled by DHCP — the template does NOT configure static IPs, gateway, or DNS. The host receives its IP automatically from the provisioning network DHCP server.
 
-   d. `reconcilePower` (unchanged)
+   c. **`reconcileNetworking` (runs after provisioning is complete):**
+      - Reads `network_attachments` from the CR spec
+      - **Operator dispatches switch-side config:** For each attachment, the operator dispatches the `osac-move-network-attachment` job, which resolves `subnetRef` → tenant network segment name and moves the server's fabric port **provisioning network → tenant network** via `osac.templates.{{ fabric_manager }}.move_network_attachment` (`host_name` = fabric server name from ExternalHostID, `logical_interface_name` = interface name from HostType, `from_vnet_name` = provisioning network, `to_vnet_name` = tenant network segment). See [Provisioning Network and Port Moves](#provisioning-network-and-port-moves).
+      - **Network segment readiness wait:** After each port attach, the move playbook polls the fabric manager until the target network segment reaches active/ready state. This ensures the switch fabric has fully converged before the operator triggers the handoff reboot — without this wait, the host may DHCP on the wrong network.
+      - Sets condition: `NetworkAttachmentsReady=True`
 
-7. **IP discovery and feedback (`reconcileIPDiscovery` — runs after provisioning):**
-   - After `reconcileProvisioning` completes and the host has received a DHCP lease, the operator queries the fabric manager's DHCP lease API via dispatcher (`osac.templates.{{ fabric_manager }}.query_dhcp_lease`). The role queries DHCP leases for the subnet and matches the server's port MAC address to find the corresponding DHCP-assigned IP.
+   d. **`reconcileReboot` (runs after networking):**
+      - Issues reboot via BareMetalHost annotation so the OS re-DHCPs on the tenant network
+      - Waits for reboot to complete
+      - Sets condition: `NetworkHandoffComplete=True`
+
+   e. `reconcilePower` (unchanged)
+
+7. **IP discovery and feedback (`reconcileIPDiscovery` — runs after reboot):**
+   - After `reconcileReboot` completes and the host has received a DHCP lease on the tenant network, the operator queries the fabric manager's DHCP lease API via dispatcher (`osac.templates.{{ fabric_manager }}.query_dhcp_lease`). The role queries DHCP leases for the tenant subnet and matches the server's port MAC address (resolved from the BareMetalHost `osac.openshift.io/interface-macs` annotation — see [IP Discovery](#ip-discovery)) to find the corresponding DHCP-assigned IP on the tenant network.
    - Operator writes the discovered IP to `status.networkAttachmentStatuses[].ipAddress` on the BaremetalInstance CR
    - Feedback controller watches CR status changes → fires Signal RPC to fulfillment-service
    - fulfillment-service reconciler syncs the discovered IP to the DB via existing `syncStatus()` pattern
@@ -266,12 +295,13 @@ Same as VMaaS/CaaS — the networking API is uniform.
 #### Deletion (reverse order)
 
 10. **Delete BaremetalInstance:**
-    - **Auto-provisioned cleanup (osac-operator):** The osac-operator adds a cleanup finalizer (`osac.openshift.io/baremetalinstance-cleanup`) on BaremetalInstance CRs that have `auto_external_ip_attachment=true`. On deletion, it performs the phased requeue cleanup: deletes ExternalIPAttachment first (by target reference), waits, then deletes ExternalIP (by `auto-provisioned-for` label), waits, then removes its finalizer. See [Unified Networking — Auto-provisioned resource cleanup](/enhancements/OSAC-1433-unified-networking/design.md#external-access-same-for-all-resource-types) for the pattern. This runs concurrently with the bare-metal-fulfillment-operator's deletion flow but does not conflict (different CRs).
+    - **Auto-provisioned cleanup (osac-operator):** The osac-operator adds a cleanup finalizer (`osac.openshift.io/baremetalinstance-cleanup`) on BaremetalInstance CRs that have `auto_external_ip_attachment=true`. On deletion, it performs the phased requeue cleanup: deletes ExternalIPAttachment first (by target reference), waits, then deletes ExternalIP (by `auto-created-for` label), waits, then removes its finalizer. See [Unified Networking — Auto-provisioned resource cleanup](/enhancements/OSAC-1433-unified-networking/design.md#external-access-same-for-all-resource-types) for the pattern. This runs concurrently with the bare-metal-fulfillment-operator's deletion flow but does not conflict (different CRs).
     - **Manually created resources are NOT cleaned up** — tenant manages their lifecycle.
     - **Default networking resources (VN, Subnet, SG, NATGateway) are NOT cleaned up** — tenant-scoped and shared.
-    - bare-metal-fulfillment-operator:
-      - `reconcileDeprovisioning`: triggers AAP delete job for OS teardown
-      - `reconcileNetworking` (delete): dispatcher calls `osac.templates.{{ fabric_manager }}.delete_network_attachment` per attachment (passing host_name, logical_interface_name, subnet_ref) to remove the server's port from the subnet's V-Net.
+    - bare-metal-fulfillment-operator (power-off-first ordering ensures tenant workloads **never** run on the provisioning network):
+      - `reconcileNetworkOffboardShutdown`: powers off the host **while the port is still on the tenant network**, tracked by `NetworkOffboardComplete` condition. If the host is already powered off, this is a no-op. This guarantees the tenant workload stops before the port moves to the provisioning network.
+      - `reconcileNetworking` (delete): dispatches the same `osac-move-network-attachment` job — because the CR now carries a `deletionTimestamp`, the playbook moves each port **tenant network → provisioning network** (`from_vnet_name` = tenant network segment, `to_vnet_name` = provisioning network), returning the fabric NIC to the provisioning network so the freed server keeps internet for its next inspection. The host is off at this point, so nothing runs on the provisioning network. A missing tenant Subnet CR is tolerated (detach skipped, port still returned to provisioning network).
+      - `reconcileDeprovisioning`: triggers AAP delete job for OS teardown. Ironic powers the host back on via BMC and PXE-boots a cleaning ramdisk on the provisioning network — not the tenant OS.
       - Removes management finalizer
     - `reconcileInventory` deletion: UnassignHost from Ironic/Metal3, removes inventory finalizer
     - osac-operator feedback controller: waits for other finalizers, removes feedback finalizer, fires final Signal
@@ -371,13 +401,145 @@ The `mutateBMI()` function in the fulfillment-service's BM reconciler currently 
 
 ### Implementation Details/Notes/Constraints
 
-#### The IP Address Feedback Question
+#### Provisioning Network and Port Moves
+
+Bare-metal servers configure host-side networking entirely via DHCP. An
+**unassigned** server (owned by no tenant) has no tenant network segment, so without
+intervention it has no default gateway and no internet — which breaks the Ironic
+Python Agent (IPA) during metal3 inspection/cleaning (it cannot download its
+rootfs). Hanging the default gateway off the management/BMC NIC is not an option:
+the host would then have two DHCP default routes (management + fabric) once a
+tenant subnet is attached, causing a default-gateway race.
+
+**Solution — a provisioning network.** A fabric manager **provisioning network
+segment** (DHCP + default gateway + SNAT for outbound internet) holds every
+server's **fabric NIC** while the server is idle and during provisioning, so an
+unassigned server always has internet via its fabric NIC. The provisioning
+network exists **only in the fabric manager** — it has no OSAC Subnet CR — and
+its name is a fabric-manager configuration value (`netris_bm_provisioning_vnet`,
+sourced from the `NETRIS_BM_PROVISIONING_VNET` environment variable, with
+backward-compatible fallback to `NETRIS_BM_PARKING_VNET`), not operator state.
+
+**Provision and deprovision are the same primitive: move a fabric port from one
+network segment to another.** The port lifecycle is:
+
+| Flow | Trigger | Move (from → to) | When |
+|------|---------|------------------|------|
+| Initial | Deployment bootstrap (deployment infrastructure) | — → provisioning network | Pre-deployment |
+| Provision | BMI `reconcileNetworking` (after ProvisionTemplateComplete) | provisioning network → tenant subnet's network segment | **POST-provisioning** |
+| Deprovision | BMI deletion (networking cleanup) | tenant subnet's network segment → provisioning network | Deletion |
+
+**Key difference from the previous design:** The port move now happens **AFTER
+provisioning is complete**, not before. The server is provisioned while on the
+provisioning network, then moved to the tenant network and rebooted so the OS
+re-DHCPs there. This achieves isolation-until-ready (G4): the tenant cannot reach
+the server during imaging/first-boot, and provisioning traffic (image
+pull/cloud-init) never traverses the tenant network.
+
+Creating the provisioning network (network segment + DHCP + gateway + SNAT) and
+performing the initial per-server attach are deployment prerequisites (handled by
+the fabric infrastructure / deployment infrastructure), not operator responsibilities. The
+provisioning network name configured for the fabric manager must match the one
+used at bootstrap.
+
+**Generic `move_network_attachment` role.** The fabric manager exposes a single
+generic primitive, keyed on plain network segment **names**:
+
+```
+move_network_attachment(host_name, logical_interface_name,
+                        from_vnet_name, to_vnet_name)
+    → detach the server's fabric port from from_vnet_name (if set),
+      then attach it to to_vnet_name (if set)
+```
+
+- The role resolves host → fabric server → fabric port, then detaches from the
+  source network segment and attaches to the target. Either side may be empty (a
+  pure attach or pure detach).
+- Detach is a **no-op when the port is not on the named segment** (robust to
+  retries and unexpected state); attach fails if the target segment or port
+  cannot be resolved.
+- It operates purely against the fabric manager — **no Subnet CR lookup inside
+  the role**. Callers resolve a `subnetRef` → tenant network segment name and
+  pass the provisioning network name from configuration.
+- The primitive is backend-/lifecycle-agnostic: callers decide what the segments
+  mean (tenant, provisioning, …), so CaaS can reuse it for its own
+  provisioning-network flow.
+
+**Single move playbook, direction from the CR.** One AAP job template
+(`osac-move-network-attachment`, playbook
+`playbook_osac_move_network_attachment.yml`) serves both provision and
+deprovision. It derives direction from the CR: a resource carrying
+`metadata.deletionTimestamp` is **offboarding** (tenant → provisioning network);
+otherwise it is **onboarding** (provisioning network → tenant). The tenant network
+segment is resolved per attachment from `subnetRef` (Subnet CR `metadata.name`
+== fabric network segment name); the provisioning network name comes from
+configuration. The
+bare-metal-fulfillment-operator therefore points **both** its networking-provision
+and networking-deprovision providers at the same `osac-move-network-attachment`
+template — no direction plumbing in the operator.
+
+#### Topology-Agnostic Operator (Transport is Environment Config)
+
+The operator owns **network segment membership + lifecycle orchestration only**,
+referenced by segment **name** (config/CR), never by physical transport:
+
+- moves the fabric port between provisioning and tenant network segments,
+- patches `spec.image`, reboots via the BMH annotation,
+- discovers the tenant lease (`query_dhcp_lease`, MAC match).
+
+The **transport** is environment config, not code:
+
+- image source = `BareMetalHost.spec.image.url` / template param (local mirror or internet via provisioning network),
+- callback/PXE/DHCP network = the metal3 `Provisioning` CR (`Managed`/`Unmanaged`/`Disabled` depending on deployment).
+
+The operator must never assume the provisioning network carries the
+image/callback (no egress checks, no SNAT logic).
+
+#### Assumptions
+
+- Single fabric NIC per server on the fabric (moves provisioning↔tenant).
+- BMC reachability (Ironic↔BMC) is a deployment prerequisite on a tenant-isolated
+  mgmt network; not fabric-managed for now.
+- The provisioning network (network segment + DHCP + gateway + egress) and the
+  initial per-server attach are deployment prerequisites (deployment infrastructure / inventory
+  tooling), as today.
+- Inventory tooling sets the `osac.openshift.io/interface-macs` annotation for
+  the tenant NIC.
+- **Self-contained images**: first boot needs no *tenant-side* internet
+  (first-boot egress happens on the provisioning network during boot #1). A
+  robust "cloud-init done" signal is a long-term item.
+
+#### Tenant Handoff Signaling
+
+The operator uses conditions and phase to signal tenant handoff readiness:
+
+- `NetworkAttachmentsReady` — the tenant port is attached to the tenant network
+  segment (set after the move + segment active wait).
+- `NetworkHandoffComplete` — the port has been moved and the server has been
+  rebooted; the OS is running on the tenant network.
+- `IPDiscoveryComplete` — the tenant-network DHCP IP is discovered and valid.
+  The orchestration function (`reconcileNetworkProvisionAndDiscovery`)
+  explicitly checks this condition after `reconcileIPDiscovery` returns —
+  if `IPDiscoveryComplete=False/TemplateFailed`, the phase is set to `Failed`
+  and the flow stops. Without this explicit check, the phase could briefly
+  reach `Ready` between IP discovery retry cycles.
+- `NetworkOffboardComplete` (deletion only) — the host has been powered off
+  while still on the tenant network, prior to the port moving back to the
+  provisioning network. Tracked by `reconcileNetworkOffboardShutdown`.
+- Phase `Ready` — fully provisioned + on the tenant network + IP known.
+
+**Gating rule:** the operator must not surface a tenant IP or report `Ready`
+until after move + segment active + reboot + discovery. The provisioning-network
+IP is never exposed to the tenant. External access is signaled separately by
+the `ExternalIPAttachment` (DNAT) and `NATGateway` (SNAT) CR statuses.
 
 #### IP Discovery
 
-IP discovery is decoupled from switch port configuration. The `create_network_attachment` role is switch-side only — it moves the server's port to the subnet's V-Net during `reconcileNetworking`, before the host boots. It does not query DHCP leases or return an IP address.
+IP discovery is decoupled from switch port configuration. The `move_network_attachment` role is switch-side only — it moves the server's fabric port onto the tenant subnet's network segment during `reconcileNetworking`, before the host boots. It does not query DHCP leases or return an IP address.
 
-After `reconcileProvisioning` completes and the host has received a DHCP lease from the fabric's DHCP server, the operator runs `reconcileIPDiscovery`. This phase dispatches `osac.templates.{{ fabric_manager }}.query_dhcp_lease`, passing the subnet reference and the server's port MAC address. The role queries the fabric manager's DHCP lease API for the subnet, matches the port MAC to find the corresponding DHCP-assigned IP, and returns it. The operator writes the discovered IP to `status.networkAttachmentStatuses[].ipAddress` on the BaremetalInstance CR.
+After `reconcileProvisioning` completes and the host has received a DHCP lease from the fabric's DHCP server, the operator runs `reconcileIPDiscovery`. This phase dispatches `osac.templates.{{ fabric_manager }}.query_dhcp_lease`, passing, per attachment, the subnet reference and the server's port MAC address. The role queries the fabric manager's DHCP lease API for the subnet, matches the port MAC to find the corresponding DHCP-assigned IP, and returns it. The operator writes the discovered IP to `status.networkAttachmentStatuses[].ipAddress` on the BaremetalInstance CR.
+
+**MAC resolution — the `osac.openshift.io/interface-macs` contract.** Bare-metal servers are not registered as named fabric servers, so their DHCP leases appear in the fabric manager's IPAM as MAC-only host entries (no server name). To match a lease, the operator must know each attachment's NIC MAC. Inventory tooling annotates each `BareMetalHost` with a JSON map of OSAC interface name → NIC MAC, e.g. `{"eth9":"52:54:00:16:04:83"}`, under the `osac.openshift.io/interface-macs` annotation. During `reconcileIPDiscovery` the operator reads this annotation, builds a `subnetRef → MAC` map, and passes it to the job as an extra var (`network_attachment_macs`). The `query_dhcp_lease` role matches the IPAM host by MAC (the fabric manager stores lease MACs lowercase; the role compares against the lowercased `mac[].address` values). When no MAC is supplied, the role falls back to matching by server name — the path named CaaS fabric servers use, which BMaaS is converging onto.
 
 The feedback controller syncs this to the fulfillment-service DB via the existing Signal / `syncStatus()` pattern. The ExternalIPAttachment controller reads the primary IP from CR status for DNAT creation.
 
@@ -391,28 +553,54 @@ The feedback controller syncs this to the fulfillment-service DB via the existin
 | osac-operator feedback controller | Signal fulfillment-service on status changes (unchanged), sync IP addresses from CR status to DB |
 | osac-operator BMI cleanup controller | Clean up auto-provisioned ExternalIPAttachment → ExternalIP on BaremetalInstance deletion (phased requeue, `baremetalinstance-cleanup` finalizer) |
 | osac-operator ExternalIPAttachment controller | Read BM's primary IP from CR status, create DNAT via fabric_manager |
-| fabric_manager role (create_network_attachment) | Switch-side only: resolve host → fabric server, add server port to subnet's V-Net (port attachment) |
-| fabric_manager role (query_dhcp_lease) | Query fabric manager's DHCP lease API for a subnet, match port MAC address to find the DHCP-assigned IP, return it |
-| fabric_manager role (delete_network_attachment) | Switch-side only: remove server port from V-Net |
+| fabric_manager role (move_network_attachment) | Switch-side only: resolve host → fabric server → fabric port, detach from the source network segment (if set) and attach to the target segment (if set). Waits for target segment active state after attach. Serves both provisioning → tenant (provision) and tenant → provisioning (deprovision) |
+| fabric_manager role (query_dhcp_lease) | Query fabric manager's DHCP lease API for a subnet, match the port MAC (or fall back to server name) to find the DHCP-assigned IP, return it |
 
 #### Reconciliation Phase Ordering
+
+**Target reconcile flow (provision-then-handoff):**
 
 ```
 bare-metal-fulfillment-operator BareMetalInstance controller phases:
 1. reconcileInventory → allocate host, populate HostClass
    Sets condition: InventoryAssigned=True
-2. reconcileNetworking → configure switch ports (dispatcher, switch-side only)
+
+2. reconcileProvisioning → OS provisioning (AAP). Server stays on the provisioning network.
+   Host PXE boots and gets IP from DHCP on the provisioning network.
    Requires: InventoryAssigned=True
-   Sets condition: NetworkingConfigured=True
-3. reconcileProvisioning → OS provisioning (AAP). Host PXE boots and gets IP from DHCP.
-   Requires: NetworkingConfigured=True
-   Sets condition: ProvisioningComplete=True
-4. reconcileIPDiscovery → query fabric manager's DHCP lease API via dispatcher
-   (query_dhcp_lease), match port MAC to assigned IP, write to CR status
-   Requires: ProvisioningComplete=True
+   Sets condition: ProvisionTemplateComplete=True
+
+3. reconcileNetworking → move fabric port provisioning network → tenant network
+   (dispatcher, switch-side only; waits for network segment active after attach)
+   Requires: ProvisionTemplateComplete=True
+   Sets condition: NetworkAttachmentsReady=True
+
+4. reconcileReboot → reboot server (BMH annotation) so OS re-DHCPs on tenant network
+   Requires: NetworkAttachmentsReady=True
+   Sets condition: NetworkHandoffComplete=True
+
+5. reconcileIPDiscovery → query fabric manager's DHCP lease API via dispatcher
+   (query_dhcp_lease), match port MAC to assigned IP on tenant network, write to CR status
+   Requires: NetworkHandoffComplete=True
    Sets condition: IPDiscoveryComplete=True
-5. reconcilePower → power state management
+
+6. Phase Ready → fully provisioned + on tenant network + IP known
+   Requires: IPDiscoveryComplete=True
+
+7. reconcilePower → power state management (independent)
+
+Deletion (power-off-first — tenant workloads never touch provisioning network):
+1. reconcileNetworkOffboardShutdown → power off while port is still on tenant network
+   Sets condition: NetworkOffboardComplete=True
+2. reconcileNetworking (delete) → move port tenant network → provisioning network
+   Host is off — nothing runs on provisioning network
+3. reconcileDeprovisioning → Ironic PXE boots cleaning ramdisk (not tenant OS)
+4. reconcileInventory (delete) → unassign host
 ```
+
+The server sits on the **provisioning network** (config identifier `netris_bm_provisioning_vnet`, with DHCP + gateway + egress) from bootstrap through the entire metal3 deploy and first boot. First-boot cloud-init runs there **with egress**, so first-boot pulls succeed. Only after `ProvisionTemplateComplete` does the operator move the fabric port to the tenant network (waiting for the network segment to reach active state) and issue **one reboot** so the OS re-DHCPs on the tenant network.
+
+**Known behavior (Netris-specific) — DHCP cross-VLAN lease persistence:** The Netris softgate DHCP server is not VLAN-scoped — it serves all V-Nets through the softgate. When the OS reboots after a port move, NetworkManager may attempt a DHCP REQUEST renewal for the old (provisioning) IP. The softgate can ACK this renewal even though the port is on the tenant VLAN, resulting in the host keeping the provisioning IP. The network segment readiness wait mitigates this by ensuring the fabric has fully converged, but in some timing scenarios a second reboot (or DHCP release before reboot) may be needed. This is a known limitation of the Netris DHCP architecture; other fabric managers with VLAN-scoped DHCP would not exhibit this behavior.
 
 ### Security Considerations
 
@@ -449,7 +637,7 @@ The bare-metal-fulfillment-operator needs additional RBAC permissions: get/list/
 All new resources (BaremetalInstance with new fields, auto-provisioned ExternalIP/ExternalIPAttachment) inherit tenant isolation from parent:
 - `osac.openshift.io/tenant` annotation propagated from BaremetalInstance to auto-created resources
 - OPA policies enforce tenant-scoped list/get/update/delete
-- Tenant User can view and manage auto-provisioned resources (labeled `osac.openshift.io/auto-provisioned: "true"`) via standard API
+- Tenant User can view and manage auto-provisioned resources (labeled `osac.openshift.io/auto-created: "true"`) via standard API
 
 ### Observability and Monitoring
 
@@ -468,7 +656,7 @@ No new metrics or alerts (existing provisioning duration and failure rate metric
 
 #### Risk: fabric_manager implementation blocked or delayed
 
-**Impact:** Fabric manager `create_network_attachment` and `delete_network_attachment` roles are prerequisites for BMaaS networking. Without them, switch port configuration cannot function. (IP allocation is operator-managed and does not depend on fabric manager roles.)
+**Impact:** The fabric manager `move_network_attachment` role and a provisioned provisioning network segment are prerequisites for BMaaS networking. Without them, switch port configuration cannot function.
 
 **Mitigation:** Prioritize Netris BM roles (OSAC-2081). Accept that BMaaS remains unavailable until a fabric_manager exists. Document as a hard dependency.
 
@@ -524,11 +712,11 @@ Resolved: Return error, no resource persisted. Pool capacity checked synchronous
 
 ### ~~3. IP address assignment~~ — Resolved
 
-Resolved: DHCP handles IP assignment. The host receives its IP from the fabric's DHCP server after booting on the V-Net. No operator IPAM needed.
+Resolved: DHCP handles IP assignment. The host receives its IP from the fabric's DHCP server after booting on the network segment. No operator IPAM needed.
 
 ### ~~4. How is the host's runtime IP discovered after network reconfiguration?~~ — Resolved
 
-Resolved: After `reconcileProvisioning` completes and the host has received a DHCP lease, the operator queries the fabric manager's DHCP lease API via dispatcher (`query_dhcp_lease` role). The role queries DHCP leases for the subnet and matches the server's port MAC address to find the assigned IP. The operator writes to `status.networkAttachmentStatuses[].ipAddress` on the BaremetalInstance CR. The feedback controller then syncs to fulfillment-service via Signal RPC. `create_network_attachment` remains switch-side only (port attachment to V-Net).
+Resolved: After `reconcileProvisioning` completes and the host has received a DHCP lease, the operator queries the fabric manager's DHCP lease API via dispatcher (`query_dhcp_lease` role). The role matches the server's port MAC address — resolved from the BareMetalHost `osac.openshift.io/interface-macs` annotation — to find the assigned IP (falling back to server-name matching for named fabric servers). The operator writes to `status.networkAttachmentStatuses[].ipAddress` on the BaremetalInstance CR. The feedback controller then syncs to fulfillment-service via Signal RPC. `move_network_attachment` remains switch-side only (moves the fabric port between network segments).
 
 ## Test Plan
 
@@ -538,7 +726,8 @@ Resolved: After `reconcileProvisioning` completes and the host has received a DH
 - fulfillment-service: interface validation (reject interface not in BareMetalInstanceType, reject duplicate interfaces, reject >1 attachment without interface)
 - fulfillment-service: auto ExternalIP pool selection (pick READY pool with most capacity, respect IP family)
 - bare-metal-fulfillment-operator: reconcileNetworking phase ordering (after inventory, before provisioning)
-- bare-metal-fulfillment-operator: dispatcher call per attachment (create_network_attachment with correct params)
+- bare-metal-fulfillment-operator: dispatcher call per attachment (move_network_attachment with correct from/to network segment params, direction from deletionTimestamp)
+- bare-metal-fulfillment-operator: `buildSubnetMACMap` resolves subnetRef → MAC from the interface-macs annotation (single-NIC fallback when interface unset)
 
 ### Integration Tests
 
@@ -547,7 +736,9 @@ Resolved: After `reconcileProvisioning` completes and the host has received a DH
 - E2E: delete BaremetalInstance with auto-provisioned resources, verify ExternalIPAttachment and ExternalIP cleaned up
 - E2E: create BaremetalInstance with interface not in BareMetalInstanceType, verify error returned
 - E2E: create BaremetalInstance with >1 attachment but no interface fields, verify error returned
-- E2E: verify IP discovery (`query_dhcp_lease` role queries fabric manager DHCP lease API after provisioning, matches port MAC to assigned IP, operator writes to CR status, feedback controller syncs to fulfillment-service, ExternalIPAttachment controller reads primary IP)
+- E2E: verify IP discovery (`query_dhcp_lease` role queries fabric manager DHCP lease API after provisioning + reboot, matches port MAC to assigned IP on tenant network, operator writes to CR status, feedback controller syncs to fulfillment-service, ExternalIPAttachment controller reads primary IP)
+- E2E: verify the port move and reboot flow — create BMI provisions on the provisioning network, then moves the fabric port provisioning network → tenant network + reboots; delete BMI returns it tenant → provisioning network (confirm in fabric manager; a freed server can re-inspect with internet)
+- E2E: verify isolation-until-ready — before the move, a tenant vantage cannot reach the server; after move + reboot, it can, and the server is no longer on the provisioning network
 
 ### Tricky Test Cases
 
@@ -555,6 +746,28 @@ Resolved: After `reconcileProvisioning` completes and the host has received a DH
 - ExternalIPPool exhaustion (verify error returned, no resource created)
 - Auto-provisioned resource cleanup failure (verify finalizer retry, eventual orphan cleanup)
 - IP address feedback latency (verify ExternalIPAttachment controller waits for IP to appear in status)
+
+## Long-Term Evolution (The Reboot is the Seam)
+
+The structure `inventory → provision → establish-tenant-networking → discovery`
+stays; only "establish-tenant-networking" changes:
+
+**Ironic Standalone Networking** (metal3-docs PR #586; BMO PR #3469, ToR
+networking part 1): Ironic switches the port VLAN per lifecycle phase
+(provisioning→tenant) on one NIC — drop the reboot. Upstream assumes
+`networking-generic-switch` (direct ToR control), which does not fit
+The fabric manager owns the switch; adopting a new backend means implementing the fabric manager interface or aligning the model.
+
+**Dedicated always-on provisioning NIC** (two NICs): attach the tenant NIC after
+`provisioned`; no move of the provisioning NIC. Needs 2 NICs, a local registry,
+gateway-less provisioning DHCP, and provisioning-network isolation.
+
+**Static host-side networking + IPAM** (`networkData`): one boot, but not
+OS-agnostic and reintroduces IPAM. Opt-in fast path for capable, self-contained
+images.
+
+Each evolution replaces just the reboot step while preserving the same overall
+flow and operator structure.
 
 ## Graduation Criteria
 
@@ -565,12 +778,14 @@ Proposed maturity level: **Tech Preview** → **GA**
 Tech Preview criteria:
 - [ ] API fields (`network_attachments`, `auto_external_ip_attachment`) implemented in fulfillment-service
 - [ ] BaremetalInstance CRD updated with `NetworkAttachments` field, CEL validation, and status field for IP addresses
-- [ ] bare-metal-fulfillment-operator `reconcileNetworking` phase implemented
-- [ ] Dispatcher integration for `create_network_attachment` and `delete_network_attachment`
+- [ ] bare-metal-fulfillment-operator `reconcileNetworking` phase implemented (provision-then-handoff flow)
+- [ ] bare-metal-fulfillment-operator `reconcileReboot` phase implemented (BMH annotation-based reboot after port move)
+- [ ] Dispatcher integration for `move_network_attachment` (provision + deprovision via one job template); provisioning network provisioned and initial per-server attach done at deployment
 - [ ] BareMetalInstanceType with network ports (`BareMetalNetworkPortSpec`) available and tested
 - [ ] Auto ExternalIP attachment provisioning functional
-- [ ] IP discovery implemented (`query_dhcp_lease` role queries fabric manager DHCP lease API after provisioning, matches port MAC to assigned IP, operator writes to CR status, feedback syncs to fulfillment-service)
-- [ ] Integration tests pass (E2E coverage for multi-NIC, auto ExternalIP, IP feedback)
+- [ ] IP discovery implemented (`query_dhcp_lease` role queries fabric manager DHCP lease API after provisioning + reboot, matches port MAC to assigned IP on tenant network, operator writes to CR status, feedback syncs to fulfillment-service)
+- [ ] Tenant handoff signaling (NetworkAttachmentsReady, NetworkHandoffComplete, IPDiscoveryComplete, Ready) implemented
+- [ ] Integration tests pass (E2E coverage for multi-NIC, auto ExternalIP, IP feedback, isolation-until-ready)
 - [ ] Documentation: API reference, user guide for simplified BM creation
 
 GA criteria:
@@ -579,6 +794,7 @@ GA criteria:
 - [ ] NATGateway full stack (OSAC-1443) implemented and stable
 - [ ] Production deployment verified (MOC or other OSAC deployment)
 - [ ] User feedback incorporated (usability, error messages, edge cases)
+- [ ] Reboot-based short-term validated; evolution path to Ironic Standalone Networking or dedicated provisioning NIC confirmed
 
 ## Upgrade / Downgrade Strategy
 
@@ -603,7 +819,7 @@ If `N+1` upgrade fails or cluster is misbehaving:
 Acceptable downgrade steps:
 - Delete CRs using new field (`network_attachments`)
 - Re-create without networking fields
-- Manually delete orphaned auto-provisioned resources (ExternalIP, ExternalIPAttachment labeled `osac.openshift.io/auto-provisioned: "true"`)
+- Manually delete orphaned auto-provisioned resources (ExternalIP, ExternalIPAttachment labeled `osac.openshift.io/auto-created: "true"`)
 
 ## Version Skew Strategy
 
@@ -637,7 +853,7 @@ kubectl describe baremetalinstance <name> -n <namespace>
 
 **Resolution:**
 1. Check bare-metal-fulfillment-operator logs for networking phase errors (dispatcher)
-2. Check AAP job logs for `create_network_attachment` role errors (switch-side)
+2. Check AAP job logs for `move_network_attachment` role errors (switch-side) — e.g. port not found on the server, or the provisioning/tenant network segment not resolvable
 3. If fabric manager unreachable, investigate connectivity
 4. If switch port config failed, investigate switch configuration
 
@@ -654,7 +870,7 @@ kubectl describe baremetalinstance <name> -n <namespace>
 
 ### Symptom: Auto-provisioned ExternalIP not cleaned up after BaremetalInstance deletion
 
-**Detection:** `kubectl get externalip` shows orphaned ExternalIP labeled `osac.openshift.io/auto-provisioned: "true"` with no parent
+**Detection:** `kubectl get externalip` shows orphaned ExternalIP labeled `osac.openshift.io/auto-created: "true"` with no parent
 
 **Cause:** Finalizer cleanup failed permanently
 
@@ -672,7 +888,7 @@ kubectl describe baremetalinstance <name> -n <namespace>
 **Resolution:**
 1. Check BaremetalInstance status: `kubectl get baremetalinstance <name> -n <namespace> -o jsonpath='{.status.networkAttachmentStatuses[?(@.primary==true)].ipAddress}'`
 2. If IP is missing, check bare-metal-fulfillment-operator logs for provisioning phase completion
-3. If provisioning completed but IP missing, investigate `query_dhcp_lease` dispatcher call (DHCP lease query may have failed, returned empty, or port MAC did not match any lease)
+3. If provisioning completed but IP missing, investigate `query_dhcp_lease` dispatcher call (DHCP lease query may have failed, returned empty, or port MAC did not match any lease). Confirm the BareMetalHost carries the `osac.openshift.io/interface-macs` annotation with the attachment's interface — without it, MAC matching is skipped and only named fabric servers resolve
 
 ### Disabling the feature
 
@@ -687,9 +903,10 @@ Consequences:
 
 ## Infrastructure Needed
 
-- AAP execution environment with fabric manager role (`create_network_attachment`, `delete_network_attachment`) for Netris (OSAC-2081)
+- AAP execution environment with the fabric manager `move_network_attachment` role
+- A provisioned provisioning network segment (DHCP + gateway + SNAT, config identifier `netris_bm_provisioning_vnet`) and the initial per-server attach, plus the BareMetalHost `osac.openshift.io/interface-macs` annotation — deployment prerequisites (deployment infrastructure)
 - Dispatcher core (OSAC-1457, OSAC-1458, OSAC-1460)
-- Integration test environment with Netris fabric manager and Ironic/Metal3 backend
+- Integration test environment with fabric manager and Ironic/Metal3 backend
 
 ## Dependencies
 
@@ -703,12 +920,15 @@ Consequences:
 | Primary field on BareMetalNetworkAttachment | OSAC-2042 | New |
 | Immutability + interface + primary validation | OSAC-1509 | New |
 | CLI --network-attachment for BareMetalInstance | OSAC-2075 | New |
-| BM provisioning flow (operator reconcileNetworking calls create_network_attachment) | OSAC-2047 | New |
+| BM provisioning flow (operator reconcileNetworking dispatches move_network_attachment after provisioning, provisioning network → tenant) | OSAC-2047 | New |
+| BM reboot flow (reconcileReboot issues BMH annotation-based reboot after port move) | Not tracked | **GAP** |
 | Integration test | OSAC-1510 | New |
-| Fabric manager create/delete_network_attachment role | OSAC-2081 (Netris BM) | New |
+| Fabric manager `move_network_attachment` role (generic port move) | OSAC-2081 (Netris BM) | New |
+| Provisioning network segment (DHCP + gateway + SNAT, config identifier `netris_bm_provisioning_vnet`) + initial per-server attach in setup-bmaas | osac-deployment infrastructure | New |
+| BareMetalHost `osac.openshift.io/interface-macs` annotation (inventory tooling) | osac-deployment infrastructure | New |
 | BareMetalInstance CRD: add NetworkAttachments | Not tracked | **GAP** |
 | mutateBMI: copy network_attachments to K8s CR | Not tracked | **GAP** |
-| IP discovery: `query_dhcp_lease` role queries fabric manager DHCP lease API after provisioning, matches port MAC to assigned IP, operator writes to CR status | Not tracked | **GAP** |
+| IP discovery: `query_dhcp_lease` role matches port MAC (from interface-macs annotation) to lease, operator writes to CR status | Not tracked | **GAP** |
 | bare-metal-fulfillment-operator dispatcher capability + RBAC for Subnet/NetworkClass CRs | Not tracked | **GAP** |
 | Remove unused BareMetalInstance spec.networkClass field | Not tracked | **GAP** |
 | BareMetalInstanceType: network ports (BareMetalNetworkPortSpec) with name, role, type, speed, description | Not tracked | **GAP** |

--- a/enhancements/OSAC-1437-bmaas-networking/design.md
+++ b/enhancements/OSAC-1437-bmaas-networking/design.md
@@ -309,6 +309,30 @@ Same as VMaaS/CaaS — the networking API is uniform.
 11. **Tenant deletes networking resources** (independently):
     - Delete ExternalIPAttachments, ExternalIPs, SecurityGroup, Subnet, VirtualNetwork — each via its own dispatcher-triggered delete job
 
+**BMaaS-specific deletion dependency guard:**
+
+The Subnet controller gates its deprovision job on the complete removal
+of all BareMetalInstance CRs with `spec.networkAttachments[].subnetRef`
+referencing the subnet. This prevents the infrastructure backend from
+rejecting the subnet deletion because bare-metal servers are still
+attached to it. The guard lists BMI CRs in the namespace and filters by
+`subnetRef` in-memory, requeuing every 10 seconds until all BMIs are gone.
+See [Unified Networking — Deletion Dependency Guards](/enhancements/OSAC-1433-unified-networking/design.md#deletion-dependency-guards)
+for the full guard table covering all networking resources.
+
+**IP discovery lease validation:**
+
+The IP discovery phase (`reconcileIPDiscovery`) requires that all network
+attachments have a valid DHCP lease before marking `IPDiscoveryComplete=True`.
+If the AAP `query_dhcp_lease` job returns no artifacts, or returns leases
+that do not cover all attachments, the operator treats this as a failure
+and backs off with exponential retry. A BareMetalInstance cannot reach
+`Ready` phase (and therefore `RUNNING` state) without all attachment IPs
+discovered. This prevents the scenario where a DHCP lease is not yet
+available (e.g., the fabric manager's DHCP server has not propagated the
+lease to the new network segment) and the BMI appears as RUNNING with
+no internal IP.
+
 ### API Extensions
 
 #### Proto (fulfillment-service)


### PR DESCRIPTION
## Summary

Aligns all 4 networking designs with the implemented and lab-validated BMaaS networking architecture. Covers [OSAC-1437](https://redhat.atlassian.net/browse/OSAC-1437) (BMaaS), [OSAC-1436](https://redhat.atlassian.net/browse/OSAC-1436) (CaaS), [OSAC-1433](https://redhat.atlassian.net/browse/OSAC-1433) (unified + default), and [OSAC-1435](https://redhat.atlassian.net/browse/OSAC-1435) (VMaaS).

## Changes

### BMaaS Networking ([OSAC-1437](https://redhat.atlassian.net/browse/OSAC-1437))
- **Provision-then-handoff flow**: provision on provisioning network → wait for fabric network segment readiness → handoff reboot → IP discovery → Ready
- **Power-off-first deletion**: stop tenant workloads while still on tenant network → move port to provisioning → Ironic cleaning ramdisk
- **Conditions**: `NetworkHandoffComplete`, `NetworkOffboardComplete`, `IPDiscoveryComplete` with explicit gating (phase never reaches Ready on failed discovery)
- **Auto ExternalIP** provisioning for BMI (`auto-eip-<id>` naming, notification to controller, DB referential integrity guards)
- **CLI**: `osac get baremetalinstance` shows `INTERNAL IP` column
- **DHCP cross-VLAN lease persistence**: documented as known fabric-manager-specific behavior

### Cross-Design Consistency
- **Genericized terminology**: V-Net → network segment, parking → provisioning, Netris → fabric manager (in generic prose; kept in implementation-specific sections)
- **Label names**: `osac.openshift.io/auto-created` / `auto-created-for` (not `auto-provisioned`)
- **Config var**: `netris_bm_provisioning_vnet` as primary (backward compat with `NETRIS_BM_PARKING_VNET`)
- **Default networking**: NATGateway included at tenant onboarding (gated on `enable_nat_gateway`)
- **Target state only**: removed "What Already Works", "What's Missing", "Why the Current Approach is Insufficient", "(NEW)" markers
- **Lab content removed**: lab validation, connectivity matrix, lab shortcuts moved to test-infra

### Other Changes
- [OSAC-3210](https://redhat.atlassian.net/browse/OSAC-3210): BM-only deployment does not require k8s manager
- [OSAC-1425](https://redhat.atlassian.net/browse/OSAC-1425): Networking UI VMaaS scope design added
- Removed superseded UI designs and metering networking PRD

## Test Plan
- [x] Lab-validated on RDU se-lab (BMI create with networking, handoff reboot, IP discovery, deletion flow)
- [x] Cross-design review for terminology and flow consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)