### PR TITLE
OSAC-3702: PRD - LVMS Node-Local Storage Backend for VMaaS

### DIFF
--- a/enhancements/OSAC-3702-lvms-vmaas/prd.md
+++ b/enhancements/OSAC-3702-lvms-vmaas/prd.md
@@ -12,16 +12,17 @@ The OSAC storage control plane provisions tenant storage only from network-attac
 
 ## In Scope
 
-*This release delivers LVMS for single-node VMaaS only. See Out of Scope for what is deferred to a future feature.*
+*This release delivers LVMS for single-node VMaaS only, as an **extension** of the existing OSAC storage control plane (OSAC-2872): it adds LVMS as a backend behind the opaque `local` tier and reuses the already-delivered `osac-csi-driver`, tier resolution, cross-cluster auth, and StorageClass generation rather than introducing any new driver-install or provisioning path. See Out of Scope for what is deferred to a future feature.*
 
 - LVMS (node-local LVM) as a storage backend in the OSAC storage control plane, exposed through the same opaque storage tier and `osac-csi-driver` model defined in OSAC-2872 — tenants see a `local` tier, not LVMS internals.
-- VMaaS onboarding installs and configures LVMS on the single-node cluster (hub == tenant) during tenant onboarding, so node-local storage is ready without manual setup.
+- VMaaS onboarding provisions the `local` tier through the **existing** OSAC storage onboarding path (OSAC-2872) — the `osac-csi-driver`, cross-cluster auth, and tenant-scoped StorageClass generation are already delivered. This feature adds installing and configuring LVMS on the single-node cluster (hub == tenant) during onboarding so that path resolves to node-local storage, leaving a usable `local` PVC path ready without manual setup.
 - Volumes on the `local` tier are provisioned on node-local LVM volume groups. Because the storage is node-local, a volume is provisioned when its consuming workload is scheduled and is then pinned to that node — the standard Kubernetes behavior for node-local storage.
 - ComputeInstance (VMaaS) workloads can consume the `local` tier for boot and additional disks using tenant-resolved StorageClasses.
 - End-to-end volume lifecycle: provision → mount → data round-trips → delete releases both the OSAC inventory record and the underlying node-local volume. This end-to-end flow is the definition of done for this release.
+- Deleting a ComputeInstance removes its node-local volume and inventory record, following the same volume lifecycle as other OSAC backends (OSAC-2872), so node-local capacity is not leaked.
 - Central inventory tracking of `local`-tier volumes (tenant, tier, state, size), consistent with OSAC-2872.
-- Clear, predictable failure when a node has insufficient local capacity to satisfy a request.
-- E2E test covering the single-node VMaaS `local`-tier provision → mount → cleanup flow.
+- When a node lacks local capacity to satisfy a request, provisioning fails predictably and leaves no partial volume or inventory record.
+- E2E test covering the single-node VMaaS `local`-tier provision → mount → cleanup flow, including that the volume remains on the node where its workload was scheduled.
 - Administrator documentation (node LVM prerequisites, registering the LVMS backend and `local` tier) and user documentation (consuming the `local` tier).
 
 ## Out of Scope
@@ -72,6 +73,6 @@ Deferred to a future feature (current scope is single-node VMaaS only):
 
 ## Provenance
 
-Authored: draft @ prd 0.8.0 - 7efcedb, workspace fix/OSAC-3985-tier-guard-before-provision @ be68f168a
+Authored: draft @ prd 0.8.0 - 7efcedb, workspace main @ 62ad8a38b
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"be68f168a","source_repo_branch":"fix/OSAC-3985-tier-guard-before-provision","commits_behind_main":0,"commits_ahead_main":2,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"62ad8a38b","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-3702-lvms-vmaas/prd.md
+++ b/enhancements/OSAC-3702-lvms-vmaas/prd.md
@@ -1,0 +1,77 @@
+# LVMS Node-Local Storage Backend for VMaaS
+
+| Field       | Value   |
+|-------------|---------|
+| Author(s)   | Zoltan Szabo |
+| Jira        | [OSAC-3702](https://redhat.atlassian.net/browse/OSAC-3702) |
+| Date        | 2026-08-25 |
+
+## Problem Statement
+
+The OSAC storage control plane provisions tenant storage only from network-attached arrays — VAST today, and Pure FlashBlade via OSAC-2117. Single-node development environments have no such array; the only storage available is the local disk on the node. In those environments OSAC cannot offer any managed persistent storage, so operators fall back to configuring node-local storage by hand — outside OSAC — losing the opaque storage tier, the central inventory, and the single uniform driver that OSAC provides everywhere else. Without a node-local backend, OSAC cannot serve single-node development VMaaS deployments as a self-service platform.
+
+## In Scope
+
+*This release delivers LVMS for single-node VMaaS only. See Out of Scope for what is deferred to a future feature.*
+
+- LVMS (node-local LVM) as a storage backend in the OSAC storage control plane, exposed through the same opaque storage tier and `osac-csi-driver` model defined in OSAC-2872 — tenants see a `local` tier, not LVMS internals.
+- VMaaS onboarding installs and configures LVMS on the single-node cluster (hub == tenant) during tenant onboarding, so node-local storage is ready without manual setup.
+- Volumes on the `local` tier are provisioned on node-local LVM volume groups. Because the storage is node-local, a volume is provisioned when its consuming workload is scheduled and is then pinned to that node — the standard Kubernetes behavior for node-local storage.
+- ComputeInstance (VMaaS) workloads can consume the `local` tier for boot and additional disks using tenant-resolved StorageClasses.
+- End-to-end volume lifecycle: provision → mount → data round-trips → delete releases both the OSAC inventory record and the underlying node-local volume. This end-to-end flow is the definition of done for this release.
+- Central inventory tracking of `local`-tier volumes (tenant, tier, state, size), consistent with OSAC-2872.
+- Clear, predictable failure when a node has insufficient local capacity to satisfy a request.
+- E2E test covering the single-node VMaaS `local`-tier provision → mount → cleanup flow.
+- Administrator documentation (node LVM prerequisites, registering the LVMS backend and `local` tier) and user documentation (consuming the `local` tier).
+
+## Out of Scope
+
+Deferred to a future feature (current scope is single-node VMaaS only):
+
+- **CaaS / multi-cluster LVMS** — provisioning node-local storage on separate tenant clusters. CaaS tenant onboarding is tracked under OSAC-1332.
+- **Multi-node capacity-aware scheduling** — selecting among multiple candidate nodes by free local capacity.
+- **Volume expansion** for `local`-tier volumes.
+- **Quota** enforcement for node-local storage.
+- **Network / array backends** — VAST and Pure FlashBlade are already covered (OSAC-2872, OSAC-2117).
+- **BMaaS storage integration.**
+
+## User Stories
+
+### Cloud Provider Admin
+
+- As a Cloud Provider Admin, I want to register LVMS as a storage backend and define a `local` storage tier with LVMS as the provider, so that VMaaS onboarding provisions node-local storage from the correct backend without a remote array.
+- As a Cloud Provider Admin, I want LVMS installed and configured automatically on the single-node cluster during VMaaS tenant onboarding, so that node-local storage is ready without manual intervention.
+- As a Cloud Provider Admin, I want `local`-tier volumes tracked in the same central inventory as other backends, so that I can account for node-local storage usage the same way.
+- As a Cloud Provider Admin, I want a clear error and a blocked status when a volume cannot be provisioned because the node lacks local capacity, so that I can add capacity and retry deterministically.
+
+### Tenant Admin / Tenant User
+
+- As a Tenant Admin or Tenant User, I want to attach a disk to a ComputeInstance using the `local` tier and have it provisioned on node-local disk without seeing any LVMS internals, so that I consume node-local storage through the same opaque storage-tier abstraction as remote backends.
+- As a Tenant Admin or Tenant User, I want a `local`-tier disk to follow the standard behavior for node-local storage — provisioned when my ComputeInstance is scheduled and then kept on that node — so that behavior is predictable, accepting that such a ComputeInstance is pinned to its node.
+- As a Tenant Admin or Tenant User, I want deleting a ComputeInstance to clean up its node-local volume and inventory record, so that storage is released and nothing leaks.
+
+### Cloud Infrastructure Admin
+
+- As a Cloud Infrastructure Admin, I want to prepare nodes with the local disks and volume group that LVMS carves volumes from, so that the `local` tier has capacity to provision.
+
+## Assumptions
+
+- The OSAC storage control plane (OSAC-2872) — Volume API, tier resolution, central inventory, and `osac-csi-driver` — supports a new backend provider with additive changes only. LVMS reuses this model rather than introducing a parallel storage path.
+- In the single-node scope, the cluster where tenants run is the same cluster that runs the OSAC control plane (hub == tenant), so no cross-cluster provisioning is required in this release.
+- Nodes have local disks and a volume group available for LVMS to consume; provisioning that hardware and capacity is a cluster/infrastructure prerequisite handled outside OSAC.
+- LVMS targets single-node development environments where remote storage arrays are unavailable or unnecessary; it does not aim for feature parity with network backends (in particular, node-local volumes do not move between nodes).
+- The LVMS installation tooling is available to the VMaaS onboarding automation.
+
+## Dependencies
+
+- **OSAC-2872 (Storage Control Plane):** provides the Volume API, tier resolution, central inventory, and `osac-csi-driver` that this backend plugs into. Must be in place for the `local` tier to resolve and provision end-to-end.
+- **VMaaS tenant onboarding automation:** extended to install and configure LVMS on the single-node cluster during onboarding.
+- **osac-csi-driver:** `local`-tier provisioning and mount route through the same driver as other backends.
+
+---
+
+## Provenance
+
+Authored: draft @ prd 0.8.0 - 7efcedb, workspace fix/OSAC-3985-tier-guard-before-provision @ be68f168a
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"be68f168a","source_repo_branch":"fix/OSAC-3985-tier-guard-before-provision","commits_behind_main":0,"commits_ahead_main":2,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-3702-lvms-vmaas/prd.md
+++ b/enhancements/OSAC-3702-lvms-vmaas/prd.md
@@ -56,7 +56,7 @@ Deferred to a future feature (current scope is single-node VMaaS only):
 
 ## Assumptions
 
-- The OSAC storage control plane (OSAC-2872) — Volume API, tier resolution, central inventory, and `osac-csi-driver` — supports a new backend provider with additive changes only. LVMS reuses this model rather than introducing a parallel storage path.
+- The `local` tier uses the same onboarding, provisioning, and inventory experience as remote backends (OSAC-2872), adding no new tenant-facing or admin-facing workflow.
 - In the single-node scope, the control plane and tenant workloads share one cluster, so no cross-cluster provisioning is required in this release.
 - Nodes have local disks and a volume group available for LVMS to consume; provisioning that hardware and capacity is a cluster/infrastructure prerequisite handled outside OSAC.
 - LVMS targets single-node development environments where remote storage arrays are unavailable or unnecessary; it does not aim for feature parity with network backends (in particular, node-local volumes do not move between nodes).

--- a/enhancements/OSAC-3702-lvms-vmaas/prd.md
+++ b/enhancements/OSAC-3702-lvms-vmaas/prd.md
@@ -12,18 +12,17 @@ The OSAC storage control plane provisions tenant storage only from network-attac
 
 ## In Scope
 
-*This release delivers LVMS for single-node VMaaS only, as an **extension** of the existing OSAC storage control plane (OSAC-2872): it adds LVMS as a backend behind the opaque `local` tier and reuses the already-delivered `osac-csi-driver`, tier resolution, cross-cluster auth, and StorageClass generation rather than introducing any new driver-install or provisioning path. See Out of Scope for what is deferred to a future feature.*
+*This release delivers LVMS as a `local` storage tier for single-node VMaaS only, extending OSAC's existing storage offering (OSAC-2872) with a node-local backend. It uses the same storage tier and onboarding path as remote backends, so no new provisioning or install path is introduced. See Out of Scope for what is deferred to a future feature.*
 
-- LVMS (node-local LVM) as a storage backend in the OSAC storage control plane, exposed through the same opaque storage tier and `osac-csi-driver` model defined in OSAC-2872 — tenants see a `local` tier, not LVMS internals.
-- VMaaS onboarding provisions the `local` tier through the **existing** OSAC storage onboarding path (OSAC-2872) — the `osac-csi-driver`, cross-cluster auth, and tenant-scoped StorageClass generation are already delivered. This feature adds installing and configuring LVMS on the single-node cluster (hub == tenant) during onboarding so that path resolves to node-local storage, leaving a usable `local` PVC path ready without manual setup.
-- Volumes on the `local` tier are provisioned on node-local LVM volume groups. Because the storage is node-local, a volume is provisioned when its consuming workload is scheduled and is then pinned to that node — the standard Kubernetes behavior for node-local storage.
-- ComputeInstance (VMaaS) workloads can consume the `local` tier for boot and additional disks using tenant-resolved StorageClasses.
-- End-to-end volume lifecycle: provision → mount → data round-trips → delete releases both the OSAC inventory record and the underlying node-local volume. This end-to-end flow is the definition of done for this release.
-- Deleting a ComputeInstance removes its node-local volume and inventory record, following the same volume lifecycle as other OSAC backends (OSAC-2872), so node-local capacity is not leaked.
-- Central inventory tracking of `local`-tier volumes (tenant, tier, state, size), consistent with OSAC-2872.
-- When a node lacks local capacity to satisfy a request, provisioning fails predictably and leaves no partial volume or inventory record.
-- E2E test covering the single-node VMaaS `local`-tier provision → mount → cleanup flow, including that the volume remains on the node where its workload was scheduled.
-- Administrator documentation (node LVM prerequisites, registering the LVMS backend and `local` tier) and user documentation (consuming the `local` tier).
+- **A `local` storage tier backed by node-local storage.** Platform admins register LVMS as a backend and define a `local` tier; tenants see an opaque tier, not LVMS internals — the same experience, tier model, and onboarding path as remote backends (OSAC-2872).
+- **Automatic setup during VMaaS onboarding.** Onboarding a single-node deployment configures the `local` tier end to end, leaving a usable local storage path ready without manual steps.
+- **Node-local provisioning behavior.** A `local`-tier volume is provisioned when its ComputeInstance is scheduled and then stays on that node; consequently a ComputeInstance using `local` storage is pinned to its node.
+- **ComputeInstance consumption.** VMaaS workloads can use the `local` tier for boot and additional disks.
+- **Full volume lifecycle with cleanup.** Provision → mount → data round-trips → delete; deleting a ComputeInstance releases both its node-local storage and its inventory record, so capacity is not leaked. This end-to-end flow is the definition of done for this release.
+- **Inventory tracking.** `local`-tier volumes are tracked centrally (tenant, tier, state, size), consistent with other backends.
+- **Predictable capacity failure.** When a node lacks local capacity, provisioning fails predictably and leaves no partial volume or inventory record.
+- **Interfaces.** The `local` tier appears through the same tenant-facing channels (console and CLI) as other storage tiers; no LVMS-specific UI is added.
+- **Test and documentation.** An E2E test covers the single-node provision → mount → cleanup flow (including that the volume stays on its scheduled node); admin docs cover node prerequisites and backend/tier registration; user docs cover consuming the `local` tier.
 
 ## Out of Scope
 
@@ -58,16 +57,15 @@ Deferred to a future feature (current scope is single-node VMaaS only):
 ## Assumptions
 
 - The OSAC storage control plane (OSAC-2872) — Volume API, tier resolution, central inventory, and `osac-csi-driver` — supports a new backend provider with additive changes only. LVMS reuses this model rather than introducing a parallel storage path.
-- In the single-node scope, the cluster where tenants run is the same cluster that runs the OSAC control plane (hub == tenant), so no cross-cluster provisioning is required in this release.
+- In the single-node scope, the control plane and tenant workloads share one cluster, so no cross-cluster provisioning is required in this release.
 - Nodes have local disks and a volume group available for LVMS to consume; provisioning that hardware and capacity is a cluster/infrastructure prerequisite handled outside OSAC.
 - LVMS targets single-node development environments where remote storage arrays are unavailable or unnecessary; it does not aim for feature parity with network backends (in particular, node-local volumes do not move between nodes).
 - The LVMS installation tooling is available to the VMaaS onboarding automation.
 
 ## Dependencies
 
-- **OSAC-2872 (Storage Control Plane):** provides the Volume API, tier resolution, central inventory, and `osac-csi-driver` that this backend plugs into. Must be in place for the `local` tier to resolve and provision end-to-end.
+- **OSAC-2872 (Storage Control Plane):** provides the storage tier model, driver, central inventory, and onboarding path this backend plugs into. Must be in place for the `local` tier to provision end to end.
 - **VMaaS tenant onboarding automation:** extended to install and configure LVMS on the single-node cluster during onboarding.
-- **osac-csi-driver:** `local`-tier provisioning and mount route through the same driver as other backends.
 
 ---
 

--- a/enhancements/OSAC-3702-lvms-vmaas/prd.md
+++ b/enhancements/OSAC-3702-lvms-vmaas/prd.md
@@ -8,21 +8,21 @@
 
 ## Problem Statement
 
-The OSAC storage control plane provisions tenant storage only from network-attached arrays — VAST today, and Pure FlashBlade via OSAC-2117. Single-node development environments have no such array; the only storage available is the local disk on the node. In those environments OSAC cannot offer any managed persistent storage, so operators fall back to configuring node-local storage by hand — outside OSAC — losing the opaque storage tier, the central inventory, and the single uniform driver that OSAC provides everywhere else. Without a node-local backend, OSAC cannot serve single-node development VMaaS deployments as a self-service platform.
+The OSAC storage control plane provisions tenant storage only from network-attached arrays — VAST today, and Pure FlashBlade via OSAC-2117. Single-node development environments have no such array; the only storage available is the local disk on the node. In those environments OSAC cannot offer any managed persistent storage, so operators fall back to configuring node-local storage by hand — outside OSAC — losing the opaque storage tier, the central inventory, and the single uniform driver that OSAC provides everywhere else. Without a node-local backend, OSAC cannot serve single-node development, testing, and CI/CD VMaaS deployments as a self-service platform. This feature targets those environments specifically — not production workloads.
 
 ## In Scope
 
-*This release delivers LVMS as a `local` storage tier for single-node VMaaS only, extending OSAC's existing storage offering (OSAC-2872) with a node-local backend. It uses the same storage tier and onboarding path as remote backends, so no new provisioning or install path is introduced. See Out of Scope for what is deferred to a future feature.*
+*This release adds LVMS as a node-local storage backend for single-node VMaaS, extending OSAC's existing storage offering (OSAC-2872). Admins register LVMS and define an LVMS-backed tier; it uses the same tier model and onboarding path as remote backends, so no new provisioning or install path is introduced. See Out of Scope for what is deferred to a future feature. LVMS is a Block backend type; the tier name is admin-defined and is not a protocol or backend-type designation.*
 
-- **A `local` storage tier backed by node-local storage.** Platform admins register LVMS as a backend and define a `local` tier; tenants see an opaque tier, not LVMS internals — the same experience, tier model, and onboarding path as remote backends (OSAC-2872).
-- **Automatic setup during VMaaS onboarding.** Onboarding a single-node deployment configures the `local` tier end to end, leaving a usable local storage path ready without manual steps.
-- **Node-local provisioning behavior.** A `local`-tier volume is provisioned when its ComputeInstance is scheduled and then stays on that node; consequently a ComputeInstance using `local` storage is pinned to its node.
-- **ComputeInstance consumption.** VMaaS workloads can use the `local` tier for boot and additional disks.
+- **An LVMS-backed storage tier backed by node-local storage.** Platform admins register LVMS as a backend and define a tier backed by it; tenants see an opaque tier, not LVMS internals — the same experience, tier model, and onboarding path as remote backends (OSAC-2872).
+- **Automatic setup during VMaaS onboarding.** Onboarding a single-node deployment configures the LVMS-backed tier end to end, leaving a usable local storage path ready without manual steps.
+- **Node-local provisioning behavior.** An LVMS-backed volume is provisioned when its ComputeInstance is scheduled and then stays on that node; consequently a ComputeInstance using LVMS-backed storage is pinned to its node.
+- **ComputeInstance consumption.** VMaaS workloads can use the LVMS-backed tier for boot and additional disks.
 - **Full volume lifecycle with cleanup.** Provision → mount → data round-trips → delete; deleting a ComputeInstance releases both its node-local storage and its inventory record, so capacity is not leaked. This end-to-end flow is the definition of done for this release.
-- **Inventory tracking.** `local`-tier volumes are tracked centrally (tenant, tier, state, size), consistent with other backends.
+- **Inventory tracking.** LVMS-backed volumes are tracked centrally (tenant, tier, state, size), consistent with other backends.
 - **Predictable capacity failure.** When a node lacks local capacity, provisioning fails predictably and leaves no partial volume or inventory record.
-- **Interfaces.** The `local` tier appears through the same tenant-facing channels (console and CLI) as other storage tiers; no LVMS-specific UI is added.
-- **Test and documentation.** An E2E test covers the single-node provision → mount → cleanup flow (including that the volume stays on its scheduled node); admin docs cover node prerequisites and backend/tier registration; user docs cover consuming the `local` tier.
+- **Interfaces.** The LVMS-backed tier appears through the same tenant-facing channels (console and CLI) as other storage tiers; no LVMS-specific UI is added.
+- **Test and documentation.** An E2E test covers the single-node provision → mount → cleanup flow (including that the volume stays on its scheduled node); admin docs cover node prerequisites and backend/tier registration; user docs cover consuming the LVMS-backed tier.
 
 ## Out of Scope
 
@@ -30,42 +30,45 @@ Deferred to a future feature (current scope is single-node VMaaS only):
 
 - **CaaS / multi-cluster LVMS** — provisioning node-local storage on separate tenant clusters. CaaS tenant onboarding is tracked under OSAC-1332.
 - **Multi-node capacity-aware scheduling** — selecting among multiple candidate nodes by free local capacity.
-- **Volume expansion** for `local`-tier volumes.
+- **Volume expansion** for LVMS-backed volumes.
 - **Quota** enforcement for node-local storage.
 - **Network / array backends** — VAST and Pure FlashBlade are already covered (OSAC-2872, OSAC-2117).
 - **BMaaS storage integration.**
+- **Production use** — LVMS as a node-local backend is not intended or supported for production workloads. Once a deployment profile flag is available (see Dependecies), LVMS will only be registerable in development/test profile installations.
 
 ## User Stories
 
 ### Cloud Provider Admin
 
-- As a Cloud Provider Admin, I want to register LVMS as a storage backend and define a `local` storage tier with LVMS as the provider, so that VMaaS onboarding provisions node-local storage from the correct backend without a remote array.
-- As a Cloud Provider Admin, I want LVMS installed and configured automatically on the single-node cluster during VMaaS tenant onboarding, so that node-local storage is ready without manual intervention.
-- As a Cloud Provider Admin, I want `local`-tier volumes tracked in the same central inventory as other backends, so that I can account for node-local storage usage the same way.
-- As a Cloud Provider Admin, I want a clear error and a blocked status when a volume cannot be provisioned because the node lacks local capacity, so that I can add capacity and retry deterministically.
+- As a Cloud Provider Admin, I want to register LVMS as a storage backend and define a storage tier with LVMS as the provider, so that VMaaS onboarding provisions node-local storage from the correct backend without a remote array.
+- As a Cloud Provider Admin, I want LVMS configured automatically on the single-node cluster during VMaaS tenant onboarding, so that node-local storage is ready without manual intervention.
+- As a Cloud Provider Admin, I want LVMS-backed volumes tracked in the same central inventory as other backends, so that I can account for node-local storage usage the same way.
+- As a Cloud Provider Admin, I want volume provisioning to fail predictably when a node lacks local capacity — with no partial volume or inventory record left behind — so that I can resolve the capacity issue and reprovision.
 
 ### Tenant Admin / Tenant User
 
-- As a Tenant Admin or Tenant User, I want to attach a disk to a ComputeInstance using the `local` tier and have it provisioned on node-local disk without seeing any LVMS internals, so that I consume node-local storage through the same opaque storage-tier abstraction as remote backends.
-- As a Tenant Admin or Tenant User, I want a `local`-tier disk to follow the standard behavior for node-local storage — provisioned when my ComputeInstance is scheduled and then kept on that node — so that behavior is predictable, accepting that such a ComputeInstance is pinned to its node.
-- As a Tenant Admin or Tenant User, I want deleting a ComputeInstance to clean up its node-local volume and inventory record, so that storage is released and nothing leaks.
+- As a Tenant Admin or Tenant User, I want to attach a disk to a ComputeInstance using an LVMS-backed tier and have it provisioned on node-local disk without seeing any LVMS internals, so that I consume node-local storage through the same opaque storage-tier abstraction as remote backends.
+- As a Tenant Admin or Tenant User, I want the LVMS-backed tier disk to follow the standard behavior for node-local storage — provisioned when my ComputeInstance is scheduled and then kept on that node — so that behavior is predictable, accepting that such a ComputeInstance is pinned to its node.
+- As a Tenant Admin or Tenant User, I want deleting a ComputeInstance to clean up its node-local volume and inventory record, so that storage capacity is released.
 
 ### Cloud Infrastructure Admin
 
-- As a Cloud Infrastructure Admin, I want to prepare nodes with the local disks and volume group that LVMS carves volumes from, so that the `local` tier has capacity to provision.
+- As a Cloud Infrastructure Admin, I want to prepare nodes with the local disks and volume group that LVMS carves volumes from, so that the LVMS-backed tier has capacity to provision.
 
 ## Assumptions
 
-- The `local` tier uses the same onboarding, provisioning, and inventory experience as remote backends (OSAC-2872), adding no new tenant-facing or admin-facing workflow.
+- The LVMS-backed tier uses the same onboarding, provisioning, and inventory experience as remote backends (OSAC-2872), adding no new tenant-facing or admin-facing workflow.
 - In the single-node scope, the control plane and tenant workloads share one cluster, so no cross-cluster provisioning is required in this release.
 - Nodes have local disks and a volume group available for LVMS to consume; provisioning that hardware and capacity is a cluster/infrastructure prerequisite handled outside OSAC.
 - LVMS targets single-node development environments where remote storage arrays are unavailable or unnecessary; it does not aim for feature parity with network backends (in particular, node-local volumes do not move between nodes).
 - The LVMS installation tooling is available to the VMaaS onboarding automation.
+- LVMS backend registration requires a deployment-level development/test profile flag (see Dependencies). This flag is a cross-cutting concern proposed separately; once available, LVMS is gated behind it alongside other dev-only capabilities.
 
 ## Dependencies
 
-- **OSAC-2872 (Storage Control Plane):** provides the storage tier model, driver, central inventory, and onboarding path this backend plugs into. Must be in place for the `local` tier to provision end to end.
+- **OSAC-2872 (Storage Control Plane):** provides the storage tier model, driver, central inventory, and onboarding path this backend plugs into. Must be in place for the LVMS-backed tier to provision end to end.
 - **VMaaS tenant onboarding automation:** extended to install and configure LVMS on the single-node cluster during onboarding.
+- **Deployment Profile Flag (proposed):** a deployment-level `deployment.profile` (or equivalent) Helm value that distinguishes development/test from production installations. LVMS registration is gated behind this flag. Until the flag lands, LVMS falls back to `lvms.enabled` (default: false) as an interim gate.
 
 ---
 


### PR DESCRIPTION
## PRD: LVMS Node-Local Storage Backend for VMaaS

**Jira:** [OSAC-3702](https://redhat.atlassian.net/browse/OSAC-3702)

### Summary
Adds LVMS (node-local LVM) as a storage backend in the OSAC storage control plane, exposed through the same opaque `local` tier and `osac-csi-driver` model defined in [OSAC-2872](https://redhat.atlassian.net/browse/OSAC-2872). Scope for this release is **single-node development VMaaS only** — node-local provisioning, mount, and cleanup end-to-end. CaaS/multi-cluster, multi-node capacity scheduling, expansion, quota, and network backends are explicitly deferred to a future feature.

This PRD is intentionally light and provider-specific: it references the approved [OSAC-2872](https://redhat.atlassian.net/browse/OSAC-2872) storage-control-plane PRD for the shared mechanism rather than re-deriving it, and mirrors the per-backend shape of [OSAC-2117](https://redhat.atlassian.net/browse/OSAC-2117) (Pure FlashBlade).

### Requesting Review On
- Requirements completeness and accuracy for a node-local backend
- Scope boundary (single-node dev VMaaS in; CaaS/multi-node/expansion/quota out)
- Whether the user stories correctly capture the node-local behavior (WaitForFirstConsumer binding, node pinning)

### How to Review
- Comment inline on specific sections
- Confirm the in/out-of-scope split matches the intended release
- Approve when the PRD accurately reflects the agreed requirements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added product requirements for a node-local storage backend supporting single-node VMaaS.
  * Documented storage provisioning, lifecycle cleanup, inventory tracking, capacity handling, and end-to-end testing requirements.
  * Clarified supported scope and explicitly excluded scenarios such as multi-node scheduling, expansion, quotas, and additional backend integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->