### PR TITLE
OSAC-3046: Design follow-up — Helm validation, runtime flag validation, Enclave alignment

### DIFF
--- a/enhancements/OSAC-3046-per-service-enablement/design.md
+++ b/enhancements/OSAC-3046-per-service-enablement/design.md
@@ -263,9 +263,19 @@ func (f *serviceFlags) enableAllIfNoneSet() {
         f.MaaS = true
     }
 }
+
+func (f *serviceFlags) validate() error {
+    if f.CaaS && !f.VMaaS && !f.BMaaS {
+        return fmt.Errorf("CaaS requires at least one of VMaaS or BMaaS to be enabled")
+    }
+    if f.MaaS && !f.CaaS {
+        return fmt.Errorf("MaaS requires CaaS to be enabled")
+    }
+    return nil
+}
 ```
 
-If no `--enable-*` flag is provided, all services are enabled — matching the operator's `enableAllIfNoneSet()` pattern for backward compatibility. [Codebase: osac-operator/cmd/main.go]
+If no `--enable-*` flag is provided, all services are enabled — matching the operator's `enableAllIfNoneSet()` pattern for backward compatibility. After `enableAllIfNoneSet()`, `validate()` is called to reject invalid combinations before any server initialization begins. The process exits with a clear error message if validation fails. This provides defense in depth alongside the Helm-level `values.schema.json` constraints — catching misconfigurations even when the binary is started outside Helm (development, testing, custom manifests). [Codebase: osac-operator/cmd/main.go]
 
 #### Fulfillment-Service: Conditional gRPC Registration
 
@@ -429,7 +439,7 @@ The osac-operator already has per-controller enable flags — no new mechanism i
 
 Shared controllers (Tenant, Storage, Volume, Networking) remain always-enabled — they are shared infrastructure. [Locked: D2]
 
-The existing `operator.controllers.*` values and their propagation to `OSAC_ENABLE_*_CONTROLLER` env vars are unchanged. [Codebase: osac-operator/charts/operator/templates/deployment.yaml]
+The existing `operator.controllers.*` values and their propagation to `OSAC_ENABLE_*_CONTROLLER` env vars are unchanged. The operator's existing `controllerFlags` struct is extended with a `validate()` method that enforces the same inter-service dependency rules as the fulfillment-service: CaaS requires VMaaS or BMaaS, MaaS requires CaaS. The operator exits on startup with a clear error if an invalid combination is detected. [Codebase: osac-operator/charts/operator/templates/deployment.yaml]
 
 #### Bare-Metal Fulfillment Operator
 
@@ -451,13 +461,15 @@ The security improvement is additive: disabled services have no attack surface b
 
 The Capabilities endpoint remains unauthenticated (consistent with its current behavior — it is matched by `anonymousMethodsRegex`). The `enabled_services` field exposes which services are active, which is intentional: clients need this information to adapt their behavior. This information is not sensitive — an attacker could determine the same by probing each service endpoint.
 
-The `--enable-*` flags are typed booleans — no input parsing or validation is needed beyond what pflag provides. If no flags are set, all services are enabled (backward compatibility).
+The `--enable-*` flags are typed booleans — no input parsing is needed beyond what pflag provides. Inter-service dependency validation (`validate()`) runs at startup to reject invalid combinations before any server initialization. If no flags are set, all services are enabled (backward compatibility).
 
 ### Failure Handling and Recovery
 
 **Invalid service combination in Helm values:** If an admin specifies an invalid combination (e.g., CaaS enabled without VMaaS or BMaaS), `helm install`/`helm upgrade` fails immediately with a validation error from `values.schema.json`. No pods are started or restarted.
 
-**No `--enable-*` flags provided:** If no service enable flag is provided, the fulfillment-service enables all services via `enableAllIfNoneSet()` (backward compatibility). This matches the operator's behavior.
+**Invalid service combination at runtime:** If the binary is started with an invalid flag combination outside Helm (development, testing, custom manifests), the `validate()` method on `serviceFlags` (fulfillment-service) or `controllerFlags` (operator) rejects the combination at startup before any server or controller initialization. The process exits with a clear error message (e.g., `"CaaS requires at least one of VMaaS or BMaaS to be enabled"`). This is defense in depth — Helm catches it at deploy time, the binary catches it at startup.
+
+**No `--enable-*` flags provided:** If no service enable flag is provided, the fulfillment-service enables all services via `enableAllIfNoneSet()` (backward compatibility). This matches the operator's behavior. The `validate()` call runs after `enableAllIfNoneSet()`, so the all-enabled default always passes validation.
 
 **Helm upgrade with new services enabled:** When a `helm upgrade` enables a previously disabled service, the fulfillment-service pod restarts and registers the new service endpoints. No database migration is needed — the database schema includes all tables regardless of enabled services (tables for disabled services are unused but present). The operator pod restarts and begins reconciling the newly enabled controller's resources.
 
@@ -580,6 +592,7 @@ Should AAP instance groups be disabled when their corresponding service is disab
 **fulfillment-service:**
 
 - `enableAllIfNoneSet` enables all services when no flag is explicitly set, and preserves explicit flags when any are set.
+- `validate` rejects invalid combinations (CaaS without VMaaS/BMaaS, MaaS without CaaS), accepts valid combinations, and passes after `enableAllIfNoneSet()`.
 - `RegisterResourceServers` with each `serviceFlags` combination registers only the expected services. Verify by checking which services are registered on the gRPC server (via reflection or the server's `GetServiceInfo()` method).
 - `UnknownServiceHandler` returns `codes.Unavailable` with the correct service name for calls to known-but-disabled services, and falls through to `codes.Unimplemented` for genuinely unknown services.
 - REST gateway `registerHandlers` returns the expected handler set for each `serviceFlags` combination.

--- a/enhancements/OSAC-3046-per-service-enablement/design.md
+++ b/enhancements/OSAC-3046-per-service-enablement/design.md
@@ -10,6 +10,7 @@ prd:
   - "prd.md"
 see-also:
   - "/enhancements/OSAC-3046-per-service-enablement/prd.md"
+  - "https://github.com/osac-project/osac/pull/380"
 replaces:
   - N/A
 superseded-by:
@@ -557,12 +558,13 @@ Should navigation items for disabled services be completely hidden or shown as g
 **Owner:** UX team (osac-ux)
 **Impact:** Affects osac-ui implementation. The design currently specifies "hidden entirely" based on the principle that showing unavailable options confuses users, but the UX team may prefer a different treatment.
 
-### 2. Enclave Wizard Alignment
+### 2. Enclave Wizard Alignment [Resolved]
 
 How do Enclave wizard "experiences" relate to the per-service enablement flags? Do experiences drive the Helm values, get replaced by them, or run alongside them?
 
-**Owner:** Enclave team
-**Impact:** Affects the Helm values structure and the Enclave wizard pipeline. The current design defines `services.*.enabled` as standalone Helm values with no dependency on experiences. If experiences should drive these values, the Helm template logic needs adjustment.
+**Resolution:** Enclave profiles drive the service enablement values. The Enclave plugin's `osacProfilesList` (e.g., `[caas, vmaas]`) is translated into individual `services.*.enabled` flags via value-map extension — the plugin sets `--set services.caas.enabled=true,services.vmaas.enabled=true` rather than templating entire value files. This aligns with the team decision to modify the Enclave plugin to extend by value map (OSAC-4106).
+
+**Reconciliation with PR [osac-project/osac#380](https://github.com/osac-project/osac/pull/380):** PR #380 introduced a `global.profilesList` convenience layer with Helm helper functions that compute per-controller flags from a list. This design's `services.*.enabled` booleans are the canonical chart interface — they are simpler to validate (schema constraints, see Helm Values Structure), propagate uniformly to all components (fulfillment-service, operator, BMF), and are directly settable via Enclave value-map extension. PR #380's `global.profilesList` should be reconciled with this design: either adopt `services.*.enabled` as the underlying mechanism that the list maps to, or be superseded by the per-service booleans.
 
 ### 3. AAP Instance Group Enablement
 

--- a/enhancements/OSAC-3046-per-service-enablement/design.md
+++ b/enhancements/OSAC-3046-per-service-enablement/design.md
@@ -3,7 +3,7 @@ title: per-service-enablement
 authors:
   - htayrie@redhat.com
 creation-date: 2026-08-26
-last-updated: 2026-08-26
+last-updated: 2026-08-27
 tracking-link:
   - https://redhat.atlassian.net/browse/OSAC-3046
 prd:
@@ -161,6 +161,12 @@ services:
 ```
 
 All four default to `true` for backward compatibility. The `values.schema.json` is updated with corresponding boolean schema entries with descriptions.
+
+The schema also enforces inter-service dependency constraints:
+- CaaS requires at least one of VMaaS or BMaaS to be enabled — CaaS provisions clusters that need compute nodes, which come from either VMaaS or BMaaS.
+- MaaS requires CaaS to be enabled — MaaS serves models on clusters provisioned by CaaS.
+
+These constraints are encoded as `if`/`then` rules in `values.schema.json` so that `helm install` and `helm upgrade` fail immediately with a descriptive error when an invalid combination is specified.
 
 The installer propagates these values to each component using the same pattern — individual boolean flags passed as container args or env vars:
 
@@ -448,6 +454,8 @@ The `--enable-*` flags are typed booleans — no input parsing or validation is 
 
 ### Failure Handling and Recovery
 
+**Invalid service combination in Helm values:** If an admin specifies an invalid combination (e.g., CaaS enabled without VMaaS or BMaaS), `helm install`/`helm upgrade` fails immediately with a validation error from `values.schema.json`. No pods are started or restarted.
+
 **No `--enable-*` flags provided:** If no service enable flag is provided, the fulfillment-service enables all services via `enableAllIfNoneSet()` (backward compatibility). This matches the operator's behavior.
 
 **Helm upgrade with new services enabled:** When a `helm upgrade` enables a previously disabled service, the fulfillment-service pod restarts and registers the new service endpoints. No database migration is needed — the database schema includes all tables regardless of enabled services (tables for disabled services are unused but present). The operator pod restarts and begins reconciling the newly enabled controller's resources.
@@ -492,7 +500,7 @@ Mitigation: The filtering implementation uses the same `interfaces` field semant
 
 ### Drawbacks
 
-**Multiple flags to coordinate.** Disabling a service requires setting flags across multiple components (e.g., `service.services.bmaas`, `operator.controllers.bareMetalInstance`, and `bmf.enabled` for BMaaS). An admin could disable one but miss the others. CI profiles demonstrate the correct combinations, and documentation must list which flags to set together for each service.
+**Multiple flags to coordinate.** Disabling a service requires setting flags across multiple components (e.g., `service.services.bmaas`, `operator.controllers.bareMetalInstance`, and `bmf.enabled` for BMaaS). An admin could disable one but miss the others. The `values.schema.json` constraints (see Helm Values Structure) catch invalid combinations at `helm install`/`helm upgrade` time, preventing the most dangerous misconfigurations. CI profiles demonstrate the correct combinations, and documentation must list which flags to set together for each service.
 
 **All-or-nothing API process startup.** The fulfillment-service is a single process serving all gRPC services. Disabling a service still requires restarting the entire process (via `helm upgrade`), not hot-reloading. This is consistent with the current deployment model and the PRD requirement that changes go through `helm upgrade` [Locked: D4], but it means enabling a new service causes brief downtime for all services.
 
@@ -643,11 +651,3 @@ No data migration is required in either direction. Database tables for all servi
 ## Infrastructure Needed
 
 None. All changes are within existing repositories (osac mono-repo) and CI infrastructure. The existing CI profiles (`vmaas-ci`, `caas-ci`, `bmaas-ci`, `full-ci`) are extended to validate the new service enablement flags.
-
----
-
-## Provenance
-
-Authored: draft @ design 0.8.0 - 837cf0d, workspace main @ 4bfc214
-
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"design","workflow_version":"0.8.0","ai_workflows":"837cf0d","source_repo":"4bfc214","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-3046-per-service-enablement/testplan.md
+++ b/enhancements/OSAC-3046-per-service-enablement/testplan.md
@@ -3,15 +3,18 @@
 ## Overview
 
 - **Feature:** OSAC-3046 — Per-Service Enablement (CaaS/VMaaS/BMaaS/MaaS)
-- **Total test cases:** 18
+- **Total test cases:** 20
 - **Requirements covered:** 8 of 8
 
 ## Execution Strategy
 
 Each `helm upgrade` triggers a pod rollout (2-5 minutes). To minimize rollout cycles, test cases should be grouped by deployment state during execution:
 
+**State 0 — Helm validation (no deployment needed):**
+TC-FR1-03, TC-FR1-04
+
 **State 1 — BMaaS+MaaS disabled** (`services.bmaas.enabled=false`, `services.maas.enabled=false`):
-TC-FR1-01, TC-FR2-01, TC-FR2-02, TC-FR2-03, TC-FR2-04, TC-FR2-05, TC-FR4-01, TC-FR5-01, TC-FR5-03, TC-FR5-04, TC-NFR1-01, TC-NFR3-01
+TC-FR1-01, TC-FR2-01, TC-FR2-02, TC-FR2-03, TC-FR2-04, TC-FR2-05, TC-FR4-01, TC-FR5-01, TC-FR5-04, TC-NFR1-01, TC-NFR3-01
 
 **State 2 — Upgrade to enable BMaaS** (`helm upgrade` with `services.bmaas.enabled=true`):
 TC-FR3-01
@@ -22,7 +25,7 @@ TC-FR1-02, TC-FR2-04, TC-FR4-02, TC-FR4-03, TC-NFR2-01
 **State 4 — VMaaS disabled** (`services.vmaas.enabled=false`):
 TC-FR5-02
 
-This reduces execution from 18 individual rollouts to 4 deployment states.
+This reduces execution from 20 individual rollouts to 4 deployment states plus a pre-deployment Helm validation step.
 
 ## Test Cases
 
@@ -71,6 +74,42 @@ This reduces execution from 18 individual rollouts to 4 deployment states.
 - The fulfillment-service container args include `--enable-caas`, `--enable-vmaas`, `--enable-bmaas`, and `--enable-maas`
 - All operator controller env vars are set to `true`
 - The BMF operator deployment is present
+
+#### TC-FR1-03: Invalid combination — CaaS without VMaaS or BMaaS — rejected
+
+| Story | AC | Priority | Automation |
+|-------|-----|----------|------------|
+| Story 1.05 | AC-2 | critical | automated |
+
+##### Preconditions
+
+- Helm chart source with `values.schema.json` containing inter-service dependency constraints
+
+##### Steps
+
+1. Run `helm template osac charts/osac --set services.caas.enabled=true --set services.vmaas.enabled=false --set services.bmaas.enabled=false`
+
+##### Expected Results
+
+- The command fails with a schema validation error indicating CaaS requires at least one of VMaaS or BMaaS
+
+#### TC-FR1-04: Invalid combination — MaaS without CaaS — rejected
+
+| Story | AC | Priority | Automation |
+|-------|-----|----------|------------|
+| Story 1.05 | AC-2 | critical | automated |
+
+##### Preconditions
+
+- Helm chart source with `values.schema.json` containing inter-service dependency constraints
+
+##### Steps
+
+1. Run `helm template osac charts/osac --set services.maas.enabled=true --set services.caas.enabled=false`
+
+##### Expected Results
+
+- The command fails with a schema validation error indicating MaaS requires CaaS
 
 ### FR-2: Disabled services are not accessible — no API endpoints, no UI surfaces, no provisioning capability
 
@@ -139,7 +178,7 @@ This reduces execution from 18 individual rollouts to 4 deployment states.
 
 ##### Preconditions
 
-- Fulfillment-service running with only CaaS enabled (VMaaS, BMaaS, MaaS disabled)
+- Fulfillment-service running with some services disabled (tested under State 1: BMaaS+MaaS disabled, and State 3: all enabled)
 
 ##### Steps
 
@@ -303,15 +342,15 @@ This reduces execution from 18 individual rollouts to 4 deployment states.
 
 | Story | AC | Priority | Automation |
 |-------|-----|----------|------------|
-| Story 3.01 | AC-3 | high | automated |
+| Story 3.01 | AC-3 | high | unit only |
 
 ##### Preconditions
 
-- Fulfillment-service running with both BMaaS and VMaaS disabled
+- `serviceFlags` with both BMaaS and VMaaS disabled (unit test — this combination is not deployable via Helm because CaaS requires VMaaS or BMaaS)
 
 ##### Steps
 
-1. Call `HostTypes.List` via gRPC
+1. Call `HostTypes.List` via the unit test harness
 
 ##### Expected Results
 
@@ -346,7 +385,7 @@ This reduces execution from 18 individual rollouts to 4 deployment states.
 
 ##### Preconditions
 
-- Fulfillment-service running with all compute services disabled (BMaaS and VMaaS both disabled, only CaaS enabled)
+- Fulfillment-service running with BMaaS and MaaS disabled (State 1 configuration)
 
 ##### Steps
 
@@ -354,8 +393,9 @@ This reduces execution from 18 individual rollouts to 4 deployment states.
 
 ##### Expected Results
 
-- The call returns `codes.OK` with an empty list (not `codes.Unavailable` or `codes.Unimplemented`)
-- The HostTypes service is accessible even though its backing compute services are disabled
+- The call returns `codes.OK` (not `codes.Unavailable` or `codes.Unimplemented`)
+- The HostTypes service is accessible even though one of its backing compute services (BMaaS) is disabled
+- The response contains only virtual host types (bare-metal types filtered out)
 
 ### NFR-2: Backward compatibility — all services enabled by default
 
@@ -406,17 +446,19 @@ This reduces execution from 18 individual rollouts to 4 deployment states.
 
 - **Story 1.04, AC-4** (`fulfillment_disabled_service_requests_total` Prometheus metric): Verified by unit tests only — metric increment is an internal implementation detail, not a behavioral scenario observable from outside the system.
 - **Story 1.04, AC-5** (startup log listing enabled/disabled services): Verified by unit tests only — log output is an operational detail, not a user-facing behavioral outcome.
+- **TC-FR5-03** (Story 3.01, AC-3 — empty host types when both compute services disabled): Unit-test-only. The `values.schema.json` constraint requires CaaS to have at least one of VMaaS or BMaaS enabled, so both-disabled is not a deployable Helm configuration. The filtering logic is verified at the unit test level with `serviceFlags` set directly.
 
 ## Summary
 
 | Metric | Count |
 |--------|-------|
-| Total test cases | 18 |
-| Critical | 8 |
+| Total test cases | 20 |
+| Critical | 10 |
 | High | 8 |
 | Medium | 0 |
 | Low | 0 |
-| Automated | 18 |
+| Automated (E2E) | 18 |
+| Unit only | 1 |
 | Manual | 0 |
 | Requirements with test cases | 8 / 8 |
 | Requirements without test cases | 0 |


### PR DESCRIPTION
## Summary

Follow-up to #234 (merged) addressing reviewer feedback, adding defense-in-depth validation, and aligning with the Enclave/PR #380 direction.

### Helm schema validation
`values.schema.json` `if/then` constraints reject invalid service combinations at `helm install`/`helm upgrade` time:
- CaaS requires at least one of VMaaS or BMaaS enabled
- MaaS requires CaaS enabled

### Startup-time flag validation
Both fulfillment-service (`serviceFlags.validate()`) and osac-operator (`controllerFlags.validate()`) reject invalid flag combinations at startup before any initialization. Defense in depth — catches misconfigurations even outside Helm (development, testing, custom manifests).

### Enclave wizard alignment
Resolves Open Question #2: Enclave profiles (`osacProfilesList`) drive `services.*.enabled` flags via value-map extension ([OSAC-4106](https://redhat.atlassian.net/browse/OSAC-4106)). Clarifies reconciliation with PR osac-project/osac#380 (`global.profilesList`): `services.*.enabled` booleans are the canonical chart interface.

### Testplan updates
- Two new test cases (TC-FR1-03, TC-FR1-04) for schema validation
- Fixed preconditions in TC-FR2-04 and TC-NFR1-01 that assumed CaaS-only deployments (now invalid with schema constraints)
- Demoted TC-FR5-03 to unit-test-only (both-compute-disabled is not a deployable Helm configuration)

## Reviewer feedback addressed

| Reviewer | Comment | Resolution |
|----------|---------|------------|
| @rccrdpccl (line 72) | Incompatible service combinations | Helm schema + runtime validation |
| @rccrdpccl (line 78) | Disable specific CaaS operator flows when BMaaS disabled | No change — @avishayt clarified: disable at API level + dedicated components; shared flows are fine |
| @rccrdpccl (line 67) | VMaaS disabled implications for CaaS | No change — @avishayt clarified: ComputeInstances blocked, CaaS clusters unaffected |
| @masayag (line 214) | CaaS requires VMaaS or BMaaS | Covered by schema + runtime validation |

## Enclave / PR #380 alignment

| Topic | Resolution |
|-------|------------|
| Open Question #2 (Enclave wizard) | Resolved: Enclave profiles → `services.*.enabled` via value-map extension |
| PR osac-project/osac#380 (`global.profilesList`) | Reconcile: `services.*.enabled` is the canonical interface; `profilesList` can map to it or be superseded |
| [OSAC-4106](https://redhat.atlassian.net/browse/OSAC-4106) (Enclave value sync) | Aligned: value-map extension avoids value file templating |

## Test plan

- [ ] Schema constraint section is clear and consistent with testplan
- [ ] New test cases TC-FR1-03 and TC-FR1-04 accurately describe schema validation behavior
- [ ] TC-FR5-03 gap rationale explains why unit-test-only is correct
- [ ] `validate()` code sample and failure handling section are consistent
- [ ] Open Question #2 resolution correctly reflects team decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Validation**
  - Added Helm and runtime checks to prevent invalid service combinations before deployment or initialization.
  - Confirmed valid defaults for all-service configurations.

- **Documentation**
  - Clarified Enclave value mappings and per-service enablement guidance.
  - Documented pre-deployment validation and updated rollout scenarios.

- **Tests**
  - Expanded coverage for invalid combinations, partially disabled services, and virtual host filtering.
  - Updated reporting to distinguish automated end-to-end tests from unit-only validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->