### PR TITLE
OSAC-3046: PRD - Per-Service Enablement (CaaS/VMaaS/BMaaS/MaaS)

### DIFF
--- a/enhancements/OSAC-3046-per-service-enablement/clarifications.md
+++ b/enhancements/OSAC-3046-per-service-enablement/clarifications.md
@@ -1,0 +1,164 @@
+# Clarification Log — OSAC-3046
+
+## Status
+
+- Rounds completed: 2
+- Open gaps: 4
+- Exit criteria met: Yes (with accepted open items marked TBD for the PRD)
+
+## Round 1 — Service Dependencies & Scope
+
+### R1.Q1: Inter-service dependencies when a service is disabled
+
+CaaS relies on BMaaS for clusters on bare metal (HostTypes with physical network interfaces) and on VMaaS for clusters on VMs (HostTypes without interfaces). If a Cloud Provider Admin disables BMaaS, should CaaS cluster provisioning on bare metal hosts be blocked, or should CaaS still be available but limited to host types that don't depend on the disabled service?
+
+#### Answer
+
+When a service is disabled, no other enabled service can provision resources that would depend on it. CaaS with only virtual HostTypes available would still work when BMaaS is disabled, but bare-metal HostTypes would be blocked. Same for VMaaS — disabling it blocks virtual HostTypes for CaaS. The rationale is compliance: if BMaaS is disabled to exclude it from the compliance surface, CaaS shouldn't be able to provision bare-metal-backed clusters as a side door around that boundary.
+
+#### Impact
+
+The PRD must define the inter-service dependency model: disabled services block dependent resource types in other services. The design will need to specify how HostType filtering works based on enabled services.
+
+#### Decision (D1)
+
+When a service is disabled, no enabled service may provision resources that depend on the disabled service. CaaS with BMaaS disabled blocks bare-metal HostTypes but allows virtual HostTypes (and vice versa for VMaaS).
+
+---
+
+### R1.Q2: Post-installation disablement
+
+The Definition of Done requires "post-installation enablement of additional services." Is post-installation disablement also in scope? If yes, what happens to existing resources when their service is disabled?
+
+#### Answer
+
+Unanswered. Liat Gamliel asked this exact question in the Jira on Aug 19 but it was not answered. The Definition of Done only mentions enablement, not disablement.
+
+#### Impact
+
+The PRD will mark post-installation disablement as TBD. The feature covers enablement at install time and post-installation enablement of additional services.
+
+---
+
+### R1.Q3: Service list completeness
+
+Are networking and storage considered always-on shared infrastructure, or could a deployment disable them independently?
+
+#### Answer
+
+Juan Hernandez's feasibility report in the Jira comments explicitly states: "The remaining services (Tenants, Projects, Users, Roles, Secrets, networking resources, storage resources, Events, Capabilities, etc.) are shared infrastructure and would remain always-on regardless of which features are enabled." The four toggleable services are CaaS, VMaaS, BMaaS, and MaaS.
+
+#### Impact
+
+The PRD scope is limited to four toggleable services. Shared infrastructure (networking, storage, tenants, etc.) is always-on.
+
+#### Decision (D2)
+
+The four toggleable services are CaaS, VMaaS, BMaaS, and MaaS. Networking, storage, tenants, and other platform services are shared infrastructure and always remain enabled.
+
+---
+
+### R1.Q4: Compliance Admin persona
+
+The user stories reference a "Compliance Admin" who needs compliance posture scoped to enabled services. OSAC's canonical personas are Cloud Provider Admin, Cloud Infrastructure Admin, Tenant Admin, and Tenant User. Is "Compliance Admin" a new persona or does it map to an existing one?
+
+#### Answer
+
+Unanswered. Left open — not immediately relevant to the PRD. A question has been flagged for posting to the Jira.
+
+#### Impact
+
+The PRD will use the Jira's original "Compliance Admin" wording with a note that the persona mapping is TBD.
+
+---
+
+### R1.Q5: Compliance integration depth
+
+Is this feature responsible for implementing compliance scoping (conditional scan profiles, filtered dashboards), or limited to providing the enablement signal that downstream features consume?
+
+#### Answer
+
+There is no compliance scoping mechanism in the codebase today. No `enabled_features` proto fields, no compliance scan profiles, no feature flag infrastructure exist. The compliance scanning features (OSAC-3029 for CaaS Compliance Operator, OSAC-3031 for RHEL OpenSCAP) also don't exist in code yet. This feature provides the enablement configuration and exposes it via the Capabilities endpoint. Downstream compliance features consume that signal to scope their scanning.
+
+#### Impact
+
+The PRD scopes compliance integration to: (1) providing the enabled-services configuration, and (2) exposing it via the Capabilities endpoint. Actual compliance scanning scoped to enabled services is a dependency on OSAC-3018, OSAC-3029, and OSAC-3031.
+
+#### Decision (D3)
+
+This feature provides the enablement signal (configuration + Capabilities endpoint). Compliance scanning scoped to enabled services is the responsibility of downstream features (OSAC-3018, OSAC-3029, OSAC-3031), which consume the signal.
+
+---
+
+## Round 2 — Cross-Component Propagation & User Experience
+
+### R2.Q1: Configuration source of truth
+
+Should there be a single source of truth for enablement (e.g., Helm values), or can each layer be configured independently? Can enablement be changed post-installation without a Helm upgrade?
+
+#### Answer
+
+Helm values are the source of truth. The installer already has per-component `enabled` flags (e.g., `bmf.enabled`, `ui.enabled`, `metering.enabled`). Helm templates propagate these to runtime config via container args or environment variables. The fulfillment-service's Capabilities endpoint serves as the read API for clients (UI, CLI) to discover enabled services at runtime. Post-installation changes require `helm upgrade` with updated values.
+
+#### Impact
+
+The PRD defines Helm values as the configuration surface. The Capabilities endpoint is the runtime discovery mechanism. Day-2 enablement changes go through `helm upgrade`, not through the API.
+
+#### Decision (D4)
+
+Helm values are the source of truth for service enablement. The Capabilities endpoint is the read-only runtime API for clients to discover enabled services. Post-installation changes require `helm upgrade`.
+
+---
+
+### R2.Q2: Enclave wizard alignment
+
+The Enclave wizard has "experiences" that select services at install time. Should this feature integrate with that mechanism, replace it, or run alongside it?
+
+#### Answer
+
+Unanswered. Left open for design phase.
+
+#### Impact
+
+The PRD will note the Enclave wizard "experiences" as a related mechanism and flag alignment as a design-phase concern.
+
+---
+
+### R2.Q3: UI behavior for disabled services
+
+When a service is disabled, should its UI pages be completely hidden or shown as disabled/grayed-out?
+
+#### Answer
+
+Unanswered. Left open for design phase.
+
+#### Impact
+
+The PRD will state that the UI must not expose disabled services but defer the specific UX treatment to the design phase.
+
+---
+
+### R2.Q4: Operator controllers for disabled services
+
+When a service is disabled, should its controllers not be deployed at all, or deployed but idle?
+
+#### Answer
+
+The Jira Feature Goal states "Disabled services are fully excluded -- no APIs, no controllers, no compliance scope" and the Definition of Done states "Disabled services have no running controllers, APIs, or UI surfaces." Controllers for disabled services should not be running.
+
+#### Impact
+
+The PRD requires that disabled services have no running controllers, consistent with the Jira.
+
+#### Decision (D5)
+
+Disabled services must have no running controllers, APIs, or UI surfaces — they are fully excluded from the deployment.
+
+---
+
+## Remaining Gaps
+
+- **Post-installation disablement** (R1.Q2): Whether disabling a service after installation is in scope, and what happens to existing resources. Unanswered in Jira.
+- **Compliance Admin persona** (R1.Q4): Whether "Compliance Admin" maps to an existing OSAC persona or is new. Flagged for Jira follow-up.
+- **Enclave wizard alignment** (R2.Q2): How Enclave "experiences" relate to the per-service enablement flags. Deferred to design phase.
+- **UI behavior for disabled services** (R2.Q3): Whether disabled service UI is hidden or shown as unavailable. Deferred to design phase.

--- a/enhancements/OSAC-3046-per-service-enablement/prd.md
+++ b/enhancements/OSAC-3046-per-service-enablement/prd.md
@@ -8,12 +8,12 @@
 
 ## Problem Statement
 
-OSAC deploys all services (CaaS, VMaaS, BMaaS, MaaS) unconditionally. Deployments that only need a subset — for example, a CaaS-only site — still run controllers, expose APIs, and carry the compliance burden for services they do not use. This increases operational complexity and widens the compliance surface area: a deployment that does not provision bare metal hosts must still satisfy BMaaS-specific attestation controls (UEFI Secure Boot, TPM 2.0) during audits.
+OSAC deploys all services (CaaS, VMaaS, BMaaS, MaaS) unconditionally. Deployments that only need a subset — for example, a CaaS-only site — still carry the compliance burden and operational overhead for services they do not use. This widens the compliance surface area: a deployment that does not provision bare metal hosts must still satisfy BMaaS-specific attestation controls (UEFI Secure Boot, TPM 2.0) during audits.
 
 ## In Scope
 
 - Cloud Provider Admins select which services are active at installation time via Helm values.
-- Disabled services are fully excluded: no running controllers, no registered APIs, no UI surfaces.
+- Disabled services are not accessible — no API endpoints, no UI surfaces, no provisioning capability.
 - Post-installation enablement of additional services via `helm upgrade`.
 - The Capabilities endpoint advertises which services are currently enabled so that clients (CLI, UI) can adapt. [Clarify: R1.Q5]
 - When a service is disabled, other enabled services cannot provision resources that depend on it (e.g., disabling BMaaS blocks bare-metal-backed CaaS cluster host types). [Clarify: R1.Q1]
@@ -37,7 +37,7 @@ OSAC deploys all services (CaaS, VMaaS, BMaaS, MaaS) unconditionally. Deployment
 
 ### Cloud Infrastructure Admin
 
-- As a Cloud Infrastructure Admin, I want the platform to block provisioning of resources that depend on a disabled service (e.g., bare-metal host types when BMaaS is disabled) so that the compliance boundary is enforced at the infrastructure level, not just the API level. [Clarify: R1.Q1]
+- As a Cloud Infrastructure Admin, I want the platform to block provisioning of resources that depend on a disabled service (e.g., bare-metal host types when BMaaS is disabled) so that the compliance boundary cannot be bypassed. [Clarify: R1.Q1]
 
 ### Tenant Admin / Tenant User
 

--- a/enhancements/OSAC-3046-per-service-enablement/prd.md
+++ b/enhancements/OSAC-3046-per-service-enablement/prd.md
@@ -1,0 +1,57 @@
+# Per-Service Enablement (CaaS/VMaaS/BMaaS/MaaS)
+
+| Field       | Value   |
+|-------------|---------|
+| Author(s)   | Haim Tayrie |
+| Jira        | https://redhat.atlassian.net/browse/OSAC-3046 |
+| Date        | 2026-08-25 |
+
+## Problem Statement
+
+OSAC deploys all services (CaaS, VMaaS, BMaaS, MaaS) unconditionally. Deployments that only need a subset — for example, a CaaS-only site — still run controllers, expose APIs, and carry the compliance burden for services they do not use. This increases operational complexity and widens the compliance surface area: a deployment that does not provision bare metal hosts must still satisfy BMaaS-specific attestation controls (UEFI Secure Boot, TPM 2.0) during audits. Both the MOC 2.0 program and the Telenor engagement require the ability to tailor deployments to only the services they need. [Jira: OSAC-3046, comment by @Bradford Nichols]
+
+## In Scope
+
+- Cloud Provider Admins select which services are active at installation time via Helm values.
+- Disabled services are fully excluded: no running controllers, no registered APIs, no UI surfaces.
+- Post-installation enablement of additional services via `helm upgrade`.
+- The Capabilities endpoint advertises which services are currently enabled so that clients (CLI, UI) can adapt. [Clarify: R1.Q5]
+- When a service is disabled, other enabled services cannot provision resources that depend on it (e.g., disabling BMaaS blocks bare-metal-backed CaaS cluster host types). [Clarify: R1.Q1]
+
+## Out of Scope
+
+- Post-installation **disablement** of services and the lifecycle of existing resources when a service is turned off — unanswered in requirements and deferred pending stakeholder input. [Clarify: R1.Q2]
+- Compliance scanning and reporting scoped to enabled services — this feature provides the enablement signal; actual scan-profile scoping is the responsibility of OSAC-3029 (ACM Compliance Policies) and OSAC-3031 (OpenSCAP/Insights Compliance). [Clarify: R1.Q5]
+- Disabling shared infrastructure (networking, storage, tenants, identity, events). These remain always-on regardless of which services are enabled. [Clarify: R1.Q3]
+- Alignment between the Enclave wizard "experiences" mechanism and per-service enablement — requires cross-team discussion to determine whether experiences drive the Helm enablement values, are replaced by them, or run alongside them. [Clarify: R2.Q2]
+
+## User Stories
+
+### Cloud Provider Admin
+
+- As a Cloud Provider Admin, I want to choose which services (CaaS, VMaaS, BMaaS, MaaS) are active when I install OSAC so that my deployment only runs what I need and my compliance surface matches my actual service offering.
+
+- As a Cloud Provider Admin, I want to enable additional services after installation so that I can expand my deployment as demand grows without reinstalling.
+
+- As a Cloud Provider Admin, I want to see which services are currently enabled so that I can verify my deployment configuration.
+
+### Cloud Infrastructure Admin
+
+- As a Cloud Infrastructure Admin, I want the platform to block provisioning of resources that depend on a disabled service (e.g., bare-metal host types when BMaaS is disabled) so that the compliance boundary is enforced at the infrastructure level, not just the API level. [Clarify: R1.Q1]
+
+### Tenant Admin / Tenant User
+
+- As a Tenant Admin or Tenant User, I want the catalog, UI, and CLI to only show resource types for enabled services so that I am not confused by options that would fail if I tried to use them.
+
+## Dependencies
+
+- **OSAC-3018 (HIPAA Compliance Readiness) and OSAC-2889 (EU Sovereignty & Compliance Readiness):** Both outcomes depend on per-service enablement to scope compliance to enabled services only. This feature provides the enablement signal they consume.
+- **OSAC-3029 (ACM Compliance Policies) and OSAC-3031 (OpenSCAP/Insights Compliance):** Responsible for scoping compliance scanning to enabled services, consuming the enablement configuration this feature provides. [Clarify: R1.Q5]
+
+---
+
+## Provenance
+
+Authored: draft @ prd 0.8.0 - 7efcedb, workspace main @ 4bfc214
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"7efcedb","source_repo":"4bfc214","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-3046-per-service-enablement/prd.md
+++ b/enhancements/OSAC-3046-per-service-enablement/prd.md
@@ -8,7 +8,7 @@
 
 ## Problem Statement
 
-OSAC deploys all services (CaaS, VMaaS, BMaaS, MaaS) unconditionally. Deployments that only need a subset — for example, a CaaS-only site — still carry the compliance burden and operational overhead for services they do not use. This widens the compliance surface area: a deployment that does not provision bare metal hosts must still satisfy BMaaS-specific attestation controls (UEFI Secure Boot, TPM 2.0) during audits.
+NIST SP 800-53 CM-7 (Least Functionality) requires organizations to "identify unnecessary functions, ports, protocols, software, and services; and disable or remove them." OSAC deploys all services (CaaS, VMaaS, BMaaS, MaaS) unconditionally, making it impossible to satisfy this control for unused services. Deployments that only need a subset — for example, a CaaS-only site — still carry the compliance burden and operational overhead for services they do not use: a deployment that does not provision bare metal hosts must still satisfy BMaaS-specific attestation controls (UEFI Secure Boot, TPM 2.0) during audits.
 
 ## In Scope
 

--- a/enhancements/OSAC-3046-per-service-enablement/prd.md
+++ b/enhancements/OSAC-3046-per-service-enablement/prd.md
@@ -8,7 +8,7 @@
 
 ## Problem Statement
 
-OSAC deploys all services (CaaS, VMaaS, BMaaS, MaaS) unconditionally. Deployments that only need a subset — for example, a CaaS-only site — still run controllers, expose APIs, and carry the compliance burden for services they do not use. This increases operational complexity and widens the compliance surface area: a deployment that does not provision bare metal hosts must still satisfy BMaaS-specific attestation controls (UEFI Secure Boot, TPM 2.0) during audits. Both the MOC 2.0 program and the Telenor engagement require the ability to tailor deployments to only the services they need. [Jira: OSAC-3046, comment by @Bradford Nichols]
+OSAC deploys all services (CaaS, VMaaS, BMaaS, MaaS) unconditionally. Deployments that only need a subset — for example, a CaaS-only site — still run controllers, expose APIs, and carry the compliance burden for services they do not use. This increases operational complexity and widens the compliance surface area: a deployment that does not provision bare metal hosts must still satisfy BMaaS-specific attestation controls (UEFI Secure Boot, TPM 2.0) during audits.
 
 ## In Scope
 


### PR DESCRIPTION
## PRD: Per-Service Enablement (CaaS/VMaaS/BMaaS/MaaS)

**Jira:** https://redhat.atlassian.net/browse/OSAC-3046

### Summary

Cloud Provider Admins can select which OSAC services (CaaS, VMaaS, BMaaS, MaaS) are active at installation time via Helm values. Disabled services are fully excluded — no APIs, no controllers, no UI surfaces. The Capabilities endpoint advertises enabled services so clients can adapt. Inter-service dependencies are enforced: disabling a service blocks dependent resource types in other services.

### Requesting Review On
- Requirements completeness and accuracy
- Scope (in scope and out of scope)
- User stories coverage across personas
- Open items: post-installation disablement, Compliance Admin persona mapping, Enclave wizard alignment, UI behavior for disabled services

### How to Review
- Comment inline on specific sections
- Review the clarifications log for the reasoning behind key decisions (D1-D5)
- Approve when the PRD accurately reflects the agreed requirements
