### PR TITLE
Add PRD for OSAC-4277: VM Resize via InstanceType Selection

### DIFF
--- a/enhancements/OSAC-4277-vm-resize-instancetype/prd.md
+++ b/enhancements/OSAC-4277-vm-resize-instancetype/prd.md
@@ -53,21 +53,17 @@ running. [Jira: OSAC-4277]
 
 - As a Tenant User, I want to change a running VM's InstanceType via API so
   that I can scale CPU and memory up or down without recreating the VM.
-- As a Tenant User, I want to know whether an InstanceType change will
-  require restarting my VM before I request it, so that I can plan for the
-  downtime. To be determined — whether the Tenant User must initiate that
-  restart themselves or OSAC restarts the VM automatically. [Clarify: R1.Q2]
+- As a Tenant User, I want to know from OSAC's deployment documentation
+  whether InstanceType changes require a VM restart in my environment, so
+  that I can plan for the downtime before requesting a resize. Whether a
+  restart is required is a property of the OSAC deployment — in most
+  deployments no restart is required. Where a restart is required, the
+  Tenant User is responsible for restarting their own VM; OSAC does not
+  restart it automatically.
 - As a Tenant User, I want a request for an InstanceType that's invalid or
   incompatible with my ComputeInstance to be rejected immediately when
   possible, so that I don't wait for a change that can't succeed. [Clarify:
   R1.Q5]
-
-## Assumptions
-
-- Whether an InstanceType change is eligible for hot-plug or requires a
-  restart is assumed to be a predictable, cluster-level capability that a
-  Tenant User can know ahead of time — not an outcome that varies
-  unpredictably per individual request. [Clarify: R1.Q2]
 
 ## Dependencies
 
@@ -81,6 +77,6 @@ running. [Jira: OSAC-4277]
 ## Provenance
 
 Authored: respond @ prd 0.8.0 - 7efcedb, workspace main @ 6e8f396
-Phases: draft, respond
+Phases: draft, respond, respond
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"6e8f396","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","respond"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"6e8f396","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","respond","respond"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-4277-vm-resize-instancetype/prd.md
+++ b/enhancements/OSAC-4277-vm-resize-instancetype/prd.md
@@ -22,8 +22,10 @@ OSAC-4277]
 
 - InstanceType changes apply to VMaaS ComputeInstances — this does not
   cover BMaaS or CaaS resource resizing.
-- Both increasing and decreasing to a different InstanceType are supported.
-  [Clarify: R1.Q1]
+- Both increasing and decreasing to a different InstanceType are supported —
+  a target InstanceType is valid regardless of whether it moves CPU and
+  memory in the same direction (e.g., increasing CPU while decreasing memory
+  is supported the same as any other target). [Clarify: R1.Q1]
 - A resize target's eligibility follows the same InstanceType lifecycle-state
   rules as VM creation (see OSAC-46): an `ACTIVE` or `DEPRECATED` target is a
   valid resize target (`DEPRECATED` succeeds with a warning), and an
@@ -78,7 +80,9 @@ does not restart it automatically.
 
 ## Provenance
 
-Authored: respond @ prd 0.8.0 - 7efcedb, workspace main @ 6e8f396
-Phases: draft, respond, respond, respond, respond
+Authored: draft @ prd 0.8.0 - 7efcedb, workspace main @ 6e8f396
+Final: respond @ prd 0.8.0 - 7efcedb, workspace main @ 505e141
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"6e8f396","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","respond","respond","respond","respond"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+> Context changed between draft and respond.
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"505e141","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","respond","respond","respond","respond","respond"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-4277-vm-resize-instancetype/prd.md
+++ b/enhancements/OSAC-4277-vm-resize-instancetype/prd.md
@@ -8,15 +8,15 @@
 
 ## Problem Statement
 
-Tenant Users provision VMaaS ComputeInstances and need to scale their CPU and
-memory as workload demands change, but today the only way to change a
-running VM's compute resources is to recreate it. The fulfillment-service
-API no longer accepts direct CPU and RAM values from tenants — as
-originally proposed in OSAC-39 — because compute sizing is now derived from
-a selected InstanceType. Without a way to change a ComputeInstance's
-InstanceType directly, Tenant Users face unnecessary downtime and
-disruption from re-provisioning just to right-size a VM they already have
-running. [Jira: OSAC-4277]
+Tenant Admins and Tenant Users provision VMaaS ComputeInstances and need to
+scale their CPU and memory as workload demands change, but today the only
+way to change a running VM's compute resources is to recreate it. The OSAC
+API no longer accepts direct CPU and RAM values from tenants — as originally
+proposed in OSAC-39 — because compute sizing is now derived from a selected
+InstanceType. Without a way to change a ComputeInstance's InstanceType
+directly, tenants face unnecessary downtime and disruption from
+re-provisioning just to right-size a VM they already have running. [Jira:
+OSAC-4277]
 
 ## In Scope
 
@@ -42,43 +42,43 @@ running. [Jira: OSAC-4277]
 - Quota validation on InstanceType changes.
 - Audit or tracking of InstanceType changes.
 - Automatic scaling or auto-resize — InstanceType changes are only made in
-  response to an explicit Tenant User request.
-- Live migration during a resize — a VM restart is the fallback when
-  hot-plug isn't supported for the requested change.
+  response to an explicit request from a Tenant Admin or Tenant User.
+- Guaranteed restart-free resize — whether a restart is required depends on
+  the OSAC deployment (see the restart-notice note under User Stories).
 - OSAC UI console support — InstanceType resize is available via API only
   in this feature; the OSAC UI does not currently support ComputeInstance
   updates beyond power management. [Clarify: R1.Q3]
 
 ## User Stories
 
-### Tenant User
+### Tenant Admin / Tenant User
 
-- As a Tenant User, I want to change a running VM's InstanceType via API so
-  that I can scale CPU and memory up or down without recreating the VM.
-- As a Tenant User, I want to know from OSAC's deployment documentation
-  whether InstanceType changes require a VM restart in my environment, so
-  that I can plan for the downtime before requesting a resize. Whether a
-  restart is required is a property of the OSAC deployment — in most
-  deployments no restart is required. Where a restart is required, the
-  Tenant User is responsible for restarting their own VM; OSAC does not
-  restart it automatically.
-- As a Tenant User, I want a request for an InstanceType that's invalid or
-  incompatible with my ComputeInstance to be rejected immediately when
-  possible, so that I don't wait for a change that can't succeed. [Clarify:
-  R1.Q5]
+- As a Tenant Admin or Tenant User, I want to change a running VM's
+  InstanceType via API so that I can scale CPU and memory up or down without
+  recreating the VM.
+- As a Tenant Admin or Tenant User, I want a request for an InstanceType
+  that's invalid or incompatible with my ComputeInstance to be rejected
+  immediately when possible, so that I don't wait for a change that can't
+  succeed. [Clarify: R1.Q5]
+
+**Note:** Whether an InstanceType resize requires a VM restart is a property
+of the OSAC deployment, documented for Tenant Admins and Tenant Users — in
+most deployments no restart is required. Where one is required, the user who
+requested the change is responsible for restarting the VM themselves; OSAC
+does not restart it automatically.
 
 ## Dependencies
 
-- **fulfillment-service InstanceType-based sizing:** This feature depends
-  on ComputeInstance CPU and memory already being derived from a selected
-  InstanceType rather than set directly, replacing the model originally
-  proposed in OSAC-39.
+- **InstanceType-based sizing:** This feature depends on ComputeInstance CPU
+  and memory already being derived from a selected InstanceType rather than
+  set directly through the OSAC API, replacing the model originally proposed
+  in OSAC-39.
 
 ---
 
 ## Provenance
 
 Authored: respond @ prd 0.8.0 - 7efcedb, workspace main @ 6e8f396
-Phases: draft, respond, respond, respond
+Phases: draft, respond, respond, respond, respond
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"6e8f396","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","respond","respond","respond"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"6e8f396","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","respond","respond","respond","respond"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-4277-vm-resize-instancetype/prd.md
+++ b/enhancements/OSAC-4277-vm-resize-instancetype/prd.md
@@ -1,0 +1,77 @@
+# VM Resize via InstanceType Selection
+
+| Field       | Value   |
+|-------------|---------|
+| Author(s)   | Ygal Blum |
+| Jira        | https://redhat.atlassian.net/browse/OSAC-4277 |
+| Date        | 2026-08-23 |
+
+## Problem Statement
+
+Tenant Users provision VMaaS ComputeInstances and need to scale their CPU and
+memory as workload demands change, but today the only way to change a
+running VM's compute resources is to recreate it. The fulfillment-service
+API no longer accepts direct CPU and RAM values from tenants — as
+originally proposed in OSAC-39 — because compute sizing is now derived from
+a selected InstanceType. Without a way to change a ComputeInstance's
+InstanceType directly, Tenant Users face unnecessary downtime and
+disruption from re-provisioning just to right-size a VM they already have
+running. [Jira: OSAC-4277]
+
+## In Scope
+
+- InstanceType changes apply to VMaaS ComputeInstances — this does not
+  cover BMaaS or CaaS resource resizing.
+- Both increasing and decreasing to a different InstanceType are supported.
+  [Clarify: R1.Q1]
+
+## Out of Scope
+
+- Disk size resize — a ComputeInstance's storage is unaffected by an
+  InstanceType change.
+- Quota validation on InstanceType changes.
+- Audit or tracking of InstanceType changes.
+- Automatic scaling or auto-resize — InstanceType changes are only made in
+  response to an explicit Tenant User request.
+- Live migration during a resize — a VM restart is the fallback when
+  hot-plug isn't supported for the requested change.
+- OSAC UI console support — InstanceType resize is available via API only
+  in this feature; the OSAC UI does not currently support ComputeInstance
+  updates beyond power management. [Clarify: R1.Q3]
+
+## User Stories
+
+### Tenant User
+
+- As a Tenant User, I want to change a running VM's InstanceType via API so
+  that I can scale CPU and memory up or down without recreating the VM.
+- As a Tenant User, I want to know whether an InstanceType change will
+  require restarting my VM before I request it, so that I can plan for the
+  downtime. To be determined — whether the Tenant User must initiate that
+  restart themselves or OSAC restarts the VM automatically. [Clarify: R1.Q2]
+- As a Tenant User, I want a request for an InstanceType that's invalid or
+  incompatible with my ComputeInstance to be rejected immediately when
+  possible, so that I don't wait for a change that can't succeed. [Clarify:
+  R1.Q5]
+
+## Assumptions
+
+- Whether an InstanceType change is eligible for hot-plug or requires a
+  restart is assumed to be a predictable, cluster-level capability that a
+  Tenant User can know ahead of time — not an outcome that varies
+  unpredictably per individual request. [Clarify: R1.Q2]
+
+## Dependencies
+
+- **fulfillment-service InstanceType-based sizing:** This feature depends
+  on ComputeInstance CPU and memory already being derived from a selected
+  InstanceType rather than set directly, replacing the model originally
+  proposed in OSAC-39.
+
+---
+
+## Provenance
+
+Authored: draft @ prd 0.8.0 - 7efcedb, workspace main @ 6e8f396
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"6e8f396","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-4277-vm-resize-instancetype/prd.md
+++ b/enhancements/OSAC-4277-vm-resize-instancetype/prd.md
@@ -29,7 +29,9 @@ running. [Jira: OSAC-4277]
   valid resize target (`DEPRECATED` succeeds with a warning), and an
   `OBSOLETE` target is invalid and rejected per the existing "invalid or
   incompatible" requirement. Resizing to the ComputeInstance's current
-  InstanceType is a no-op.
+  InstanceType is a no-op — the no-op check takes precedence over lifecycle
+  validation, so a request targeting the current InstanceType is always a
+  no-op even when that InstanceType is `DEPRECATED` or `OBSOLETE`.
 
 ## Out of Scope
 
@@ -77,6 +79,6 @@ running. [Jira: OSAC-4277]
 ## Provenance
 
 Authored: respond @ prd 0.8.0 - 7efcedb, workspace main @ 6e8f396
-Phases: draft, respond, respond
+Phases: draft, respond, respond, respond
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"6e8f396","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","respond","respond"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"6e8f396","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","respond","respond","respond"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-4277-vm-resize-instancetype/prd.md
+++ b/enhancements/OSAC-4277-vm-resize-instancetype/prd.md
@@ -24,11 +24,19 @@ running. [Jira: OSAC-4277]
   cover BMaaS or CaaS resource resizing.
 - Both increasing and decreasing to a different InstanceType are supported.
   [Clarify: R1.Q1]
+- A resize target's eligibility follows the same InstanceType lifecycle-state
+  rules as VM creation (see OSAC-46): an `ACTIVE` or `DEPRECATED` target is a
+  valid resize target (`DEPRECATED` succeeds with a warning), and an
+  `OBSOLETE` target is invalid and rejected per the existing "invalid or
+  incompatible" requirement. Resizing to the ComputeInstance's current
+  InstanceType is a no-op.
 
 ## Out of Scope
 
 - Disk size resize — a ComputeInstance's storage is unaffected by an
   InstanceType change.
+- Specific API error codes and response formats for rejected or no-op resize
+  requests — a design-level concern for the design document.
 - Quota validation on InstanceType changes.
 - Audit or tracking of InstanceType changes.
 - Automatic scaling or auto-resize — InstanceType changes are only made in
@@ -72,6 +80,7 @@ running. [Jira: OSAC-4277]
 
 ## Provenance
 
-Authored: draft @ prd 0.8.0 - 7efcedb, workspace main @ 6e8f396
+Authored: respond @ prd 0.8.0 - 7efcedb, workspace main @ 6e8f396
+Phases: draft, respond
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"6e8f396","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"6e8f396","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","respond"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->


### PR DESCRIPTION
## PRD: VM Resize via InstanceType Selection

**Jira:** https://redhat.atlassian.net/browse/OSAC-4277

### Summary
Enables Tenant Users to change a running VM's InstanceType via the fulfillment-service API to scale CPU and memory up or down without recreating the VM, replacing the direct CPU/RAM resize model originally proposed in OSAC-39. API-only for this feature; disk resize, quota validation, and UI support are out of scope.

### Requesting Review On
- Requirements completeness and accuracy
- Scope (goals and non-goals)
- Acceptance criteria clarity
- Open questions that need resolution

### How to Review
- Comment inline on specific sections
- Review the open questions — these need your input
- Approve when the PRD accurately reflects the agreed requirements

Assisted-by: Claude Code <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented VM instance type resizing requirements and supported scope.
  * Clarified lifecycle eligibility and no-op behavior when resizing to the current instance type, including deprecated or obsolete types.
  * Documented that no-op checks occur before lifecycle validation.
  * Clarified OSAC deployment–dependent restart requirements and that required restarts must be initiated by the Tenant User.
  * Noted that resizing is available through the API only and is not automatically performed by OSAC.
  * Documented response-phase provenance tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->