### PR TITLE
NO-ISSUE: fix ep-review CI to clone skills from osac-ai-skills

### DIFF
--- a/.github/scripts/ep_review.py
+++ b/.github/scripts/ep_review.py
@@ -194,8 +194,11 @@ def main():
         work_dir = Path(f"workdir-{skill_name}")
         if work_dir.exists():
             shutil.rmtree(work_dir)
+        # Tolerate cross-repo symlinks whose targets are absent in CI rather
+        # than aborting the whole copy.
         shutil.copytree(SKILLS_PATH, work_dir,
-                        ignore=shutil.ignore_patterns('.git'))
+                        ignore=shutil.ignore_patterns('.git'),
+                        ignore_dangling_symlinks=True)
         exclude_own_slug_from_reference_library(work_dir, files)
 
         print(f"\nRunning {skill_name}...")

--- a/.github/workflows/ep-review.yml
+++ b/.github/workflows/ep-review.yml
@@ -98,8 +98,31 @@ jobs:
       - name: Install dependencies
         run: pip install -r .github/scripts/requirements.txt
 
-      - name: Clone workspace
-        run: git clone --depth 1 https://github.com/osac-project/osac-workspace /opt/skills
+      - name: Clone skills
+        run: |
+          git clone --depth 1 https://github.com/osac-project/osac-ai-skills /opt/skills
+          for s in prd-review design-review; do
+            if [[ ! -f "/opt/skills/skills/$s/SKILL.md" ]]; then
+              echo "::error::skills/$s/SKILL.md missing from osac-ai-skills"
+              exit 1
+            fi
+          done
+
+      - name: Stage reference docs for skill lookups
+        # Optional grounding the skills read if present; these live in
+        # osac/docs, not the skills repo. Best-effort: a missing doc must
+        # not fail the review.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p /opt/skills/reference
+          for f in ARCHITECTURE CONVENTIONS; do
+            if ! gh api "repos/osac-project/osac/contents/docs/${f}.md" \
+                 --jq '.content' | base64 -d > "/opt/skills/reference/${f}.md"; then
+              echo "::warning::optional reference doc ${f}.md unavailable, continuing"
+              rm -f "/opt/skills/reference/${f}.md"
+            fi
+          done
 
       - name: Stage enhancement-proposals content for skill lookups
         # Reuses the repo already checked out by the first step above (at


### PR DESCRIPTION
## Problem

The EP-review job fails on every PR at the "Clone workspace" / copy step:

```
shutil.Error: [('/opt/skills/reference/ARCHITECTURE.md', ..., "No such file or directory"),
               ('/opt/skills/reference/CONVENTIONS.md', ..., "No such file or directory")]
```

The review skills moved from `osac-workspace` to `osac-ai-skills`, and the shared reference docs moved to `osac/docs`. The workflow still cloned `osac-workspace`, which now has no skills and only dangling `reference/*.md` symlinks. `shutil.copytree` dereferences those symlinks and aborts before any review runs.

## Fix

- Clone `osac-ai-skills` (skills resolve at the paths `ep_review.py` expects).
- Stage `reference/{ARCHITECTURE,CONVENTIONS}.md` from `osac/docs`.
- Pass `ignore_dangling_symlinks=True` to `copytree` so a stray symlink can't abort the copy again.

## Verification

Simulated the full CI staging locally: clone + reference staging + enhancement-proposals staging + `copytree` + own-slug exclusion all succeed, and `SKILL.md` + reference docs land at the expected paths. The AI-review call itself needs CI Vertex secrets, so it only runs in CI.

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skills directory copying so missing symbolic-link targets no longer interrupt the review workflow.

* **Improvements**
  * Updated the review workflow to use the skills repository and verify required review capabilities are available.
  * Added architecture and conventions reference documents to support more informed reviews.
  * Missing reference documents now produce warnings without stopping the review process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->