### PR TITLE
OSAC-2907: stop truncating EP review criterion notes at 500 chars

### DIFF
--- a/.github/scripts/ep_hooks.py
+++ b/.github/scripts/ep_hooks.py
@@ -283,7 +283,7 @@ class EPHooks:
         for key in scores:
             label = display_labels.get(key, key.capitalize())
             note = self._sanitize_text(
-                notes.get(key, "")
+                notes.get(key, ""), 1000
             ).replace("|", "\\|").replace("\n", " ")
             lines.append(f"| {label} | {scores[key]}/2 | {note} |")
 

--- a/.github/scripts/test_ep_hooks.py
+++ b/.github/scripts/test_ep_hooks.py
@@ -1,7 +1,9 @@
 import json
 import os
+import subprocess
 import tempfile
 import unittest
+from unittest import mock
 
 from ep_hooks import (
     DESIGN_DISPLAY,
@@ -317,6 +319,64 @@ class DesignPromptThresholdTests(unittest.TestCase):
     def test_prompt_pass_threshold(self):
         self.assertIn("total >= 5", self.prompt)
         self.assertIn("no zeros", self.prompt)
+
+
+class CriterionNoteTruncationTests(unittest.TestCase):
+    """Criterion notes in the PR comment must not be cut off at 500 chars (OSAC-2907)."""
+
+    def setUp(self):
+        self.hooks = EPHooks(repo="test/repo", skills_path="/tmp", shadow=False)
+
+    def _render_comment(self, note_text):
+        verdict = {
+            "verdict": "pass",
+            "scores": {
+                "feasibility": 2, "testability": 2,
+                "scope": 2, "architecture": 2,
+            },
+            "total": 8,
+            "criterionNotes": {
+                "feasibility": note_text, "testability": "",
+                "scope": "", "architecture": "",
+            },
+            "summary": "",
+            "feedback": "",
+            "findings": {"critical": [], "important": [], "suggestions": []},
+        }
+        captured = {}
+
+        def fake_run(cmd, capture_output=True, text=True, timeout=120):
+            if "comment" in cmd and "--body-file" in cmd:
+                body_file = cmd[cmd.index("--body-file") + 1]
+                with open(body_file) as f:
+                    captured["body"] = f.read()
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with mock.patch("ep_hooks.subprocess.run", side_effect=fake_run):
+            self.hooks.apply_labels(
+                "EP-1", verdict, "resolve", "/tmp",
+                ticket={"headRefOid": "abc12345"},
+            )
+        return captured["body"]
+
+    def test_criterion_note_over_500_chars_not_truncated(self):
+        long_note = "x" * 700
+        body = self._render_comment(long_note)
+        self.assertIn(long_note, body)
+
+    def test_criterion_note_still_bounded_at_1000(self):
+        long_note = "x" * 5000
+        body = self._render_comment(long_note)
+        self.assertIn("x" * 1000, body)
+        self.assertNotIn("x" * 1001, body)
+
+    def test_sanitize_text_default_limit_unchanged(self):
+        """Unrelated _sanitize_text call sites (e.g. findings items) keep the 500 default."""
+        self.assertEqual(len(self.hooks._sanitize_text("x" * 600)), 500)
+
+
+if __name__ == "__main__":
+    unittest.main()
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_ep_hooks.py
+++ b/.github/scripts/test_ep_hooks.py
@@ -377,7 +377,3 @@ class CriterionNoteTruncationTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
## Summary
- EP review criterion notes in the PR review comment's Notes column were cut off mid-word because `_sanitize_text()` fell back to its 500-char default at that call site.
- Pass an explicit `1000` limit at the criterion-notes call site only (`.github/scripts/ep_hooks.py`), matching the existing precedent already used by the `feedback` field on the same code path. The global default (500) and other call sites (e.g. findings items) are unchanged.

## Jira
https://redhat.atlassian.net/browse/OSAC-2907

## Test plan
- [x] Added `CriterionNoteTruncationTests` in `.github/scripts/test_ep_hooks.py`, verifying a 700-char note is no longer truncated and a 5000-char note is still bounded at 1000, and that the unrelated `_sanitize_text` default stays 500.
- [x] Verified regression: reverted just the fix and confirmed the new tests fail against the old 500-char behavior.
- [x] `python3 -m pytest test_ep_hooks.py` — 32/32 passed.

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.1.3). Review for accuracy_