### PR TITLE
OSAC-4470: Update EP review comment with progress placeholder

### DIFF
--- a/.github/scripts/ep_hooks.py
+++ b/.github/scripts/ep_hooks.py
@@ -62,6 +62,96 @@ class EPHooks:
             return ""
         return result.stdout
 
+    # ── Comment upsert (one comment per review type, updated in place) ──
+
+    @staticmethod
+    def _comment_tag(skill_name):
+        """Stable invisible marker identifying this bot's comment for a given
+        review type. Embedded in every comment body so re-runs update the same
+        comment in place instead of posting a new one each time."""
+        kind = "prd-review" if skill_name == "prd-review" else "design-review"
+        return f"<!-- ep-review-bot:{kind} -->"
+
+    def _find_comment_id(self, pr_number, tag):
+        """Return the id of this bot's existing comment carrying `tag`, or
+        None. Matches on both bot login and the hidden tag so a human quoting
+        the tag can't hijack the target comment."""
+        out = self._gh([
+            "api", f"repos/{self.repo}/issues/{pr_number}/comments",
+            "--paginate", "--jq",
+            f'[.[] | select(.user.login == "{self.bot_login}") '
+            f'| select(.body | contains("{tag}"))][0].id // empty'
+        ]).strip()
+        return out or None
+
+    def _upsert_comment(self, pr_number, tag, body):
+        """PATCH the bot's existing tagged comment if present, else create one.
+
+        `gh api -F body=@FILE` reads the field value verbatim from the file,
+        which sidesteps shell/JSON escaping of the markdown body.
+        """
+        comment_id = self._find_comment_id(pr_number, tag)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write(body)
+            path = f.name
+        try:
+            if comment_id:
+                self._gh(["api", "--method", "PATCH",
+                          f"repos/{self.repo}/issues/comments/{comment_id}",
+                          "-F", f"body=@{path}"], check=True)
+            else:
+                self._gh(["pr", "comment", pr_number, "--repo", self.repo,
+                          "--body-file", path], check=True)
+        finally:
+            os.unlink(path)
+        return comment_id is not None
+
+    def _post_status(self, ticket_key, skill_name, title, status, message):
+        """Upsert a short status comment (in-progress or failed) that shares
+        the final review's header and hidden tag, so the update reads as one
+        comment evolving. It deliberately carries no `<!-- sha:XXXX -->` marker
+        and adds no reviewed label, so check_pr_state doesn't see it as
+        "already reviewed at this SHA" and the real review still runs."""
+        if self.shadow:
+            print(f"  [{ticket_key}] SHADOW: would post status '{status}'")
+            return
+        pr_number = ticket_key.replace("EP-", "")
+        tag = self._comment_tag(skill_name)
+        marker = "AI Design Review:" if skill_name == "design-review" else "AI EP Review:"
+        body = "\n".join([
+            f"## {marker} {title}",
+            tag,
+            "",
+            f"**Status:** {status}",
+            "",
+            message,
+        ])
+        # The progress/failure comment is cosmetic — never let a comment API
+        # hiccup abort the actual review, which runs after this returns.
+        try:
+            self._upsert_comment(pr_number, tag, body)
+            print(f"  [{ticket_key}] Posted status '{status}'")
+        except Exception as e:
+            print(f"  [{ticket_key}] status comment failed (ignored): {e}",
+                  file=sys.stderr)
+
+    def post_progress_placeholder(self, ticket_key, skill_name):
+        """Show immediate "in progress" feedback before the (slow) review runs;
+        apply_labels later updates this same comment with the full results."""
+        self._post_status(
+            ticket_key, skill_name, "Analyzing changes…", "Review in progress",
+            "The automated review is analyzing the updated document. This "
+            "comment will be replaced with the full results (scores, findings, "
+            "and structural notes) as soon as the run completes.")
+
+    def post_failure_note(self, ticket_key, skill_name):
+        """Replace an in-progress placeholder with a failure note so the comment
+        doesn't sit on "in progress" after an errored run."""
+        self._post_status(
+            ticket_key, skill_name, "Review failed", "Failed",
+            "The automated review encountered an error and did not complete. "
+            "It will retry on the next push.")
+
     @staticmethod
     def _sanitize_text(text, max_len=500):
         text = re.sub(r'!\[[^\]]*\]\([^\)]*\)', '', text)
@@ -81,16 +171,26 @@ class EPHooks:
 
     # ── Pre-gate ──
 
-    def check_pr_state(self, ticket_key, ticket, mode, work_dir, **kw):
+    def check_pr_state(self, ticket_key, ticket, mode, work_dir,
+                       skill_name=None, **kw):
         labels = ticket.get("labels", [])
         if self.reviewed_label in labels:
             head = ticket.get("headRefOid", "")
             pr_number = ticket_key.replace("EP-", "")
+            # Scope the lookup to THIS review type's tagged comment only. A PR
+            # can carry both a PRD and a design review; if the PRD review
+            # completed (its comment holds the current SHA) but the design
+            # review failed, an any-type query would treat the PRD comment as
+            # the design review's own and wrongly skip the design retry.
+            skill_name = skill_name or ticket.get("_skill_name", "")
+            tag = self._comment_tag(skill_name)
             existing = self._gh([
                 "api", f"repos/{self.repo}/issues/{pr_number}/comments",
-                "--jq",
+                "--paginate", "--jq",
+                # An in-progress placeholder carries the tag but no SHA marker,
+                # so the head[:8] check below still lets the real review run.
                 f'[.[] | select(.user.login == "{self.bot_login}") '
-                f'| select(.body | contains("AI EP Review:") or contains("AI Design Review:"))][0].body // empty'
+                f'| select(.body | contains("{tag}"))][0].body // empty'
             ]).strip()
             if existing and head and head[:8] in existing:
                 return f"Already reviewed at SHA {head[:8]}"
@@ -295,9 +395,13 @@ class EPHooks:
         pass_fail = "PASS" if total >= threshold and not has_zero else "FAIL"
         marker = "AI EP Review:" if is_prd else "AI Design Review:"
         display_labels = PRD_DISPLAY if is_prd else DESIGN_DISPLAY
+        skill_name = ticket.get("_skill_name") or (
+            "prd-review" if is_prd else "design-review")
+        tag = self._comment_tag(skill_name)
 
         lines = [
             f"## {marker} {self._sanitize_text(verdict.get('title', ticket_key), 200)}",
+            tag,
             f"<!-- sha:{head_sha[:8]} -->" if head_sha else "",
             "",
             f"**Score: {total}/{max_total}** | **Verdict: {pass_fail}**",
@@ -360,16 +464,8 @@ class EPHooks:
                 print(f"  [{ticket_key}] SHADOW cost: {cost_summary}")
             return
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
-            f.write(comment)
-            comment_file = f.name
-
-        self._gh(["pr", "comment", pr_number, "--repo", self.repo,
-                   "--body-file", comment_file],
-                  check=True)
-        print(f"  [{ticket_key}] Posted new review comment")
-
-        os.unlink(comment_file)
+        updated = self._upsert_comment(pr_number, tag, comment)
+        print(f"  [{ticket_key}] {'Updated' if updated else 'Posted'} review comment")
 
         self._gh(["pr", "edit", pr_number, "--repo", self.repo,
                    "--add-label", self.reviewed_label],
@@ -398,9 +494,11 @@ class EPHooks:
             else "**Feature:** could not be determined"
         )
         marker = "AI Design Review:" if skill_name == "design-review" else "AI EP Review:"
+        tag = self._comment_tag(skill_name)
 
         lines = [
             f"## {marker} Logistics-only change — full review skipped",
+            tag,
             f"<!-- sha:{head_sha[:8]} -->" if head_sha else "",
             "",
             "This PR was classified as **logistics-only** (a rename, frontmatter "
@@ -423,16 +521,9 @@ class EPHooks:
                   f"({len(comment)} chars)")
             return
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
-            f.write(comment)
-            comment_file = f.name
-
-        self._gh(["pr", "comment", pr_number, "--repo", self.repo,
-                   "--body-file", comment_file],
-                  check=True)
-        print(f"  [{ticket_key}] Posted logistics-only comment")
-
-        os.unlink(comment_file)
+        updated = self._upsert_comment(pr_number, tag, comment)
+        print(f"  [{ticket_key}] {'Updated' if updated else 'Posted'} "
+              "logistics-only comment")
 
         self._gh(["pr", "edit", pr_number, "--repo", self.repo,
                    "--add-label", self.reviewed_label],

--- a/.github/scripts/ep_review.py
+++ b/.github/scripts/ep_review.py
@@ -247,17 +247,21 @@ def main():
     for skill_name, skill_path in skills:
         ticket_key = f"EP-{pr_number}"
 
+        # Same-SHA dedup for both paths. The full-review path runs this again as
+        # a run_skill pre_gate, but checking here first keeps the logistics
+        # branch (which bypasses pre_gates) from posting a duplicate and stops
+        # us overwriting a valid final comment with a placeholder then bailing.
+        # A placeholder carries the stable tag but no SHA marker, so this check
+        # still lets the review run against a new SHA.
+        already_reviewed = hooks.check_pr_state(
+            ticket_key, ticket_base, mode="resolve", work_dir=Path("."),
+            skill_name=skill_name,
+        )
+        if already_reviewed:
+            print(f"\n[{skill_name}] {already_reviewed} — skipping")
+            continue
+
         if skip_logistics and logistics_verdict == ep_classify.LOGISTICS_ONLY:
-            # apply_logistics_comment() is called directly, bypassing the
-            # pre_gates list run_review()/run_skill() uses for the full-review
-            # path — call the same same-SHA dedup check explicitly so a rerun
-            # against an unchanged head doesn't post a duplicate comment.
-            already_reviewed = hooks.check_pr_state(
-                ticket_key, ticket_base, mode="resolve", work_dir=Path("."),
-            )
-            if already_reviewed:
-                print(f"\n[{skill_name}] {already_reviewed} — skipping")
-                continue
             print(f"\n[{skill_name}] LOGISTICS_ONLY — skipping full review")
             hooks.apply_logistics_comment(ticket_key, ticket_base, skill_name)
             continue
@@ -272,6 +276,10 @@ def main():
                         ignore_dangling_symlinks=True)
         exclude_own_slug_from_reference_library(work_dir, filenames)
 
+        # Show immediate feedback on the PR while the (slow) review runs; the
+        # final apply_labels upsert updates this same comment in place.
+        hooks.post_progress_placeholder(ticket_key, skill_name)
+
         print(f"\nRunning {skill_name}...")
         try:
             run_review(hooks, skill_name, skill_path, ticket_key, ticket_base, work_dir)
@@ -279,6 +287,9 @@ def main():
             print(f"  [{skill_name}] failed: {e}", file=sys.stderr)
             import traceback
             traceback.print_exc()
+            # Replace the in-progress placeholder so the comment doesn't sit on
+            # "in progress" after an errored run.
+            hooks.post_failure_note(ticket_key, skill_name)
             if IN_CI:
                 sys.exit(1)
 

--- a/.github/scripts/test_ep_hooks.py
+++ b/.github/scripts/test_ep_hooks.py
@@ -565,7 +565,8 @@ class ApplyLogisticsCommentTests(unittest.TestCase):
         captured, mock_gh = self._comment()
         self.assertIn("body", captured)
         self.assertEqual(captured.get("label"), "rfe-creator-auto-reviewed")
-        self.assertEqual(mock_gh.call_count, 2)
+        # find-existing-comment (returns none) + create + add-label.
+        self.assertEqual(mock_gh.call_count, 3)
 
     def test_shadow_mode_prints_only_no_gh_calls(self):
         from unittest.mock import patch
@@ -574,6 +575,231 @@ class ApplyLogisticsCommentTests(unittest.TestCase):
         with patch.object(hooks, "_gh") as mock_gh:
             hooks.apply_logistics_comment("EP-1", self.ticket, "design-review")
         mock_gh.assert_not_called()
+
+
+class CommentTagTests(unittest.TestCase):
+    """_comment_tag() must map skill names to stable per-type hidden tags."""
+
+    def setUp(self):
+        self.hooks = EPHooks(repo="test/repo", skills_path="/tmp")
+
+    def test_prd_tag(self):
+        self.assertEqual(
+            self.hooks._comment_tag("prd-review"), "<!-- ep-review-bot:prd-review -->",
+        )
+
+    def test_design_tag(self):
+        self.assertEqual(
+            self.hooks._comment_tag("design-review"),
+            "<!-- ep-review-bot:design-review -->",
+        )
+
+    def test_unknown_skill_defaults_to_design(self):
+        self.assertEqual(
+            self.hooks._comment_tag("something-else"),
+            "<!-- ep-review-bot:design-review -->",
+        )
+
+
+class UpsertCommentTests(unittest.TestCase):
+    """apply_labels()/_upsert_comment() must edit the existing tagged comment
+    in place when one exists, and create a new one otherwise."""
+
+    def setUp(self):
+        self.hooks = EPHooks(repo="test/repo", skills_path="/tmp", shadow=False)
+        self.verdict = {
+            "verdict": "pass",
+            "scores": {
+                "feasibility": 2, "testability": 2,
+                "scope": 2, "architecture": 2,
+            },
+            "total": 8,
+            "criterionNotes": {},
+            "summary": "Good design",
+            "feedback": "No issues",
+            "findings": {"critical": [], "important": [], "suggestions": []},
+        }
+        self.ticket = {
+            "headRefOid": "abc12345", "jira_key": "OSAC-1", "_skill_name": "design-review",
+            "jira_key_ambiguous": False, "structure_violations": [],
+        }
+
+    def _apply(self, existing_id):
+        from unittest.mock import patch
+
+        calls = []
+
+        def fake_gh(args, check=False):
+            calls.append(args)
+            # The _find_comment_id lookup ends in the issues/{pr}/comments API
+            # read — return the existing comment id (or empty to force create).
+            if args and args[0] == "api" and args[1].endswith("/comments"):
+                return existing_id or ""
+            return ""
+
+        with patch.object(self.hooks, "_gh", side_effect=fake_gh):
+            self.hooks.apply_labels(
+                "EP-1", self.verdict, "resolve", "/tmp", ticket=self.ticket,
+            )
+        return calls
+
+    def test_creates_new_comment_when_none_exists(self):
+        calls = self._apply(existing_id=None)
+        self.assertTrue(any(c[:2] == ["pr", "comment"] for c in calls),
+                        "expected a create via 'gh pr comment'")
+        self.assertFalse(any("PATCH" in c for c in calls),
+                         "must not PATCH when no comment exists")
+
+    def test_updates_existing_comment_in_place(self):
+        calls = self._apply(existing_id="12345")
+        patch_calls = [c for c in calls if "PATCH" in c]
+        self.assertEqual(len(patch_calls), 1, "expected exactly one PATCH")
+        self.assertIn("repos/test/repo/issues/comments/12345", patch_calls[0])
+        self.assertFalse(any(c[:2] == ["pr", "comment"] for c in calls),
+                         "must not also create a new comment")
+
+    def test_comment_body_carries_stable_tag(self):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        captured = {}
+
+        def fake_gh(args, check=False):
+            if "--body-file" in args:
+                captured["body"] = Path(args[args.index("--body-file") + 1]).read_text()
+            return ""
+
+        with patch.object(self.hooks, "_gh", side_effect=fake_gh):
+            self.hooks.apply_labels(
+                "EP-1", self.verdict, "resolve", "/tmp", ticket=self.ticket,
+            )
+        self.assertIn("<!-- ep-review-bot:design-review -->", captured["body"])
+        self.assertIn("<!-- sha:abc12345 -->", captured["body"])
+
+
+class ProgressPlaceholderTests(unittest.TestCase):
+    """post_progress_placeholder()/post_failure_note() must upsert a minimal
+    comment carrying the tag but NO sha marker and NO reviewed label."""
+
+    def _run(self, method_name, shadow):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        hooks = EPHooks(repo="test/repo", skills_path="/tmp", shadow=shadow)
+        captured = {}
+
+        def fake_gh(args, check=False):
+            if "--body-file" in args:
+                captured["body"] = Path(args[args.index("--body-file") + 1]).read_text()
+            if "--add-label" in args:
+                captured["label"] = True
+            return ""
+
+        with patch.object(hooks, "_gh", side_effect=fake_gh) as mock_gh:
+            getattr(hooks, method_name)("EP-1", "prd-review")
+        return captured, mock_gh
+
+    def test_placeholder_body_has_tag_no_sha_no_label(self):
+        captured, _ = self._run("post_progress_placeholder", shadow=False)
+        self.assertIn("<!-- ep-review-bot:prd-review -->", captured["body"])
+        self.assertNotIn("<!-- sha:", captured["body"])
+        self.assertNotIn("label", captured)
+        self.assertIn("in progress", captured["body"].lower())
+
+    def test_failure_note_body_has_tag_no_sha_no_label(self):
+        captured, _ = self._run("post_failure_note", shadow=False)
+        self.assertIn("<!-- ep-review-bot:prd-review -->", captured["body"])
+        self.assertNotIn("<!-- sha:", captured["body"])
+        self.assertNotIn("label", captured)
+        self.assertIn("failed", captured["body"].lower())
+
+    def test_placeholder_shadow_makes_no_gh_calls(self):
+        _, mock_gh = self._run("post_progress_placeholder", shadow=True)
+        mock_gh.assert_not_called()
+
+    def test_status_comment_failure_is_swallowed(self):
+        """A gh failure while publishing the progress/failure comment must not
+        propagate — the comment is cosmetic and the review must still run."""
+        from unittest.mock import patch
+
+        hooks = EPHooks(repo="test/repo", skills_path="/tmp", shadow=False)
+
+        def boom(args, check=False):
+            raise RuntimeError("gh api exploded")
+
+        with patch.object(hooks, "_gh", side_effect=boom):
+            # Must not raise.
+            hooks.post_progress_placeholder("EP-1", "prd-review")
+            hooks.post_failure_note("EP-1", "prd-review")
+
+
+class CheckPrStateTagTests(unittest.TestCase):
+    """check_pr_state() must locate the bot comment by the stable tag and only
+    treat it as already-reviewed when the current SHA marker is present."""
+
+    def setUp(self):
+        self.hooks = EPHooks(repo="test/repo", skills_path="/tmp")
+
+    def _check(self, existing_body, skill_name="prd-review"):
+        from unittest.mock import patch
+
+        with patch.object(self.hooks, "_gh", return_value=existing_body):
+            return self.hooks.check_pr_state(
+                "EP-1",
+                {"labels": ["rfe-creator-auto-reviewed"], "headRefOid": "abc12345deadbeef"},
+                mode="resolve", work_dir=".", skill_name=skill_name,
+            )
+
+    def _check_scoped(self, comments, skill_name):
+        """Drive check_pr_state against a fake comment list where each review
+        type has its own body, honouring the per-type --jq the lookup builds.
+        `comments` maps "prd"/"design" -> body (or None for absent)."""
+        from unittest.mock import patch
+
+        def fake_gh(args, check=False):
+            jq = args[args.index("--jq") + 1] if "--jq" in args else ""
+            if "ep-review-bot:prd-review" in jq:
+                return comments.get("prd") or ""
+            if "ep-review-bot:design-review" in jq:
+                return comments.get("design") or ""
+            return ""
+
+        with patch.object(self.hooks, "_gh", side_effect=fake_gh):
+            return self.hooks.check_pr_state(
+                "EP-1",
+                {"labels": ["rfe-creator-auto-reviewed"], "headRefOid": "abc12345deadbeef"},
+                mode="resolve", work_dir=".", skill_name=skill_name,
+            )
+
+    def test_tag_only_comment_with_matching_sha_is_already_reviewed(self):
+        body = "## AI EP Review: x\n<!-- ep-review-bot:prd-review -->\n<!-- sha:abc12345 -->\n"
+        self.assertIsNotNone(self._check(body))
+
+    def test_placeholder_tag_without_sha_is_not_already_reviewed(self):
+        body = "## AI EP Review: Review in progress…\n<!-- ep-review-bot:prd-review -->\n"
+        self.assertIsNone(self._check(body))
+
+    def test_completed_prd_does_not_block_failed_design_retry(self):
+        # PRD review completed (its comment holds the current SHA); the design
+        # review failed at the same SHA, leaving only a no-SHA placeholder. The
+        # design retry must NOT see the PRD comment as its own completed review.
+        prd_done = ("## AI EP Review: x\n<!-- ep-review-bot:prd-review -->\n"
+                    "<!-- sha:abc12345 -->\n")
+        design_placeholder = ("## AI Design Review: Analyzing changes…\n"
+                              "<!-- ep-review-bot:design-review -->\n")
+        result = self._check_scoped(
+            {"prd": prd_done, "design": design_placeholder},
+            skill_name="design-review",
+        )
+        self.assertIsNone(result)
+
+    def test_completed_prd_is_recognized_for_prd_retry(self):
+        prd_done = ("## AI EP Review: x\n<!-- ep-review-bot:prd-review -->\n"
+                    "<!-- sha:abc12345 -->\n")
+        result = self._check_scoped(
+            {"prd": prd_done, "design": None}, skill_name="prd-review",
+        )
+        self.assertIsNotNone(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## [OSAC-4470](https://redhat.atlassian.net/browse/OSAC-4470): Upsert the EP review comment (progress placeholder + in-place update)

### Problem

The EP review bot posted a **brand-new PR comment on every run**. On a PR with several pushes this left a pile of stale review comments — the "too verbose / new comment each time" complaint. The only thing preventing duplicates was `check_pr_state`, which merely *skipped* posting on the same SHA; it never edited or collapsed old comments, so any new push spawned another comment.

### What this does

Keep **one comment per review type** and **update it in place** (CodeRabbit-style), located by a stable invisible HTML tag embedded in the body:

- `<!-- ep-review-bot:prd-review -->`
- `<!-- ep-review-bot:design-review -->`

PRD and Design reviews remain **separate** comments, each updated independently. All GitHub calls stay on the `gh` CLI.

### The comment lifecycle — what gets posted

For each review type on a PR, the bot maintains a single comment that moves through these states:

1. **Review in progress** — posted immediately, before the (slow) model review starts, so the PR shows instant feedback:

   > ## AI EP Review: Analyzing changes…
   > **Status:** Review in progress
   >
   > The automated review is analyzing the updated document. This comment will be replaced with the full results (scores, findings, and structural notes) as soon as the run completes.

2. **Full review** — the *same* comment is edited in place when the review finishes: score table, verdict (PASS/FAIL), feature key, findings by severity, and structural notes (unchanged from today's format, just now an in-place update).

3. **Failure note** — if the review errors after the placeholder was posted, the *same* comment is updated so it doesn't sit on "in progress":

   > ## AI EP Review: Review failed
   > **Status:** Failed
   >
   > The automated review encountered an error and did not complete. It will retry on the next push.

On the next push (new SHA), the bot finds its existing tagged comment and edits it again — no new comment. A re-run on the **same** SHA is still skipped by `check_pr_state` (same-SHA dedup).

### How it finds the comment

`_find_comment_id` queries the PR's comments and matches on **both** the bot login and the hidden tag, then PATCHes that comment (`gh api --method PATCH .../issues/comments/{id}`); if none is found it creates one (`gh pr comment`). The comment body is written to a temp file and passed via `-F body=@FILE` / `--body-file`, which reads it verbatim and sidesteps shell/JSON escaping of the markdown.

### Robustness

- **Progress/failure publication is best-effort.** It flows through `_post_status`, which swallows and logs any `gh` error, so a comment API hiccup can **never** abort the actual review before it produces a verdict.
- **The final review comment stays strict.** `apply_labels` calls the upsert directly with `check=True`, so a genuine failure to post the real result still fails CI.
- **Per-type same-SHA dedup.** `check_pr_state` is scoped to the specific review type's tag. Previously a completed PRD review (whose comment carried the current SHA) could make a *failed* design-review retry wrongly skip; now each type only matches its own tagged comment.
- The placeholder deliberately carries the tag but **no** `<!-- sha:XXXX -->` marker and adds **no** reviewed label, so it is never mistaken for "already reviewed at this SHA" — the real review still runs and overwrites it.

### Rollout note

Production runs with `EP_REVIEW_SHADOW` controlling whether comments are actually posted; shadow mode remains a no-op for all new logic. One-time migration caveat: on an already-open PR that has a *pre-tag* comment, the first run under this change posts one fresh tagged comment (the old untagged one is left as-is); every run after that updates in place. New/first-time-reviewed PRs are clean from the start.

### Tests

`test_ep_hooks.py` adds coverage for the tag helper, upsert PATCH-vs-create paths, placeholder/failure bodies (tag present, no SHA, no label), shadow no-op, per-type dedup scoping, and that a raising `gh` during status publication does not propagate. Full suite: 168 tests pass (`python3 -m unittest discover -s .github/scripts -p "test_*ep*.py"`).

Assisted-by: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Review comments now update in place instead of creating duplicates.
  - Progress and failure statuses are displayed more clearly during automated reviews.
  - Review status tracking is separated by review type, allowing independent retries.
  - Logistics-only and final review updates now use consistent comment handling.
  - Shadow-mode behavior and publishing failures are handled more reliably.
- **Testing**
  - Expanded coverage for comment creation, updates, labeling, status reporting, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->