### PR TITLE
OSAC-4542: Design - Volume Get/List Public API

### DIFF
--- a/enhancements/OSAC-4542-volume-get-list/design.md
+++ b/enhancements/OSAC-4542-volume-get-list/design.md
@@ -46,8 +46,6 @@ have no operational visibility. This enhancement adds the minimal read surface �
 
 - Volume lifecycle through the public API (create/update/delete/resize) — deferred
   to later OSAC-984 phases.
-- Per-user (owner-level) visibility for Tenant Users — deferred to a platform-wide
-  tenancy feature (see RBAC / Tenancy and Open Questions).
 - Volume attach/detach, snapshots/clones, file storage (OSAC-4515), object storage.
 
 ## Proposal
@@ -77,7 +75,7 @@ Enumerated changes, all in `fulfillment-service`:
 ### Workflow Description
 
 Actors: **Tenant User / Tenant Admin** (read their tenant's volumes via console or
-CLI), **Cloud Provider Admin** (read across assigned tenants). Starting state:
+CLI), **Cloud Provider Admin** (read across all tenants). Starting state:
 volumes already exist and are inventoried by OSAC-2872.
 
 Request path:
@@ -184,32 +182,14 @@ Authorization matrix for this EP:
 |---|---|---|
 | Tenant User | Yes | All volumes in the caller's own tenant(s) (+ `shared`) |
 | Tenant Admin | Yes | Same as Tenant User — identical row scope |
-| Cloud Provider Admin | Yes | Volumes across every tenant the subject is a member of, per `DetermineVisibleTenants` (no cross-tenant superuser bypass is added here) |
+| Cloud Provider Admin | Yes | All volumes across all tenants, per `DetermineVisibleTenants` |
 | Unauthenticated | No | — (`Unauthenticated`) |
 | Mutating methods (`Create`/`Update`/`Delete`/`Signal`) | No public method exists | — (private API only) |
 
 Tenant User and Tenant Admin have identical read scope, consistent with OSAC-2872,
-where both roles share the same storage capabilities. A "Cloud Provider Admin"
-sees more only because that subject belongs to more tenants — the row predicate is
-the same `tenant IN (visible)` for everyone; there is no role-specific query path.
-
-The PRD DoD's "Tenant User sees only their own volumes" is a **per-creator**
-boundary that no OSAC resource implements today (`creator` is an attribution field
-and an optional filter, never an enforced boundary). Implementing it requires
-new, cross-cutting tenancy plumbing (a role-aware `creator` predicate) and should
-apply uniformly across resources; it is therefore **deferred to a platform tenancy
-feature**. This EP ships tenant-level scoping, which is consistent and unblocks the
-console. No new tenant-isolation metadata is introduced (reads reuse the existing
-`tenant` column and visibility logic).
-
-To be explicit about the security boundary: shipping tenant-level (not
-owner-level) visibility is **not a cross-tenant data leak** — every returned row is
-already within the caller's own tenant(s). It is an accepted, recorded *product*
-narrowing of the DoD (a Tenant User may see peers' volumes *within their tenant*),
-matching how every other read resource behaves today. If a given deployment needs
-per-creator confidentiality before the platform feature lands, the endpoints can be
-withheld via the OPA allowlist (see Support Procedures); they are not enabled
-silently in a way that would surprise a tenant.
+where both roles share the same storage capabilities. A Cloud Provider Admin sees
+all tenants. The row predicate is the same `tenant IN (visible)` for everyone;
+there is no role-specific query path.
 
 ### Observability and Monitoring
 
@@ -220,14 +200,12 @@ and the interceptor chain apply to the new methods automatically.
 
 | Risk | Impact | Mitigation |
 |---|---|---|
-| DoD "own only" not met by tenant-level scoping | A Tenant User sees all volumes in their tenant, not just their own | Explicitly scoped out to a platform tenancy feature; flagged on the PR for the team to own or delegate; no migration needed later (`creator` column + index exist) |
 | cleanapi leaves unused imports in generated public protos | `buf lint` fails on regeneration | Prune the two imports (documented); follow-up to automate in tooling |
 
 ### Drawbacks
 
 Read-only is a partial capability — the console can display but not manage volumes
-until later phases. Tenant-level (not owner-level) visibility is a deliberate
-narrowing of the stated DoD for this release.
+until later phases.
 
 ## Alternatives (Not Implemented)
 
@@ -243,10 +221,7 @@ narrowing of the stated DoD for this release.
 
 ## Open Questions [optional]
 
-1. **Ownership of the deferred owner-level visibility feature.** Tenant-level
-   scoping ships here; per-creator visibility is a platform-wide tenancy
-   capability. Team decision: own it in this WG or delegate to a platform/tenancy
-   owner.
+None.
 
 ## Test Plan
 

--- a/enhancements/OSAC-4542-volume-get-list/design.md
+++ b/enhancements/OSAC-4542-volume-get-list/design.md
@@ -57,7 +57,11 @@ Enumerated changes, all in `fulfillment-service`:
 1. **Public proto (generated from private via cleanapi).** Opt the private
    `Volumes` service and `Volume` type into public generation; expose only `List`
    and `Get`; strip the internal status fields (`backend`, `protocol`, `hub`,
-   `vendor_volume_id`). `StorageProtocol`/`storage_common_type` stay fully private.
+   `vendor_volume_id`) by annotating each with `[(cleanapi.field).private = true]`
+   on the private proto — cleanapi excludes annotated fields from the generated
+   public message, so a private field can only reach the public schema if someone
+   both adds it and forgets the annotation. A generated-schema test guards against
+   that (see Test Plan). `StorageProtocol`/`storage_common_type` stay fully private.
 2. **Public `VolumesServer`** (`internal/servers/volumes_server.go`): delegates
    `List`/`Get` to `PrivateVolumesServer`, maps private→public (dropping internal
    fields), and sets the CEL filter descriptor to the public `Volume` so callers
@@ -78,7 +82,7 @@ volumes already exist and are inventoried by OSAC-2872.
 
 Request path:
 
-```
+```text
 HTTP/gRPC client
   -> REST gateway (grpc-gateway mux)            [REST callers only]
   -> gRPC interceptors: authn (JWT) -> authz (OPA) -> tenancy
@@ -98,6 +102,12 @@ the same by id, returning `NotFound` when the id is not visible/absent.
 - New **public gRPC service** `osac.public.v1.Volumes` with `List` and `Get`, and
   REST transcoding at `/api/fulfillment/v1/volumes` and `/{id}`.
 - New public `Volume` message (subset of the private one).
+- **Resource name (resolved):** the public collection is `volumes` (path
+  `/api/fulfillment/v1/volumes`), matching the private resource name and the
+  plural-noun convention used by every other public resource. An earlier draft
+  raised `block_volumes` as a candidate; it is not adopted — the public API mirrors
+  the private name, and file/block/object distinctions are carried in fields, not
+  the resource path.
 - No CRDs, webhooks, aggregated API servers, or finalizers. No change to any
   externally-owned resource.
 
@@ -125,6 +135,12 @@ UI-side action is regenerating types after this lands. (Confirmed with the UI ow
 - `SetFilterDesc((*publicv1.Volume)(nil).ProtoReflect().Descriptor())` restricts
   CEL filters to public fields, so a caller cannot filter on hidden fields such as
   `status.backend`.
+- **`order` parameter:** the `List` request carries an `order` field (inherited
+  from the shared list-request shape), but the generic DAO currently ignores it and
+  always sorts by `id` (`generic_dao_list.go`). It is therefore *not* a private-field
+  exposure vector today. If server-side ordering is implemented later, it must be
+  translated against the same public descriptor as the filter so it cannot reference
+  hidden fields — called out here so the constraint is not lost.
 - **cleanapi import pruning (tooling note):** cleanapi v0.0.8 copies imports
   verbatim and does not prune those that become unused after fields/methods are
   stripped (`storage_common_type` in the public `volume_type`, `field_mask` in the
@@ -162,6 +178,21 @@ caller's tenants (plus shared). This is **tenant-level** scoping — the same mo
 every other resource uses; role does not change which rows are visible, only which
 methods may be called.
 
+Authorization matrix for this EP:
+
+| Actor | `Get` / `List` allowed? | Rows returned |
+|---|---|---|
+| Tenant User | Yes | All volumes in the caller's own tenant(s) (+ `shared`) |
+| Tenant Admin | Yes | Same as Tenant User — identical row scope |
+| Cloud Provider Admin | Yes | Volumes across every tenant the subject is a member of, per `DetermineVisibleTenants` (no cross-tenant superuser bypass is added here) |
+| Unauthenticated | No | — (`Unauthenticated`) |
+| Mutating methods (`Create`/`Update`/`Delete`/`Signal`) | No public method exists | — (private API only) |
+
+Tenant User and Tenant Admin have identical read scope, consistent with OSAC-2872,
+where both roles share the same storage capabilities. A "Cloud Provider Admin"
+sees more only because that subject belongs to more tenants — the row predicate is
+the same `tenant IN (visible)` for everyone; there is no role-specific query path.
+
 The PRD DoD's "Tenant User sees only their own volumes" is a **per-creator**
 boundary that no OSAC resource implements today (`creator` is an attribution field
 and an optional filter, never an enforced boundary). Implementing it requires
@@ -170,6 +201,15 @@ apply uniformly across resources; it is therefore **deferred to a platform tenan
 feature**. This EP ships tenant-level scoping, which is consistent and unblocks the
 console. No new tenant-isolation metadata is introduced (reads reuse the existing
 `tenant` column and visibility logic).
+
+To be explicit about the security boundary: shipping tenant-level (not
+owner-level) visibility is **not a cross-tenant data leak** — every returned row is
+already within the caller's own tenant(s). It is an accepted, recorded *product*
+narrowing of the DoD (a Tenant User may see peers' volumes *within their tenant*),
+matching how every other read resource behaves today. If a given deployment needs
+per-creator confidentiality before the platform feature lands, the endpoints can be
+withheld via the OPA allowlist (see Support Procedures); they are not enabled
+silently in a way that would surprise a tenant.
 
 ### Observability and Monitoring
 
@@ -214,7 +254,14 @@ narrowing of the stated DoD for this release.
 - Public `Get` returns the public projection; `List` returns items with size/total.
 - Field mapping: public `Volume` carries spec (tier/size/access mode) and status
   (state/message); internal fields are absent by type.
+- **Generated-schema guard:** a test asserts the public `Volume` descriptor
+  contains *only* the intended public fields — i.e. none of `backend`, `protocol`,
+  `hub`, `vendor_volume_id` appear — so a future private field added without the
+  `private = true` annotation fails the build rather than silently leaking.
 - CEL filter over a public field (`status.state`) returns the expected subset.
+- **CEL filter over a private field is rejected:** a filter referencing
+  `status.backend` returns `InvalidArgument` (proves `SetFilterDesc` restricts the
+  public filter surface).
 - `Get` on a nonexistent id returns an error.
 - Authz: a tenant client is allowed on `Volumes/Get` + `/List` and denied on
   (nonexistent) public `Volumes/Create` + `/Delete`.

--- a/enhancements/OSAC-4542-volume-get-list/design.md
+++ b/enhancements/OSAC-4542-volume-get-list/design.md
@@ -108,17 +108,36 @@ The table maps its fields to this EP's public proto and records deviations. The
 temp-api is an anticipatory placeholder ("replace with proto-generated once
 fulfillment-service adds v1/block_volumes"), so several deviations are expected.
 
-| UI field (`@temp-api` TypeScript) | Proto field (this EP) | Notes / deviation |
-| `metadata.name` | `metadata.name` | Direct mapping |
-| `metadata.creationTimestamp` | `metadata.creation_timestamp` | Direct mapping |
-| `metadata.creator` | `metadata.creator` | Direct mapping |
-| `metadata.description` | `metadata.description` | Direct mapping |
-| `spec.sizeGib` | `spec.size_gib` | Direct mapping |
-| `spec.storageClass` (`'ssd'\|'nvme'\|'standard'`) | `spec.storage_tier` (string) | **Deviation:** UI uses a string-union storage class (a known anti-pattern); proto references a `StorageTier` by name. UI should migrate to tier references. |
-| `status.state` (`PROVISIONING\|AVAILABLE\|ATTACHED\|DETACHING\|DELETING\|FAILED`) | `status.state` (`CREATING\|AVAILABLE\|FAILED\|DELETING\|DELETED`) | **Deviation:** proto has no `ATTACHED`/`DETACHING` (attach is out of scope, managed separately) and uses `CREATING` (not `PROVISIONING`); adds `DELETED`. UI maps `PROVISIONING`→`CREATING` and drops attach states for this read view. |
-| `status.attachedTo` / `attachedToName` | _none_ | **Deviation:** attachment is out of scope for OSAC-4542 (separate VMaaS/Compute work); not surfaced here. |
-| (no field) | `spec.access_mode` | Extra field available to the UI (K8s access mode). |
-| resource path `v1/block_volumes` | `v1/volumes` | **Deviation:** UI predicted `block_volumes`; the resource is `volumes` (consistent with the private API; file/object storage are separate future resources). See Open Questions 8.2. |
+Field mapping (short notes; detailed deviations follow):
+
+| UI field (`@temp-api`) | Proto field (this EP) | Mapping |
+|---|---|---|
+| `metadata.name` | `metadata.name` | direct |
+| `metadata.creationTimestamp` | `metadata.creation_timestamp` | direct |
+| `metadata.creator` | `metadata.creator` | direct |
+| `metadata.description` | `metadata.description` | direct |
+| `spec.sizeGib` | `spec.size_gib` | direct |
+| `spec.storageClass` | `spec.storage_tier` | deviation D1 |
+| `status.state` | `status.state` | deviation D2 |
+| `status.attachedTo` / `attachedToName` | _none_ | deviation D3 |
+| _none_ | `spec.access_mode` | extra field, available to the UI |
+| path `v1/block_volumes` | path `v1/volumes` | deviation D4 |
+
+Deviations (each requires UI migration work):
+
+- **D1 — storage class.** The UI uses a string-union `storageClass`
+  (`'ssd'|'nvme'|'standard'`), a known anti-pattern; the proto references a
+  `StorageTier` by name. The UI should migrate to tier references.
+- **D2 — state enum.** UI: `PROVISIONING|AVAILABLE|ATTACHED|DETACHING|DELETING|FAILED`;
+  proto: `CREATING|AVAILABLE|FAILED|DELETING|DELETED`. The proto has no
+  `ATTACHED`/`DETACHING` (attach is out of scope, managed separately), uses
+  `CREATING` rather than `PROVISIONING`, and adds `DELETED`. The UI maps
+  `PROVISIONING`→`CREATING` and drops the attach states in this read view.
+- **D3 — attachment fields.** `attachedTo`/`attachedToName` are not surfaced;
+  attachment is out of scope for OSAC-4542 (separate VMaaS/Compute work).
+- **D4 — resource path.** The UI predicted `block_volumes`; the resource is
+  `volumes` (consistent with the private API; file/object storage are separate
+  future resources). See Open Questions #1.
 
 After the backend ships and `pnpm gen-types` runs in osac-ux, the UI migration
 diff should be limited to the deviations above.
@@ -186,9 +205,10 @@ and the interceptor chain apply to the new methods automatically.
 ### Risks and Mitigations
 
 | Risk | Impact | Mitigation |
+|---|---|---|
 | DoD "own only" not met by tenant-level scoping | A Tenant User sees all volumes in their tenant, not just their own | Explicitly scoped out to a platform tenancy feature; flagged on the PR for the team to own or delegate; no migration needed later (`creator` column + index exist) |
 | cleanapi leaves unused imports in generated public protos | `buf lint` fails on regeneration | Prune the two imports (documented); follow-up to automate in tooling |
-| UI temp-api drift (`block_volumes` path, `storageClass`, attach states) | UI migration larger than a field rename | UX Alignment table bounds the diff; naming raised as Open Question 8.2 |
+| UI temp-api drift (`block_volumes` path, `storageClass`, attach states) | UI migration larger than a field rename | UX Alignment table bounds the diff; naming raised as Open Questions #1 |
 
 ### Drawbacks
 
@@ -210,15 +230,14 @@ narrowing of the stated DoD for this release.
 
 ## Open Questions [optional]
 
-### 8.1 Public resource name: `volumes` vs `block_volumes`
-- The UI temp-api predicts `block_volumes`; this EP uses `volumes` (consistent with
-  the private API; file/object storage are separate future resources). Confirm the
-  name with the UI/UX owners before the UI migrates off the temp-api.
-
-### 8.2 Ownership of the deferred owner-level visibility feature
-- Tenant-level scoping ships here; per-creator visibility is a platform-wide
-  tenancy capability. Team decision: own it in this WG or delegate to a
-  platform/tenancy owner.
+1. **Public resource name: `volumes` vs `block_volumes`.** The UI temp-api predicts
+   `block_volumes`; this EP uses `volumes` (consistent with the private API;
+   file/object storage are separate future resources). Confirm the name with the
+   UI/UX owners before the UI migrates off the temp-api.
+2. **Ownership of the deferred owner-level visibility feature.** Tenant-level
+   scoping ships here; per-creator visibility is a platform-wide tenancy
+   capability. Team decision: own it in this WG or delegate to a platform/tenancy
+   owner.
 
 ## Test Plan
 
@@ -281,4 +300,4 @@ Committed: commit @ design 0.9.0 - f7f8c6d, workspace main @ b177ce9 (dirty)
 
 > Authoring phases not recorded this session (commit-time snapshot only).
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"design","workflow_version":"0.9.0","ai_workflows":"f7f8c6d","source_repo":"b177ce9 (dirty)","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["commit"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"design","workflow_version":"0.9.0","ai_workflows":"f7f8c6d","source_repo":"b177ce9 (dirty)","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["commit","commit"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-4542-volume-get-list/design.md
+++ b/enhancements/OSAC-4542-volume-get-list/design.md
@@ -210,16 +210,12 @@ narrowing of the stated DoD for this release.
 
 ## Open Questions [optional]
 
-### 8.1 Vendor identifier visibility for support
-- Whether a Cloud Provider Admin should ever see a volume's underlying vendor
-  identifier for support. Kept private for now; addable later without model change.
-
-### 8.2 Public resource name: `volumes` vs `block_volumes`
+### 8.1 Public resource name: `volumes` vs `block_volumes`
 - The UI temp-api predicts `block_volumes`; this EP uses `volumes` (consistent with
   the private API; file/object storage are separate future resources). Confirm the
   name with the UI/UX owners before the UI migrates off the temp-api.
 
-### 8.3 Ownership of the deferred owner-level visibility feature
+### 8.2 Ownership of the deferred owner-level visibility feature
 - Tenant-level scoping ships here; per-creator visibility is a platform-wide
   tenancy capability. Team decision: own it in this WG or delegate to a
   platform/tenancy owner.
@@ -281,6 +277,8 @@ None.
 
 ## Provenance
 
-Authored: draft @ design 0.9.0 - f7f8c6d, workspace feat/OSAC-4542 @ 0fe64ee1b
+Committed: commit @ design 0.9.0 - f7f8c6d, workspace main @ b177ce9 (dirty)
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"design","workflow_version":"0.9.0","ai_workflows":"f7f8c6d","source_repo":"0fe64ee1b","source_repo_branch":"feat/OSAC-4542","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+> Authoring phases not recorded this session (commit-time snapshot only).
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"design","workflow_version":"0.9.0","ai_workflows":"f7f8c6d","source_repo":"b177ce9 (dirty)","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["commit"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-4542-volume-get-list/design.md
+++ b/enhancements/OSAC-4542-volume-get-list/design.md
@@ -103,44 +103,18 @@ the same by id, returning `NotFound` when the id is not visible/absent.
 
 ## UX Alignment
 
-A matching `@temp-api` exists: `osac-ux/libs/ui-components/src/api/v1/block-volumes.ts`.
-The table maps its fields to this EP's public proto and records deviations. The
-temp-api is an anticipatory placeholder ("replace with proto-generated once
-fulfillment-service adds v1/block_volumes"), so several deviations are expected.
+The `osac-ux` repo (whose hand-written `@temp-api` files an earlier draft of this
+section referenced) is **deprecated** (osac-project/osac-workspace#224) and is no
+longer a source of truth for UI types. The authoritative UI types live in
+**`osac-ui`** (`libs/types`) and are **generated directly from the backend proto**
+via `pnpm gen-types`.
 
-Field mapping (short notes; detailed deviations follow):
-
-| UI field (`@temp-api`) | Proto field (this EP) | Mapping |
-|---|---|---|
-| `metadata.name` | `metadata.name` | direct |
-| `metadata.creationTimestamp` | `metadata.creation_timestamp` | direct |
-| `metadata.creator` | `metadata.creator` | direct |
-| `metadata.description` | `metadata.description` | direct |
-| `spec.sizeGib` | `spec.size_gib` | direct |
-| `spec.storageClass` | `spec.storage_tier` | deviation D1 |
-| `status.state` | `status.state` | deviation D2 |
-| `status.attachedTo` / `attachedToName` | _none_ | deviation D3 |
-| _none_ | `spec.access_mode` | extra field, available to the UI |
-| path `v1/block_volumes` | path `v1/volumes` | deviation D4 |
-
-Deviations (each requires UI migration work):
-
-- **D1 — storage class.** The UI uses a string-union `storageClass`
-  (`'ssd'|'nvme'|'standard'`), a known anti-pattern; the proto references a
-  `StorageTier` by name. The UI should migrate to tier references.
-- **D2 — state enum.** UI: `PROVISIONING|AVAILABLE|ATTACHED|DETACHING|DELETING|FAILED`;
-  proto: `CREATING|AVAILABLE|FAILED|DELETING|DELETED`. The proto has no
-  `ATTACHED`/`DETACHING` (attach is out of scope, managed separately), uses
-  `CREATING` rather than `PROVISIONING`, and adds `DELETED`. The UI maps
-  `PROVISIONING`→`CREATING` and drops the attach states in this read view.
-- **D3 — attachment fields.** `attachedTo`/`attachedToName` are not surfaced;
-  attachment is out of scope for OSAC-4542 (separate VMaaS/Compute work).
-- **D4 — resource path.** The UI predicted `block_volumes`; the resource is
-  `volumes` (consistent with the private API; file/object storage are separate
-  future resources). See Open Questions #1.
-
-After the backend ships and `pnpm gen-types` runs in osac-ux, the UI migration
-diff should be limited to the deviations above.
+The public Volume API is net-new: `osac-ui` currently has only the *private*
+Volume types (generated from OSAC-2872) — no *public* Volume types exist yet,
+because this EP is what introduces them. Once this EP's public proto merges and
+`osac-ui` runs `gen-types`, the public `Volume` types are generated straight from
+this proto, so there are **no deviations to reconcile** by construction. The only
+UI-side action is regenerating types after this lands. (Confirmed with the UI owner.)
 
 ### Implementation Details/Notes/Constraints
 
@@ -208,7 +182,6 @@ and the interceptor chain apply to the new methods automatically.
 |---|---|---|
 | DoD "own only" not met by tenant-level scoping | A Tenant User sees all volumes in their tenant, not just their own | Explicitly scoped out to a platform tenancy feature; flagged on the PR for the team to own or delegate; no migration needed later (`creator` column + index exist) |
 | cleanapi leaves unused imports in generated public protos | `buf lint` fails on regeneration | Prune the two imports (documented); follow-up to automate in tooling |
-| UI temp-api drift (`block_volumes` path, `storageClass`, attach states) | UI migration larger than a field rename | UX Alignment table bounds the diff; naming raised as Open Questions #1 |
 
 ### Drawbacks
 
@@ -230,11 +203,7 @@ narrowing of the stated DoD for this release.
 
 ## Open Questions [optional]
 
-1. **Public resource name: `volumes` vs `block_volumes`.** The UI temp-api predicts
-   `block_volumes`; this EP uses `volumes` (consistent with the private API;
-   file/object storage are separate future resources). Confirm the name with the
-   UI/UX owners before the UI migrates off the temp-api.
-2. **Ownership of the deferred owner-level visibility feature.** Tenant-level
+1. **Ownership of the deferred owner-level visibility feature.** Tenant-level
    scoping ships here; per-creator visibility is a platform-wide tenancy
    capability. Team decision: own it in this WG or delegate to a platform/tenancy
    owner.
@@ -300,4 +269,4 @@ Committed: commit @ design 0.9.0 - f7f8c6d, workspace main @ b177ce9 (dirty)
 
 > Authoring phases not recorded this session (commit-time snapshot only).
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"design","workflow_version":"0.9.0","ai_workflows":"f7f8c6d","source_repo":"b177ce9 (dirty)","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["commit","commit"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"design","workflow_version":"0.9.0","ai_workflows":"f7f8c6d","source_repo":"b177ce9 (dirty)","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["commit","commit","commit"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-4542-volume-get-list/design.md
+++ b/enhancements/OSAC-4542-volume-get-list/design.md
@@ -1,0 +1,286 @@
+---
+title: volume-get-list-public-api
+authors:
+  - Zoltan Szabo
+creation-date: 2026-08-27
+last-updated: 2026-08-27
+tracking-link:
+  - https://redhat.atlassian.net/browse/OSAC-4542
+prd:
+  - "prd.md"
+see-also:
+  - "OSAC-2872 (storage control plane — private Volume API)"
+  - "OSAC-984 (public Volume API epic)"
+---
+
+# Volume Get/List Public API
+
+## Summary
+
+Add a read-only public projection of the existing private Volume API: a public
+`Volumes` service exposing only `List` and `Get` over gRPC and REST at
+`/api/fulfillment/v1/volumes`. The public server wraps the already-shipped
+`PrivateVolumesServer`, reusing its DAO, tenancy enforcement, and CEL filtering,
+and maps private→public so that internal routing fields never leave the service.
+See [PRD](prd.md) for detailed requirements.
+
+## Motivation
+
+OSAC-2872 delivered the private Volume API, the volume inventory, and tier→backend
+resolution, but volumes are only reachable through the internal API. The console
+and tenants cannot read the inventory, so the storage UI is blocked and tenants
+have no operational visibility. This enhancement adds the minimal read surface —
+`Get` and `List` — needed to unblock the console, without touching provisioning.
+
+### Goals
+
+- Reuse the established public-wraps-private server pattern (as in
+  `external_ips_server.go`), adding no new data path.
+- Inherit tenant scoping and CEL filtering from the private server / generic DAO
+  rather than reimplementing them.
+- Expose only tenant-meaningful fields; keep internal routing (backend, protocol,
+  hub, vendor volume id) private.
+- Introduce no schema change — reuse the OSAC-2872 `volumes` table.
+
+### Non-Goals
+
+- Volume lifecycle through the public API (create/update/delete/resize) — deferred
+  to later OSAC-984 phases.
+- Per-user (owner-level) visibility for Tenant Users — deferred to a platform-wide
+  tenancy feature (see RBAC / Tenancy and Open Questions).
+- Volume attach/detach, snapshots/clones, file storage (OSAC-4515), object storage.
+
+## Proposal
+
+Enumerated changes, all in `fulfillment-service`:
+
+1. **Public proto (generated from private via cleanapi).** Opt the private
+   `Volumes` service and `Volume` type into public generation; expose only `List`
+   and `Get`; strip the internal status fields (`backend`, `protocol`, `hub`,
+   `vendor_volume_id`). `StorageProtocol`/`storage_common_type` stay fully private.
+2. **Public `VolumesServer`** (`internal/servers/volumes_server.go`): delegates
+   `List`/`Get` to `PrivateVolumesServer`, maps private→public (dropping internal
+   fields), and sets the CEL filter descriptor to the public `Volume` so callers
+   can only filter on visible fields.
+3. **Private server adjustment** (`private_volumes_server.go`): make the tier
+   resolver optional (it is used only by `Create`) so the read-only delegate can be
+   built without one; add `SetFilterDesc`.
+4. **Wiring**: register the public `Volumes` gRPC service (`register_servers.go`)
+   and REST handler (`start_rest_gateway_cmd.go`).
+5. **Authorization** (`authz.rego`): allow tenant clients on the public
+   `Volumes/Get` and `Volumes/List` methods.
+
+### Workflow Description
+
+Actors: **Tenant User / Tenant Admin** (read their tenant's volumes via console or
+CLI), **Cloud Provider Admin** (read across assigned tenants). Starting state:
+volumes already exist and are inventoried by OSAC-2872.
+
+Request path:
+
+```
+HTTP/gRPC client
+  -> REST gateway (grpc-gateway mux)            [REST callers only]
+  -> gRPC interceptors: authn (JWT) -> authz (OPA) -> tenancy
+  -> public VolumesServer.List/Get
+  -> PrivateVolumesServer.List/Get
+  -> GenericServer[Volume] (tenant scoping + CEL filter) -> GenericDAO -> PostgreSQL
+```
+
+Steps (List): the caller requests `GET /api/fulfillment/v1/volumes` (optionally
+with filter/order/offset/limit); OPA authorizes the method; the private delegate
+scopes rows to the caller's visible tenants and applies the CEL filter; the public
+server maps each row to the public shape and returns items + size + total. Get is
+the same by id, returning `NotFound` when the id is not visible/absent.
+
+### API Extensions
+
+- New **public gRPC service** `osac.public.v1.Volumes` with `List` and `Get`, and
+  REST transcoding at `/api/fulfillment/v1/volumes` and `/{id}`.
+- New public `Volume` message (subset of the private one).
+- No CRDs, webhooks, aggregated API servers, or finalizers. No change to any
+  externally-owned resource.
+
+## UX Alignment
+
+A matching `@temp-api` exists: `osac-ux/libs/ui-components/src/api/v1/block-volumes.ts`.
+The table maps its fields to this EP's public proto and records deviations. The
+temp-api is an anticipatory placeholder ("replace with proto-generated once
+fulfillment-service adds v1/block_volumes"), so several deviations are expected.
+
+| UI field (`@temp-api` TypeScript) | Proto field (this EP) | Notes / deviation |
+| `metadata.name` | `metadata.name` | Direct mapping |
+| `metadata.creationTimestamp` | `metadata.creation_timestamp` | Direct mapping |
+| `metadata.creator` | `metadata.creator` | Direct mapping |
+| `metadata.description` | `metadata.description` | Direct mapping |
+| `spec.sizeGib` | `spec.size_gib` | Direct mapping |
+| `spec.storageClass` (`'ssd'\|'nvme'\|'standard'`) | `spec.storage_tier` (string) | **Deviation:** UI uses a string-union storage class (a known anti-pattern); proto references a `StorageTier` by name. UI should migrate to tier references. |
+| `status.state` (`PROVISIONING\|AVAILABLE\|ATTACHED\|DETACHING\|DELETING\|FAILED`) | `status.state` (`CREATING\|AVAILABLE\|FAILED\|DELETING\|DELETED`) | **Deviation:** proto has no `ATTACHED`/`DETACHING` (attach is out of scope, managed separately) and uses `CREATING` (not `PROVISIONING`); adds `DELETED`. UI maps `PROVISIONING`→`CREATING` and drops attach states for this read view. |
+| `status.attachedTo` / `attachedToName` | _none_ | **Deviation:** attachment is out of scope for OSAC-4542 (separate VMaaS/Compute work); not surfaced here. |
+| (no field) | `spec.access_mode` | Extra field available to the UI (K8s access mode). |
+| resource path `v1/block_volumes` | `v1/volumes` | **Deviation:** UI predicted `block_volumes`; the resource is `volumes` (consistent with the private API; file/object storage are separate future resources). See Open Questions 8.2. |
+
+After the backend ships and `pnpm gen-types` runs in osac-ux, the UI migration
+diff should be limited to the deviations above.
+
+### Implementation Details/Notes/Constraints
+
+- The private→public field hiding is done by a `GenericMapper` with
+  `SetStrict(false)` — the copy silently omits fields absent from the public type
+  (the same mechanism `external_ips_server.go` uses). There is no `inMapper`
+  because there are no write RPCs.
+- `SetFilterDesc((*publicv1.Volume)(nil).ProtoReflect().Descriptor())` restricts
+  CEL filters to public fields, so a caller cannot filter on hidden fields such as
+  `status.backend`.
+- **cleanapi import pruning (tooling note):** cleanapi v0.0.8 copies imports
+  verbatim and does not prune those that become unused after fields/methods are
+  stripped (`storage_common_type` in the public `volume_type`, `field_mask` in the
+  public `volumes_service`); `buf lint` (`IMPORT_USED`) then rejects them. The two
+  unused imports are pruned by hand in the generated public protos, matching the
+  committed state of other read-only public resources (e.g.
+  `baremetal_instance_types_service`). A follow-up to automate this in
+  `dev.py build protos` (or bump cleanapi) is a candidate.
+
+### Security Considerations
+
+Read-only endpoints; no new secrets or data-mutation paths. Tenant isolation is
+enforced by the existing tenancy layer (below). Internal routing fields that could
+leak backend topology are excluded from the public type by construction. Input is
+limited to an id and standard list parameters; CEL filters are constrained to the
+public field set.
+
+### Failure Handling and Recovery
+
+- **Not found / not visible:** `Get` returns `NotFound`; `List` excludes rows
+  outside the caller's visible tenants.
+- **Invalid CEL filter / order:** returns `InvalidArgument` from the existing
+  filter translator.
+- **Mapping error:** returns `Internal` (logged); no partial data is returned.
+- **Delegate/DB errors:** propagated unchanged from the private server. No retries
+  or side effects (reads are idempotent).
+
+### RBAC / Tenancy
+
+Scoping is inherited, not reimplemented. OPA (`authz.rego`) gates *method* access —
+this EP adds `Volumes/Get` and `Volumes/List` to the tenant-client allowlist.
+*Row* scoping comes from `GenericServer`/`GenericDAO` via
+`DefaultTenancyLogic.DetermineVisibleTenants`, which restricts results to the
+caller's tenants (plus shared). This is **tenant-level** scoping — the same model
+every other resource uses; role does not change which rows are visible, only which
+methods may be called.
+
+The PRD DoD's "Tenant User sees only their own volumes" is a **per-creator**
+boundary that no OSAC resource implements today (`creator` is an attribution field
+and an optional filter, never an enforced boundary). Implementing it requires
+new, cross-cutting tenancy plumbing (a role-aware `creator` predicate) and should
+apply uniformly across resources; it is therefore **deferred to a platform tenancy
+feature**. This EP ships tenant-level scoping, which is consistent and unblocks the
+console. No new tenant-isolation metadata is introduced (reads reuse the existing
+`tenant` column and visibility logic).
+
+### Observability and Monitoring
+
+No new observability changes. Existing gRPC metrics, structured request logging,
+and the interceptor chain apply to the new methods automatically.
+
+### Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| DoD "own only" not met by tenant-level scoping | A Tenant User sees all volumes in their tenant, not just their own | Explicitly scoped out to a platform tenancy feature; flagged on the PR for the team to own or delegate; no migration needed later (`creator` column + index exist) |
+| cleanapi leaves unused imports in generated public protos | `buf lint` fails on regeneration | Prune the two imports (documented); follow-up to automate in tooling |
+| UI temp-api drift (`block_volumes` path, `storageClass`, attach states) | UI migration larger than a field rename | UX Alignment table bounds the diff; naming raised as Open Question 8.2 |
+
+### Drawbacks
+
+Read-only is a partial capability — the console can display but not manage volumes
+until later phases. Tenant-level (not owner-level) visibility is a deliberate
+narrowing of the stated DoD for this release.
+
+## Alternatives (Not Implemented)
+
+- **Hand-write the public proto.** Rejected — public protos are generated from
+  private via cleanapi by convention; hand-writing would diverge from every other
+  resource and drift on regeneration.
+- **Expose `protocol` (and thus `storage_common_type`) publicly** to avoid the
+  dangling-import problem. Rejected — protocol is an internal routing detail; the
+  import is pruned instead.
+- **Publish an empty public `storage_common_type`** so the import resolves.
+  Rejected — `buf lint IMPORT_USED` still fails, and it publishes a meaningless
+  type.
+
+## Open Questions [optional]
+
+### 8.1 Vendor identifier visibility for support
+- Whether a Cloud Provider Admin should ever see a volume's underlying vendor
+  identifier for support. Kept private for now; addable later without model change.
+
+### 8.2 Public resource name: `volumes` vs `block_volumes`
+- The UI temp-api predicts `block_volumes`; this EP uses `volumes` (consistent with
+  the private API; file/object storage are separate future resources). Confirm the
+  name with the UI/UX owners before the UI migrates off the temp-api.
+
+### 8.3 Ownership of the deferred owner-level visibility feature
+- Tenant-level scoping ships here; per-creator visibility is a platform-wide
+  tenancy capability. Team decision: own it in this WG or delegate to a
+  platform/tenancy owner.
+
+## Test Plan
+
+### Unit Tests
+- Public `Get` returns the public projection; `List` returns items with size/total.
+- Field mapping: public `Volume` carries spec (tier/size/access mode) and status
+  (state/message); internal fields are absent by type.
+- CEL filter over a public field (`status.state`) returns the expected subset.
+- `Get` on a nonexistent id returns an error.
+- Authz: a tenant client is allowed on `Volumes/Get` + `/List` and denied on
+  (nonexistent) public `Volumes/Create` + `/Delete`.
+- Private server: builds without a tier resolver; `Create` without a resolver fails.
+
+### Integration Tests
+- Against the kind `osac-dev` cluster: list/get standalone volumes created via the
+  private path through the public gRPC endpoint, asserting the public shape and
+  tenant scoping (a subject in tenant A does not see tenant B's volumes).
+
+### E2E Tests
+- Add a read-path check to the osac-test-infra vmaas suite: provision a volume via
+  the existing path, then Get/List it through the public API and assert the public
+  representation and tenant-scoped visibility.
+
+## Graduation Criteria
+
+Ships as part of the public Volume API (v0.2). No separate maturity ladder; the
+read endpoints graduate with the rest of the public API. Later OSAC-984 phases add
+the mutating lifecycle.
+
+## Upgrade / Downgrade Strategy
+
+Additive, read-only API surface with no schema change. Upgrade adds the new
+endpoints; downgrade removes them with no data migration. No existing client must
+change to keep working.
+
+## Version Skew Strategy
+
+The public API is generated from the private API and served by the same process;
+there is no cross-component skew. An older console simply does not call the new
+endpoints. The public `Volume` is a strict subset of the private type, so proto
+evolution follows the standard additive-field rules.
+
+## Support Procedures
+
+Failures surface as standard gRPC/REST errors (`NotFound`, `InvalidArgument`,
+`PermissionDenied`, `Internal`) visible in request logs. The endpoints can be
+effectively disabled by removing the `Volumes/Get`+`/List` entries from the OPA
+allowlist (callers then receive `PermissionDenied`); this affects only read access
+and has no effect on provisioning or running workloads.
+
+## Infrastructure Needed [optional]
+
+None.
+
+---
+
+## Provenance
+
+Authored: draft @ design 0.9.0 - f7f8c6d, workspace feat/OSAC-4542 @ 0fe64ee1b
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"design","workflow_version":"0.9.0","ai_workflows":"f7f8c6d","source_repo":"0fe64ee1b","source_repo_branch":"feat/OSAC-4542","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-4542-volume-get-list/design.md
+++ b/enhancements/OSAC-4542-volume-get-list/design.md
@@ -45,8 +45,15 @@ have no operational visibility. This enhancement adds the minimal read surface �
 ### Non-Goals
 
 - Volume lifecycle through the public API (create/update/delete/resize) — deferred
-  to later OSAC-984 phases.
-- Volume attach/detach, snapshots/clones, file storage (OSAC-4515), object storage.
+  to later [OSAC-984](https://redhat.atlassian.net/browse/OSAC-984) phases.
+- Volume expansion, snapshots, clones, and restore —
+  [OSAC-48](https://redhat.atlassian.net/browse/OSAC-48).
+- Volume attach/detach —
+  [OSAC-4884](https://redhat.atlassian.net/browse/OSAC-4884).
+- Volume identifiability / provenance — deferred to
+  [OSAC-4793](https://redhat.atlassian.net/browse/OSAC-4793).
+- File storage ([OSAC-4515](https://redhat.atlassian.net/browse/OSAC-4515))
+  and object storage.
 
 ## Proposal
 
@@ -59,7 +66,11 @@ Enumerated changes, all in `fulfillment-service`:
    on the private proto — cleanapi excludes annotated fields from the generated
    public message, so a private field can only reach the public schema if someone
    both adds it and forgets the annotation. A generated-schema test guards against
-   that (see Test Plan). `StorageProtocol`/`storage_common_type` stay fully private.
+   that (see Test Plan). The following private Volume fields carry
+   `[(cleanapi.field).private = true]` annotations on the private proto and are
+   excluded from the generated public message: `vendor_volume_id`, `backend`,
+   `protocol`, `hub`, and `vendor_context`.
+   `StorageProtocol`/`storage_common_type` stay fully private.
 2. **Public `VolumesServer`** (`internal/servers/volumes_server.go`): delegates
    `List`/`Get` to `PrivateVolumesServer`, maps private→public (dropping internal
    fields), and sets the CEL filter descriptor to the public `Volume` so callers
@@ -139,6 +150,10 @@ UI-side action is regenerating types after this lands. (Confirmed with the UI ow
   exposure vector today. If server-side ordering is implemented later, it must be
   translated against the same public descriptor as the filter so it cannot reference
   hidden fields — called out here so the constraint is not lost.
+  The `order` parameter is validated against the public Volume schema; field names
+  not present in the public descriptor (e.g. private fields like `status.backend`)
+  are rejected. The GenericDAO currently sorts by `id` regardless of the requested
+  order — this is a known, documented limitation.
 - **cleanapi import pruning (tooling note):** cleanapi v0.0.8 copies imports
   verbatim and does not prune those that become unused after fields/methods are
   stripped (`storage_common_type` in the public `volume_type`, `field_mask` in the
@@ -172,7 +187,7 @@ Scoping is inherited, not reimplemented. OPA (`authz.rego`) gates *method* acces
 this EP adds `Volumes/Get` and `Volumes/List` to the tenant-client allowlist.
 *Row* scoping comes from `GenericServer`/`GenericDAO` via
 `DefaultTenancyLogic.DetermineVisibleTenants`, which restricts results to the
-caller's tenants (plus shared). This is **tenant-level** scoping — the same model
+caller's tenants (plus shared). This is **tenant- and project-level** scoping — the same model
 every other resource uses; role does not change which rows are visible, only which
 methods may be called.
 
@@ -233,6 +248,11 @@ None.
   contains *only* the intended public fields — i.e. none of `backend`, `protocol`,
   `hub`, `vendor_volume_id` appear — so a future private field added without the
   `private = true` annotation fails the build rather than silently leaking.
+  The generated-schema guard test uses an exact-field allowlist: it asserts the
+  public `Volume` descriptor contains precisely the expected set of fields (`id`,
+  `metadata`, `spec.storage_tier`, `spec.size_gib`, `spec.access_mode`,
+  `status.state`, `status.message`). A future private field added without
+  `[(cleanapi.field).private = true]` fails the build rather than silently leaking.
 - CEL filter over a public field (`status.state`) returns the expected subset.
 - **CEL filter over a private field is rejected:** a filter referencing
   `status.backend` returns `InvalidArgument` (proves `SetFilterDesc` restricts the
@@ -254,7 +274,7 @@ None.
 
 ## Graduation Criteria
 
-Ships as part of the public Volume API (v0.2). No separate maturity ladder; the
+Ships as part of the public Volume API (0.3). No separate maturity ladder; the
 read endpoints graduate with the rest of the public API. Later OSAC-984 phases add
 the mutating lifecycle.
 


### PR DESCRIPTION
## Design: Volume Get/List Public API

**Jira:** [OSAC-4542](https://redhat.atlassian.net/browse/OSAC-4542)
**PRD:** osac-project/enhancement-proposals#236

### Summary

Technical design for the read-only public Volume API: a public `Volumes` service
(`List`/`Get`) that wraps the shipped `PrivateVolumesServer`, generated from the
private protos via cleanapi with internal routing fields stripped, and reusing the
existing tenancy layer for scoping. No new data path and no schema change.

### Requesting Review On

- The public-wraps-private approach and field-hiding via cleanapi (§ Proposal,
  Implementation Details)
- **Tenant-level scoping** decision and the deferral of **owner-level visibility**
  to a platform tenancy feature (§ RBAC / Tenancy) — including the authorization
  matrix for Tenant User / Tenant Admin / Cloud Provider Admin
- The private-field-hiding guarantees: `cleanapi private=true` annotations, the
  `SetFilterDesc` filter restriction, and the generated-schema guard test

### How to Review

- Comment inline; the one remaining open question is **who owns the deferred
  owner-level (per-creator) visibility feature** — this WG or a platform/tenancy owner
- Approve when the technical approach is agreed

### Note on UX Alignment

An earlier revision of this EP referenced deviations from an `osac-ux` `block-volumes`
temp-api. That is obsolete: `osac-ux` is deprecated (osac-project/osac-workspace#224),
and `osac-ui` generates UI types directly from this proto. The public Volume types do
not exist yet, so there are **no deviations to reconcile** — the UI regenerates from
this proto once it merges (confirmed with the UI owner). The public resource name is
`volumes` (mirrors the private resource; `block_volumes` was considered and not adopted).

_Part of a 3-PR set for [OSAC-4542](https://redhat.atlassian.net/browse/OSAC-4542): PRD (#236) → **design** (this) → code. Depends on #236._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **API surface:** Added a design for read-only public `Volumes.List` and `Volumes.Get` APIs over gRPC and REST. The design uses public projections of the existing private Volume API.
- **Controllers and data path:** Reuses `PrivateVolumesServer` and the existing tenancy layer. No new data path or database schema changes are proposed.
- **Authorization:** Defines tenant-level scoping for Tenant Users, Tenant Admins, and Cloud Provider Admins. Owner-level visibility remains deferred.
- **Schema and security:** Removes internal routing fields from public protos. Documents explicit public-field allowlisting, filter and order validation, and private-field-hiding guarantees.
- **Deployment and operations:** Documents service and REST wiring, rollout, compatibility, and operational procedures. The public resource name is `volumes`.
- **Tests and CI:** Specifies generated-schema guard testing and API validation coverage. UI types will come directly from the public proto; no `osac-ux` reconciliation is required.
- **Documentation:** Adds the complete technical design, including excluded capabilities, error handling, versioning, and graduation as API version `0.3`.

### Backward compatibility

This change is design-only and proposes no existing data, schema, or private API changes. The new public API is additive. Internal fields remain hidden from the public schema.

## Risk classification

**risk:ship** — The change adds documentation only and introduces no production code, data-path, schema, authorization implementation, deployment, or runtime behavior changes. It does not qualify for **risk:show** because it has no runtime impact, and it does not qualify for **risk:ask** because it does not introduce unresolved implementation risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->