### PR TITLE
OSAC-4291: PRD - K8s Manager — OVN EVPN Phase 1

### DIFF
--- a/enhancements/OSAC-4291-ovn-evpn-phase-1/clarifications.md
+++ b/enhancements/OSAC-4291-ovn-evpn-phase-1/clarifications.md
@@ -1,0 +1,364 @@
+# Clarification Log — OSAC-4291
+
+## Status
+
+- Rounds completed: 3
+- Open gaps: None
+- Exit criteria met: Yes
+
+## Round 1 — User Personas and Visibility
+
+### R1.Q1: Personas — Who configures EVPN?
+
+The feature describes k8s manager registration, CUDN creation, and BGP peering setup. Which OSAC persona(s) are responsible for enabling EVPN for a deployment/region? Is this:
+- Cloud Infrastructure Admin work during initial OSAC installation?
+- Cloud Provider Admin work when onboarding a new region?
+- Automatically enabled based on infrastructure detection?
+
+#### Answer
+
+Cloud Infrastructure Admin work during initial OSAC installation.
+
+#### Impact
+
+PRD user stories will target Cloud Infrastructure Admin for EVPN setup/configuration workflows. Tenant-facing sections describe VirtualNetwork/Subnet provisioning with no EVPN visibility.
+
+#### Decision (D1)
+
+EVPN configuration is Cloud Infrastructure Admin responsibility during installation - not tenant-facing, not automatic, not per-region onboarding.
+
+---
+
+### R1.Q2: Tenant visibility — Is EVPN transparent to tenants?
+
+When a Tenant User or Tenant Admin provisions a VM, do they:
+- Choose EVPN vs. other networking methods explicitly (e.g., via a dropdown or flag)?
+- See EVPN mentioned anywhere in the UI/CLI (e.g., "Network type: EVPN")?
+- Experience EVPN as completely infrastructure-transparent (no visibility)?
+
+#### Answer
+
+Tenants use VirtualNetwork / Subnet. They do not choose EVPN, set VNIs or route-targets, or peer BGP. The provider picks how the hosting cluster joins the fabric.
+
+#### Impact
+
+PRD will not include tenant-facing EVPN configuration options. Tenant user stories focus on VirtualNetwork/Subnet provisioning. All EVPN implementation details (VNI, route targets, BGP peering) are infrastructure-side only.
+
+#### Decision (D2)
+
+EVPN is completely transparent to tenants. No UI/CLI exposure of EVPN-specific concepts (VNI, route targets, BGP) in tenant workflows.
+
+---
+
+### R1.Q3: Scope — VNI Management
+
+The demo shows **Netris manages VPC/VNet allocations (sets VNI IDs)** and **OSAC allocates VPC/Subnet → Netris provisions VNIs → CUDN consumes them**.
+
+For Phase 1:
+- Does the PRD include **automatic VNI extraction from Netris** and propagation to CUDN?
+- Or is manual VNI coordination (like the demo's Phase 4/5) acceptable for 0.3?
+- Should Phase 1 include the **`0:VNI_ID` route-target standardization** the demo mentions Netris will fix?
+
+#### Answer
+
+Phase 1 will not include `0:VNI_ID` route-target standardization. VNI extraction happens automatically - when creating VPC on Netris, the VNI is automatically set in CUDN.
+
+#### Impact
+
+PRD scope includes automatic VNI propagation (no manual extraction step like demo Phase 4). Out of scope: `0:VNI_ID` route-target format (deferred until Netris implements it). Netris VPC creation must return VNI ID, which OSAC's k8s manager consumes when creating CUDN.
+
+#### Decision (D3)
+
+Automatic VNI extraction and propagation to CUDN is in scope for Phase 1. The `0:VNI_ID` route-target standardization is out of scope (Phase 1 uses `(leaf ASN % 65536):VNI` formula from demo).
+
+---
+
+### R1.Q4: Edge case — CUDN Single-Subnet Limitation
+
+The demo states **"CUDN is limited to a single subnet per VPC ipVRF — cannot reuse a VPC and add more subnets."**
+
+This is stricter than the Jira description's "one VM-subnet per VirtualNetwork" constraint:
+- Is the constraint **one CUDN per VPC ipVRF** (demo limitation)?
+- Or **one VM-hosting subnet per VirtualNetwork** (Jira wording)?
+- Where is this validated? (When creating the Subnet? When creating the CUDN? When provisioning the VM?)
+
+#### Answer
+
+The limit is one subnet per VirtualNetwork. The validation happens when creating the subnet - a second subnet under the same VirtualNetwork won't be allowed.
+
+#### Impact
+
+PRD validation requirements: fulfillment-service Subnet creation API must reject a second subnet when the parent VirtualNetwork already has one subnet. Error message should reference OVN Connectors limitation. No operator-side validation needed (API rejection prevents the CR from ever being created).
+
+#### Decision (D4)
+
+Validation enforced at Subnet API creation time in fulfillment-service. Constraint is one subnet per VirtualNetwork (not the stricter "one CUDN per VPC ipVRF"). Second subnet creation attempt returns validation error.
+
+---
+
+### R1.Q5: Scope — IPAM and Gateway Management
+
+The demo shows **OCP CUDN runs IPAM** (not Netris DHCP) and **gateway IP collision requires same MAC address on both sides**.
+
+For Phase 1:
+- Is **dual gateway MAC coordination** in scope (OCP CUDN gateway + Netris VNet gateway must match)?
+- Or is this a **known limitation** to document (out of scope for automatic handling)?
+- Does Phase 1 handle **DHCP range coordination** to avoid IP collisions?
+
+#### Answer
+
+Dual gateway MAC coordination is a known limitation (out of scope for automatic handling). Phase 1 handles DHCP range coordination to avoid IP collisions.
+
+#### Impact
+
+PRD Known Limitations section documents dual gateway MAC requirement (manual coordination needed). PRD scope includes DHCP range coordination mechanism - k8s manager must configure OCP CUDN IPAM to avoid overlap with Netris DHCP ranges.
+
+---
+
+## Round 2 — BGP Configuration and Automation
+
+### R2.Q1: BGP Configuration Automation
+
+The demo shows **manual FRRConfiguration CRD creation** (40+ lines of YAML with ASN, router ID, neighbor config, route targets).
+
+For Phase 1:
+- Does the k8s manager **automatically create** the FRRConfiguration CRD when a subnet is created?
+- Or does the Cloud Infrastructure Admin **manually create** it during installation (one-time setup)?
+- If automatic: what parameters come from Netris vs. NetworkClass configuration?
+
+#### Answer
+
+When CUDN is created, FRRConfiguration is created for the VirtualNetwork and Subnet. But the Cloud Infrastructure Admin should create the BGP session with Netris (underlay peering is manual prerequisite).
+
+The required BGP configuration fields are:
+- BGP local AS
+- BGP remote AS (from Netris)
+- BGP peer address (from same subnet as physical interface IP)
+- BGP peer local interface address (peering with Netris IP)
+
+#### Impact
+
+PRD scope: k8s manager automatically creates FRRConfiguration for EVPN overlay when CUDN is created (VNI-specific route targets, L2VPN EVPN config). Out of scope: BGP underlay session setup (manual prerequisite). Prerequisites section documents what Cloud Infrastructure Admin must configure before creating first VirtualNetwork.
+
+#### Decision (D5)
+
+FRRConfiguration for EVPN overlay (VNI, route targets) is automatic. BGP underlay peering (physical link, neighbor session) is a manual prerequisite configured by Cloud Infrastructure Admin.
+
+---
+
+### R2.Q2: VTEP Configuration Automation
+
+The demo shows **manual VTEP setup** (VTEP CRD + NMState dummy interface with `10.200.255.1/32`).
+
+For Phase 1:
+- Does the k8s manager **automatically provision** the VTEP interface on each hosting cluster node?
+- Or is VTEP setup a **prerequisite** (Cloud Infrastructure Admin does it once before enabling EVPN)?
+- If automatic: where does the VTEP IP range come from?
+
+#### Answer
+
+VTEP address should be predefined once per node by infrastructure (same as BGP configuration with Netris as underlay). This is a prerequisite setup, not automatic provisioning.
+
+#### Impact
+
+PRD Prerequisites section documents VTEP setup (VTEP CRD + NMState NNCP per node with dummy interface and /32 IP). VTEP configuration is one-time infrastructure setup, not per-VirtualNetwork automation.
+
+---
+
+### R2.Q3: NMState Underlay Configuration
+
+The demo shows **manual underlay link setup** (Netris API + NMState NNCP for physical interface IP).
+
+For Phase 1:
+- Is underlay link configuration a **prerequisite** documented in installation docs?
+- Or does Phase 1 include **automation** for underlay provisioning?
+
+#### Answer
+
+Installation prerequisites must be documented in the PRD. Before creating CUDN, the worker must join the fabric and establish BGP. This means: the port connected to the worker is set in Netris as underlay, which configures BGP on the Netris side.
+
+#### Impact
+
+PRD includes "Installation Prerequisites" section documenting the infrastructure setup workflow:
+1. Configure underlay link in Netris (port → underlay mode)
+2. Configure physical interface IP via NMState
+3. Set up VTEP interface per node
+4. Verify BGP session established
+
+All steps are manual Cloud Infrastructure Admin work, prerequisite to creating first VirtualNetwork.
+
+#### Decision (D6)
+
+Underlay configuration (physical link, Netris port setup, BGP session) is a documented prerequisite, not automated by Phase 1. PRD includes detailed Prerequisites section.
+
+---
+
+### R2.Q4: NetworkClass ConfigMap Schema
+
+The Jira mentions "k8s manager registration via ConfigMap with declared capabilities."
+
+What exact fields are in the ConfigMap?
+
+#### Answer
+
+NetworkClass ConfigMap should contain: `name: cudn_evpn` with capabilities `ipv4` or `dualstack` (same structure as other k8s managers, no additional EVPN-specific fields).
+
+#### Impact
+
+PRD documents NetworkClass ConfigMap schema matching existing pattern from OSAC-1433 unified networking. No EVPN-specific ConfigMap fields beyond standard name and capabilities.
+
+---
+
+### R2.Q5: Route Target Calculation
+
+The demo uses formula `(leaf ASN % 65536):VNI` to calculate route targets.
+
+For Phase 1:
+- Does the k8s manager **calculate** route targets using this formula?
+- Or does Netris **return** the route target when creating VPC/VNet?
+
+#### Answer
+
+Route target is automatically set during CUDN creation. The route target is not known until Netris creates the VPC and subnet. The k8s manager then uses that route target when creating the CUDN. No manual configuration by users.
+
+#### Impact
+
+PRD workflow: Netris VPC/VNet creation returns route target values → k8s manager uses those values in FRRConfiguration when creating CUDN. No route-target calculation logic in k8s manager. Netris is source of truth for route targets.
+
+#### Decision (D7)
+
+Route targets come from Netris (returned during VPC/VNet creation). K8s manager uses Netris-provided route target values when creating CUDN - no client-side calculation.
+
+---
+
+## Round 3 — Testing, Observability, and Design Context
+
+### R3.Q1: Integration Test Scope
+
+The Jira Definition of Done mentions "Integration test covering subnet creation → CUDN + EVPN → VM placement → fabric reachability."
+
+For Phase 1:
+- What test infrastructure is required? (Real Netris fabric? Simulated? Kind cluster?)
+- What does "fabric reachability" verification mean specifically?
+- Does the test run in CI, or is it a manual verification step?
+
+#### Answer
+
+Phase 1 requires a real Netris fabric (not simulated). Fabric reachability means ping from worker's IP (BGP source) to Netris switch port, and verify BGP session is up.
+
+Integration test runs automatically in CI. Setup requires creating BGP configuration and configuring the worker OCP as underlay peer to Netris. VM-to-bare-metal connectivity is checked only after CUDN is created, VM booted up, and bare-metal configured on Netris with same VPC subnet.
+
+#### Impact
+
+PRD Test Plan section documents CI integration test requirements:
+- Real Netris fabric infrastructure (not mocked)
+- Automated setup: BGP underlay peering between OCP worker and Netris ns-leaf
+- Test phases: 1) Verify BGP session up (ping worker to switch), 2) Create VirtualNetwork/Subnet via OSAC API, 3) Verify CUDN creation with correct VNI/route-targets, 4) Deploy VM, 5) Provision bare-metal node on Netris in same VPC subnet, 6) Verify VM-to-bare-metal connectivity
+
+#### Decision (D8)
+
+Integration test is automated in CI, requires real Netris fabric, and validates full path from subnet creation through VM-to-bare-metal connectivity.
+
+---
+
+### R3.Q2: EVPN Failure Modes and Observability
+
+If BGP peering fails or EVPN routes aren't advertised properly:
+- What does the user observe?
+- What diagnostic tools does the Cloud Infrastructure Admin have?
+- Are there automated health checks before marking Subnet as "Ready"?
+
+#### Answer
+
+In case BGP peering is up but there is a mismatch in VNI or route-target between VMs and Netris bare-metal, the user won't have traffic/ping to remote nodes in the same VPC. VM provisions successfully but connectivity fails (silent failure).
+
+Cloud Infrastructure Admin can verify VNI created properly by running FRR commands:
+- `show evpn vni`
+- `show bgp l2vpn evpn`
+- `show bgp vni <VNI ID>`
+- `show bgp l2vpn evpn summary`
+
+#### Impact
+
+PRD Known Limitations section documents failure mode: VNI/route-target mismatch results in silent connectivity failure (VM provisions but can't reach fabric). No automated health checks in Phase 1 - verification is manual via FRR commands. PRD Troubleshooting section documents diagnostic commands for Cloud Infrastructure Admin.
+
+---
+
+### R3.Q3: MetalLB IPAddressPool Creation
+
+The Jira Definition of Done mentions "MetalLB IPAddressPool created at subnet creation (for CaaS VIP allocation)."
+
+Is this in scope for Phase 1?
+
+#### Answer
+
+MetalLB IPAddressPool is out of scope for Phase 1.
+
+#### Impact
+
+PRD Out of Scope section explicitly lists MetalLB IPAddressPool creation. This is handled separately in OSAC-1436 (CaaS Networking).
+
+#### Decision (D9)
+
+MetalLB IPAddressPool creation is out of scope for Phase 1 (deferred to OSAC-1436 CaaS Networking).
+
+---
+
+### R3.Q4: Relationship to OSAC-1433 Design
+
+Does this feature extend the existing OSAC-1433 design document, or create a new design document?
+
+#### Answer
+
+This extends the existing OSAC-1433 design document.
+
+#### Impact
+
+Design phase will add an "OVN EVPN k8s Manager" section to the existing OSAC-1433 unified networking design document, not create a standalone design.
+
+#### Decision (D10)
+
+Design extends OSAC-1433 (unified networking architecture) - not a new standalone document.
+
+---
+
+## Additional Context Captured
+
+### Installation Prerequisites (from R2.Q3 and Round 3 discussion)
+
+Cloud Infrastructure Admin must complete these steps before creating the first VirtualNetwork:
+
+1. **Configure VTEP on all OCP nodes** (VTEP CRD + NMState NNCP per node with dummy interface and /32 IP)
+2. **Configure address on physical interface on worker** (will be BGP peer)
+3. **Ensure worker interface has connectivity to fabric switch**
+4. **Configure underlay link in Netris** (set port to underlay mode)
+5. **Create BGP peer between worker and ns-leaf** (FRRConfiguration with local AS, remote AS from Netris, peer addresses)
+6. **Verify BGP session established** (Netris adds OCP worker as underlay, worker configures BGP and enables EVPN)
+
+### CUDN Creation Workflow (from Round 3 discussion)
+
+When tenant creates VirtualNetwork/Subnet:
+1. **Netris creates VPC and subnet first** (allocates VNIs and route targets)
+2. **Only after that, CUDN is created** (reuses Netris VNIs and route-targets)
+3. **When CUDN is set up, EVPN routes are updated**
+
+### Subnet Flexibility (from Round 3 discussion)
+
+- CUDN can reuse existing VPC and VNet from Netris if we get the VNI for Layer 2, Layer 3, and route-targets
+- The subnet can be the same as Netris or different
+- In case of different subnets (OCP CUDN subnet vs. Netris VNet subnet), Layer 3 VNI (ipVRF) is used for routing between them
+
+---
+
+## Locked Decisions Summary
+
+- **D1:** EVPN configuration is Cloud Infrastructure Admin responsibility during installation
+- **D2:** EVPN is completely transparent to tenants
+- **D3:** Automatic VNI extraction and propagation to CUDN is in scope; `0:VNI_ID` route-target format is out of scope
+- **D4:** One-subnet-per-VirtualNetwork validation enforced at Subnet API creation time in fulfillment-service
+- **D5:** FRRConfiguration for EVPN overlay is automatic; BGP underlay peering is manual prerequisite
+- **D6:** Underlay configuration is documented prerequisite, not automated
+- **D7:** Route targets come from Netris (no client-side calculation)
+- **D8:** Integration test is automated in CI with real Netris fabric
+- **D9:** MetalLB IPAddressPool creation is out of scope
+- **D10:** Design extends OSAC-1433, not a new document

--- a/enhancements/OSAC-4291-ovn-evpn-phase-1/clarifications.md
+++ b/enhancements/OSAC-4291-ovn-evpn-phase-1/clarifications.md
@@ -61,15 +61,15 @@ For Phase 1:
 
 #### Answer
 
-Phase 1 will not include `0:VNI_ID` route-target standardization. VNI extraction happens automatically - when creating VPC on Netris, the VNI is automatically set in CUDN.
+Phase 1 will not include `0:VNI_ID` route-target standardization. VNI propagation from fabric manager to k8s manager is automatic - no manual extraction or coordination steps required (unlike the demo's Phase 4/5 manual workflow).
 
 #### Impact
 
-PRD scope includes automatic VNI propagation (no manual extraction step like demo Phase 4). Out of scope: `0:VNI_ID` route-target format (deferred until Netris implements it). Netris VPC creation must return VNI ID, which OSAC's k8s manager consumes when creating CUDN.
+PRD scope includes automatic VNI propagation (no manual steps). Out of scope: `0:VNI_ID` route-target format (deferred until Netris implements it). The fabric manager must provide VNI when provisioning VPC/VNet, and the k8s manager must receive it to configure the overlay network. The mechanism for passing VNI from fabric manager output to k8s manager input is a design decision.
 
 #### Decision (D3)
 
-Automatic VNI extraction and propagation to CUDN is in scope for Phase 1. The `0:VNI_ID` route-target standardization is out of scope (Phase 1 uses `(leaf ASN % 65536):VNI` formula from demo).
+Automatic VNI propagation from fabric manager to k8s manager is in scope for Phase 1. The `0:VNI_ID` route-target standardization is out of scope.
 
 ---
 

--- a/enhancements/OSAC-4291-ovn-evpn-phase-1/clarifications.md
+++ b/enhancements/OSAC-4291-ovn-evpn-phase-1/clarifications.md
@@ -88,11 +88,11 @@ The limit is one subnet per VirtualNetwork. The validation happens when creating
 
 #### Impact
 
-PRD validation requirements: fulfillment-service Subnet creation API must reject a second subnet when the parent VirtualNetwork already has one subnet. Error message should reference OVN Connectors limitation. No operator-side validation needed (API rejection prevents the CR from ever being created).
+PRD validation requirements: fulfillment-service Subnet creation API must reject a second subnet when the parent VirtualNetwork uses a NetworkClass whose k8s manager has this limitation. Error message should reference OVN Connectors limitation. No operator-side validation needed (API rejection prevents the CR from ever being created).
 
 #### Decision (D4)
 
-Validation enforced at Subnet API creation time in fulfillment-service. Constraint is one subnet per VirtualNetwork (not the stricter "one CUDN per VPC ipVRF"). Second subnet creation attempt returns validation error.
+Validation enforced at Subnet API creation time in fulfillment-service, conditional on the NetworkClass's k8s manager. Constraint is one subnet per VirtualNetwork when the k8s manager is `cudn_evpn` (not a universal constraint; other NetworkClasses support multiple subnets). Second subnet creation attempt returns validation error.
 
 ---
 
@@ -354,8 +354,8 @@ When tenant creates VirtualNetwork/Subnet:
 
 - **D1:** EVPN configuration is Cloud Infrastructure Admin responsibility during installation
 - **D2:** EVPN is completely transparent to tenants
-- **D3:** Automatic VNI extraction and propagation to CUDN is in scope; `0:VNI_ID` route-target format is out of scope
-- **D4:** One-subnet-per-VirtualNetwork validation enforced at Subnet API creation time in fulfillment-service
+- **D3:** Automatic VNI propagation from fabric manager to k8s manager is in scope; `0:VNI_ID` route-target format is out of scope
+- **D4:** One-subnet-per-VirtualNetwork validation enforced at Subnet API creation time, conditional on NetworkClass's k8s manager (applies to `cudn_evpn`, not universal)
 - **D5:** FRRConfiguration for EVPN overlay is automatic; BGP underlay peering is manual prerequisite
 - **D6:** Underlay configuration is documented prerequisite, not automated
 - **D7:** Route targets come from Netris (no client-side calculation)

--- a/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
+++ b/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
@@ -17,9 +17,9 @@ The OVN EVPN spike (OSAC-1717) validated the technical approach: VMs can join th
 ## In Scope
 
 - **K8s manager registration** via ConfigMap (identifier: `cudn_evpn`, capabilities: IPv4 address family) [Clarify: R2.Q4]
-- **Automatic VNI and route-target propagation** from Netris VPC/VNet creation to CUDN configuration — route targets are set automatically without manual configuration [Clarify: R1.Q3, R2.Q5, D7] [User]
+- **Automatic VNI propagation** from Netris VPC/VNet creation to CUDN configuration (route targets are calculated automatically from VNI) [Clarify: R1.Q3, R2.Q5, D7] [User]
 - **Automatic CUDN creation** with EVPN transport topology when a VirtualNetwork/Subnet is created [Clarify: R2.Q1]
-- **Automatic FRRConfiguration creation** for EVPN overlay (VNI-specific route targets, L2VPN EVPN address family) [Clarify: R2.Q1, D5]
+- **Automatic BGP EVPN route advertisement** for VMs, using VNI mappings from Netris [Clarify: R2.Q1, D5]
 - **VM-to-fabric connectivity** via BGP EVPN (Type-2 MAC/IP routes, Type-3 VTEP discovery, Type-5 prefix routes)
 - **Layer 2 and Layer 3 VPC support** — CUDN can bridge to Netris VPCs with flexible subnet configuration: same subnet as Netris VNet uses Layer 2 VNI (macVRF) for L2 connectivity; different subnet uses Layer 3 VNI (ipVRF) for L3 routing [User]
 - **Single-subnet-per-VirtualNetwork constraint** enforced at Subnet API creation time (OVN Connectors limitation) [Clarify: R1.Q4, D4]
@@ -56,13 +56,13 @@ The following are out of scope for Phase 1:
 
 - As a Cloud Infrastructure Admin, I want FRR diagnostic commands documented (show evpn vni, show bgp l2vpn evpn, show bgp vni <VNI>, show bgp l2vpn evpn summary) so that I can verify VNI creation and troubleshoot VNI/route-target mismatches. [Clarify: R3.Q2]
 
-- As a Cloud Infrastructure Admin, I want the k8s manager to automatically create FRRConfiguration for EVPN overlay (VNI-specific route targets from Netris, L2VPN EVPN address family) when a CUDN is created so that VMs can advertise routes to the fabric without manual FRR or route-target configuration. [Clarify: R2.Q1, D5, D7] [User]
+- As a Cloud Infrastructure Admin, I want VMs to automatically advertise their routes to the fabric via BGP EVPN when a subnet is provisioned, using VNI mappings from Netris, so that VMs are reachable from the fabric without manual BGP configuration. [Clarify: R2.Q1, D5, D7] [User]
 
 - As a Cloud Infrastructure Admin, I want integration tests to run automatically in CI against a real Netris fabric so that I can verify the full path from subnet creation through VM-to-bare-metal connectivity before deployment. [Clarify: R3.Q1, D8]
 
 ### Tenant Admin / Tenant User
 
-- As a Tenant Admin or Tenant User, I want to create VirtualNetworks and Subnets using the existing OSAC API without needing to configure EVPN details (VNIs, route targets, BGP peering) so that VMs I provision are automatically bridged to the physical fabric. [Clarify: R1.Q2, D2]
+- As a Tenant Admin or Tenant User, I want to create VirtualNetworks and Subnets using the existing OSAC API without needing to configure EVPN details (VNIs, BGP peering) so that VMs I provision are automatically bridged to the physical fabric. [Clarify: R1.Q2, D2]
 
 - As a Tenant Admin or Tenant User, I want VMs I provision on an EVPN-bridged subnet to receive IP addresses via OVN DHCP and be reachable from bare-metal servers in the same Netris VPC so that my workloads can span VMs and physical hosts — either via Layer 2 connectivity when using the same subnet, or via Layer 3 routing when using different subnets within the same VPC. [User]
 
@@ -72,7 +72,7 @@ The following are out of scope for Phase 1:
 
 - The Cloud Infrastructure Admin has completed the documented prerequisites (underlay link configuration, VTEP setup, BGP session with Netris including VTEP subnets/prefixes advertisement) before creating the first VirtualNetwork. [Clarify: R2.Q3] [User]
 
-- The Netris fabric manager returns VNI IDs and route target values when OSAC creates a VPC/VNet, enabling automatic propagation to CUDN without client-side calculation. [Clarify: R1.Q3, R2.Q5, D7]
+- The Netris fabric manager returns VNI IDs when OSAC creates a VPC/VNet, enabling automatic propagation to CUDN. Route targets are calculated automatically from VNI (no manual configuration required). [Clarify: R1.Q3, R2.Q5, D7]
 
 - OCP workers have network connectivity to the Netris fabric switches via the configured underlay link. [Clarify: R2.Q3]
 
@@ -92,10 +92,11 @@ The following are out of scope for Phase 1:
   - OSAC-1460: Wire dispatcher into controllers
 
 - **Netris Fabric Manager:** Must support:
-  - VPC/VNet creation with VNI ID allocation
-  - Route target calculation and return via API (`(leaf ASN % 65536):VNI` formula)
+  - VPC/VNet creation with VNI ID allocation and return via API
   - Underlay port configuration (via Netris API or UI)
   - BGP session configuration with OCP workers
+  
+  Route targets are calculated automatically using `(leaf ASN % 65536):VNI` formula — no API return or manual configuration needed.
 
 - **OVN-Kubernetes:** FRR routing capability with EVPN support, RouteAdvertisements for CUDN with EVPN transport topology. Constraint: does not currently route between separate CUDNs on the same cluster (Connectors feature pending). [Clarify: R1.Q4]
 

--- a/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
+++ b/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
@@ -20,12 +20,11 @@ The OVN EVPN spike (OSAC-1717) validated the technical approach: VMs can join th
 - **Automatic VNI propagation** from Netris VPC/VNet creation to CUDN configuration (route targets are calculated automatically from VNI) [Clarify: R1.Q3, R2.Q5, D7] [User]
 - **Automatic overlay network provisioning** on hosting clusters (via ClusterUserDefinedNetwork with EVPN transport) when a VirtualNetwork/Subnet is created [Clarify: R2.Q1]
 - **Automatic BGP EVPN route advertisement** for VMs, using VNI mappings from Netris [Clarify: R2.Q1, D5]
-- **VM-to-fabric connectivity** via BGP EVPN (Type-2 MAC/IP routes, Type-3 VTEP discovery, Type-5 prefix routes)
-- **Layer 2 and Layer 3 VPC support** — CUDN can bridge to Netris VPCs with flexible subnet configuration: same subnet as Netris VNet uses Layer 2 VNI (macVRF) for L2 connectivity; different subnet uses Layer 3 VNI (ipVRF) for L3 routing [User]
+- **VM-to-fabric connectivity** — VMs are discoverable and directly reachable from bare-metal servers on the physical fabric
+- **Layer 2 and Layer 3 VPC support** — VMs can be bridged to Netris VPCs with flexible subnet configuration: same subnet uses Layer 2 bridging for direct connectivity; different subnets within the same VPC use Layer 3 routing [User]
 - **Single-subnet-per-VirtualNetwork constraint** enforced at Subnet API creation time (OVN Connectors limitation) [Clarify: R1.Q4, D4]
-- **DHCP range coordination** between OCP CUDN IPAM and Netris DHCP to avoid IP collisions [Clarify: R1.Q5]
+- **Non-conflicting IP address assignment** — VMs receive IP addresses that do not conflict with Netris DHCP allocations [Clarify: R1.Q5]
 - **Installation prerequisites documentation** for Cloud Infrastructure Admin (underlay link, VTEP setup, BGP peering with VTEP subnets/prefixes advertisement) [Clarify: R2.Q2, R2.Q3, D6] [User]
-- **Integration test** automated in CI with real Netris fabric, covering subnet creation → CUDN + EVPN → VM placement → fabric reachability (ping from worker to switch, VM to bare-metal connectivity) [Clarify: R3.Q1, D8]
 - **Diagnostic tooling documentation** for Cloud Infrastructure Admin (FRR commands: `show evpn vni`, `show bgp l2vpn evpn`, `show bgp vni <VNI>`, `show bgp l2vpn evpn summary`) [Clarify: R3.Q2]
 - **Single hosting cluster** (no multi-cluster VM placement)
 - **Release 0.3**
@@ -41,7 +40,7 @@ The following are explicitly deferred to Phase 2 (OSAC-3667, release 0.4):
 
 The following are out of scope for Phase 1:
 
-- **`0:VNI_ID` route-target standardization** — deferred until Netris implements it. Phase 1 uses `(leaf ASN % 65536):VNI` formula, but route targets are automatically provided by Netris (no manual calculation or configuration required). [Clarify: R1.Q3, D3, D7] [User]
+- **`0:VNI_ID` route-target standardization** — deferred until Netris implements it. Phase 1 uses `(leaf ASN % 65536):VNI` formula, with route targets calculated automatically from VNI (no manual configuration required). [Clarify: R1.Q3, D3, D7] [User]
 - **MetalLB IPAddressPool creation** — handled separately in OSAC-1436 (CaaS Networking) [Clarify: R3.Q3, D9]
 - **BGP underlay automation** — physical link configuration, Netris port setup, and BGP session creation are manual prerequisites configured by Cloud Infrastructure Admin [Clarify: R2.Q1, R2.Q3, D5, D6]
 - **Dual gateway MAC coordination** — automatic matching of OCP CUDN gateway and Netris VNet gateway MAC addresses (known limitation requiring manual coordination) [Clarify: R1.Q5]
@@ -57,8 +56,6 @@ The following are out of scope for Phase 1:
 - As a Cloud Infrastructure Admin, I want FRR diagnostic commands documented (show evpn vni, show bgp l2vpn evpn, show bgp vni <VNI>, show bgp l2vpn evpn summary) so that I can verify VNI creation and troubleshoot VNI/route-target mismatches. [Clarify: R3.Q2]
 
 - As a Cloud Infrastructure Admin, I want VMs to automatically advertise their routes to the fabric via BGP EVPN when a subnet is provisioned, using VNI mappings from Netris, so that VMs are reachable from the fabric without manual BGP configuration. [Clarify: R2.Q1, D5, D7] [User]
-
-- As a Cloud Infrastructure Admin, I want integration tests to run automatically in CI against a real Netris fabric so that I can verify the full path from subnet creation through VM-to-bare-metal connectivity before deployment. [Clarify: R3.Q1, D8]
 
 - As a Cloud Infrastructure Admin, I want to identify which VirtualNetworks have reached the single-subnet limit (via monitoring or status queries) so that I can plan for Phase 2 deployment or guide tenants to create additional VirtualNetworks.
 
@@ -85,12 +82,14 @@ The following are out of scope for Phase 1:
 ## Acceptance Criteria
 
 - [ ] A NetworkClass with `fabric_manager: "netris"` and `k8s_manager: "cudn_evpn"` can be created and transitions to READY state
-- [ ] Creating a VirtualNetwork + Subnet with this NetworkClass provisions both Netris VNet (with L2/L3 VNI) and OCP CUDN with EVPN transport
-- [ ] VMs deployed on the subnet receive IP addresses via OVN DHCP
-- [ ] VMs are reachable via ping from a bare-metal server on the same Netris VPC (both L2 same-subnet and L3 different-subnet scenarios)
-- [ ] FRR diagnostic commands (`show evpn vni`, `show bgp l2vpn evpn`) show correct VNI and route-target state on OCP workers
+- [ ] Creating a VirtualNetwork + Subnet with this NetworkClass provisions both Netris VNet (with L2/L3 VNI) and overlay network on OCP
+- [ ] VMs deployed on the subnet receive IP addresses that do not conflict with Netris DHCP allocations
+- [ ] VMs are discoverable and directly reachable from bare-metal servers on the physical fabric (both L2 same-subnet and L3 different-subnet scenarios)
+- [ ] FRR diagnostic commands show correct VNI state on OCP workers
 - [ ] Creating a second Subnet under the same VirtualNetwork returns a validation error message referencing OVN Connectors limitation
-- [ ] Integration test in CI passes: subnet creation → CUDN + EVPN provisioning → VM placement → fabric reachability verification
+
+**Non-Functional:**
+- [ ] Automated integration test in CI verifies end-to-end flow: subnet creation → dual-dispatch provisioning → VM placement → fabric reachability
 
 ## Dependencies
 
@@ -98,10 +97,7 @@ The following are out of scope for Phase 1:
 
 - **OSAC-1433 (Unified Networking Architecture):** Provides foundation for NetworkClass, dispatcher, k8s manager registration pattern. This design extends OSAC-1433 with the OVN EVPN k8s manager section. [Clarify: R3.Q4, D10]
 
-- **OSAC-1440 (Dispatcher Core):** Provides dispatcher infrastructure for routing networking operations to fabric and k8s managers. Specifically:
-  - OSAC-1457: Dispatcher resolution logic
-  - OSAC-1458: Dispatch table
-  - OSAC-1460: Wire dispatcher into controllers
+- **OSAC-1440 (Dispatcher Core):** Provides dispatcher infrastructure for routing networking operations to fabric and k8s managers based on NetworkClass configuration.
 
 - **Netris Fabric Manager:** Must support:
   - VPC/VNet creation with VNI ID allocation and return via API

--- a/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
+++ b/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
@@ -21,6 +21,7 @@ The OVN EVPN spike (OSAC-1717) validated the technical approach: VMs can join th
 - **Automatic CUDN creation** with EVPN transport topology when a VirtualNetwork/Subnet is created [Clarify: R2.Q1]
 - **Automatic FRRConfiguration creation** for EVPN overlay (VNI-specific route targets, L2VPN EVPN address family) [Clarify: R2.Q1, D5]
 - **VM-to-fabric connectivity** via BGP EVPN (Type-2 MAC/IP routes, Type-3 VTEP discovery, Type-5 prefix routes)
+- **Layer 2 and Layer 3 VPC support** — CUDN can bridge to Netris VPCs with flexible subnet configuration: same subnet as Netris VNet uses Layer 2 VNI (macVRF) for L2 connectivity; different subnet uses Layer 3 VNI (ipVRF) for L3 routing [User]
 - **Single-subnet-per-VirtualNetwork constraint** enforced at Subnet API creation time (OVN Connectors limitation) [Clarify: R1.Q4, D4]
 - **DHCP range coordination** between OCP CUDN IPAM and Netris DHCP to avoid IP collisions [Clarify: R1.Q5]
 - **Installation prerequisites documentation** for Cloud Infrastructure Admin (underlay link, VTEP setup, BGP peering) [Clarify: R2.Q2, R2.Q3, D6]
@@ -63,7 +64,7 @@ The following are out of scope for Phase 1:
 
 - As a Tenant Admin or Tenant User, I want to create VirtualNetworks and Subnets using the existing OSAC API without needing to configure EVPN details (VNIs, route targets, BGP peering) so that VMs I provision are automatically bridged to the physical fabric. [Clarify: R1.Q2, D2]
 
-- As a Tenant Admin or Tenant User, I want VMs I provision on an EVPN-bridged subnet to receive IP addresses via OVN DHCP and be reachable from bare-metal servers on the same Netris VPC subnet so that my workloads can span VMs and physical hosts in the same L2 network.
+- As a Tenant Admin or Tenant User, I want VMs I provision on an EVPN-bridged subnet to receive IP addresses via OVN DHCP and be reachable from bare-metal servers in the same Netris VPC so that my workloads can span VMs and physical hosts — either via Layer 2 connectivity when using the same subnet, or via Layer 3 routing when using different subnets within the same VPC. [User]
 
 - As a Tenant Admin or Tenant User, I want the system to reject my second Subnet creation attempt under the same VirtualNetwork with a clear error message referencing the OVN Connectors limitation so that I understand the constraint and can structure my networks accordingly. [Clarify: R1.Q4, D4]
 
@@ -104,8 +105,11 @@ The following are out of scope for Phase 1:
 
 ## Provenance
 
-Committed: commit @ prd 0.8.0 - 837cf0d, workspace prd/OSAC-4291 @ e18362f (20 behind origin/main)
+Authored: commit @ prd 0.8.0 - 837cf0d, workspace prd/OSAC-4291 @ e18362f (20 behind origin/main)
+Final: revise @ prd 0.8.0 - 837cf0d, workspace prd/OSAC-4291 @ a346761 (20 behind origin/main)
 
-> Authoring phases not recorded this session (commit-time snapshot only).
+> Context changed between commit and revise.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"837cf0d","source_repo":"e18362f","source_repo_branch":"prd/OSAC-4291","commits_behind_main":20,"commits_ahead_main":0,"main_ref":"main","phases":["commit"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+> This document's phase history does not include an initial /draft — structure was not verified against the template from origin.
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"837cf0d","source_repo":"a346761","source_repo_branch":"prd/OSAC-4291","commits_behind_main":20,"commits_ahead_main":1,"main_ref":"main","phases":["commit","revise"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":true} -->

--- a/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
+++ b/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
@@ -24,7 +24,7 @@ The OVN EVPN spike (OSAC-1717) validated the technical approach: VMs can join th
 - **Layer 2 and Layer 3 VPC support** — CUDN can bridge to Netris VPCs with flexible subnet configuration: same subnet as Netris VNet uses Layer 2 VNI (macVRF) for L2 connectivity; different subnet uses Layer 3 VNI (ipVRF) for L3 routing [User]
 - **Single-subnet-per-VirtualNetwork constraint** enforced at Subnet API creation time (OVN Connectors limitation) [Clarify: R1.Q4, D4]
 - **DHCP range coordination** between OCP CUDN IPAM and Netris DHCP to avoid IP collisions [Clarify: R1.Q5]
-- **Installation prerequisites documentation** for Cloud Infrastructure Admin (underlay link, VTEP setup, BGP peering) [Clarify: R2.Q2, R2.Q3, D6]
+- **Installation prerequisites documentation** for Cloud Infrastructure Admin (underlay link, VTEP setup, BGP peering with VTEP subnets/prefixes advertisement) [Clarify: R2.Q2, R2.Q3, D6] [User]
 - **Integration test** automated in CI with real Netris fabric, covering subnet creation → CUDN + EVPN → VM placement → fabric reachability (ping from worker to switch, VM to bare-metal connectivity) [Clarify: R3.Q1, D8]
 - **Diagnostic tooling documentation** for Cloud Infrastructure Admin (FRR commands: `show evpn vni`, `show bgp l2vpn evpn`, `show bgp vni <VNI>`, `show bgp l2vpn evpn summary`) [Clarify: R3.Q2]
 - **Single hosting cluster** (no multi-cluster VM placement)
@@ -52,7 +52,7 @@ The following are out of scope for Phase 1:
 
 - As a Cloud Infrastructure Admin, I want to register the OVN EVPN k8s manager via a NetworkClass ConfigMap so that OSAC can provision EVPN-bridged subnets for VMs. [Clarify: R1.Q1, R2.Q4, D1]
 
-- As a Cloud Infrastructure Admin, I want documented installation prerequisites (underlay link setup, VTEP configuration, BGP peering with Netris) so that I can prepare the infrastructure before enabling EVPN for the first time. [Clarify: R2.Q2, R2.Q3, D6]
+- As a Cloud Infrastructure Admin, I want documented installation prerequisites (underlay link setup, VTEP configuration, BGP peering with Netris including VTEP subnets/prefixes advertisement) so that I can prepare the infrastructure before enabling EVPN for the first time. [Clarify: R2.Q2, R2.Q3, D6] [User]
 
 - As a Cloud Infrastructure Admin, I want FRR diagnostic commands documented (show evpn vni, show bgp l2vpn evpn, show bgp vni <VNI>, show bgp l2vpn evpn summary) so that I can verify VNI creation and troubleshoot VNI/route-target mismatches. [Clarify: R3.Q2]
 
@@ -70,7 +70,7 @@ The following are out of scope for Phase 1:
 
 ## Assumptions
 
-- The Cloud Infrastructure Admin has completed the documented prerequisites (underlay link configuration, VTEP setup, BGP session with Netris) before creating the first VirtualNetwork. [Clarify: R2.Q3]
+- The Cloud Infrastructure Admin has completed the documented prerequisites (underlay link configuration, VTEP setup, BGP session with Netris including VTEP subnets/prefixes advertisement) before creating the first VirtualNetwork. [Clarify: R2.Q3] [User]
 
 - The Netris fabric manager returns VNI IDs and route target values when OSAC creates a VPC/VNet, enabling automatic propagation to CUDN without client-side calculation. [Clarify: R1.Q3, R2.Q5, D7]
 
@@ -106,10 +106,10 @@ The following are out of scope for Phase 1:
 ## Provenance
 
 Authored: commit @ prd 0.8.0 - 837cf0d, workspace prd/OSAC-4291 @ e18362f (20 behind origin/main)
-Final: revise @ prd 0.8.0 - 837cf0d, workspace prd/OSAC-4291 @ a346761 (20 behind origin/main)
+Final: revise @ prd 0.8.0 - 837cf0d, workspace prd/OSAC-4291 @ cd2cbfa (20 behind origin/main)
 
 > Context changed between commit and revise.
 
 > This document's phase history does not include an initial /draft — structure was not verified against the template from origin.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"837cf0d","source_repo":"a346761","source_repo_branch":"prd/OSAC-4291","commits_behind_main":20,"commits_ahead_main":1,"main_ref":"main","phases":["commit","revise"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"837cf0d","source_repo":"cd2cbfa","source_repo_branch":"prd/OSAC-4291","commits_behind_main":20,"commits_ahead_main":2,"main_ref":"main","phases":["commit","revise","revise"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":true} -->

--- a/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
+++ b/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
@@ -16,9 +16,9 @@ The OVN EVPN spike (OSAC-1717) validated the technical approach: VMs can join th
 
 ## In Scope
 
-- **K8s manager registration** via ConfigMap (identifier: `cudn_evpn`, capabilities: IPv4 address family) [Clarify: R2.Q4]
+- **K8s manager registration** via ConfigMap (identifier: `cudn_evpn`, capabilities: `addressFamily:ipv4`) [Clarify: R2.Q4]
 - **Automatic VNI propagation** from Netris VPC/VNet creation to CUDN configuration (route targets are calculated automatically from VNI) [Clarify: R1.Q3, R2.Q5, D7] [User]
-- **Automatic CUDN creation** with EVPN transport topology when a VirtualNetwork/Subnet is created [Clarify: R2.Q1]
+- **Automatic overlay network provisioning** on hosting clusters (via ClusterUserDefinedNetwork with EVPN transport) when a VirtualNetwork/Subnet is created [Clarify: R2.Q1]
 - **Automatic BGP EVPN route advertisement** for VMs, using VNI mappings from Netris [Clarify: R2.Q1, D5]
 - **VM-to-fabric connectivity** via BGP EVPN (Type-2 MAC/IP routes, Type-3 VTEP discovery, Type-5 prefix routes)
 - **Layer 2 and Layer 3 VPC support** — CUDN can bridge to Netris VPCs with flexible subnet configuration: same subnet as Netris VNet uses Layer 2 VNI (macVRF) for L2 connectivity; different subnet uses Layer 3 VNI (ipVRF) for L3 routing [User]
@@ -50,7 +50,7 @@ The following are out of scope for Phase 1:
 
 ### Cloud Infrastructure Admin
 
-- As a Cloud Infrastructure Admin, I want to register the `cudn_evpn` k8s manager via a ConfigMap (with IPv4 address family capability) so that OSAC can provision EVPN-bridged subnets for VMs. [Clarify: R1.Q1, R2.Q4, D1]
+- As a Cloud Infrastructure Admin, I want to register the `cudn_evpn` k8s manager via a ConfigMap (with `addressFamily:ipv4` capability) so that OSAC can provision EVPN-bridged subnets for VMs. [Clarify: R1.Q1, R2.Q4, D1]
 
 - As a Cloud Infrastructure Admin, I want documented installation prerequisites (underlay link setup, VTEP configuration, BGP peering with Netris including VTEP subnets/prefixes advertisement) so that I can prepare the infrastructure before enabling EVPN for the first time. [Clarify: R2.Q2, R2.Q3, D6] [User]
 
@@ -59,6 +59,8 @@ The following are out of scope for Phase 1:
 - As a Cloud Infrastructure Admin, I want VMs to automatically advertise their routes to the fabric via BGP EVPN when a subnet is provisioned, using VNI mappings from Netris, so that VMs are reachable from the fabric without manual BGP configuration. [Clarify: R2.Q1, D5, D7] [User]
 
 - As a Cloud Infrastructure Admin, I want integration tests to run automatically in CI against a real Netris fabric so that I can verify the full path from subnet creation through VM-to-bare-metal connectivity before deployment. [Clarify: R3.Q1, D8]
+
+- As a Cloud Infrastructure Admin, I want to identify which VirtualNetworks have reached the single-subnet limit (via monitoring or status queries) so that I can plan for Phase 2 deployment or guide tenants to create additional VirtualNetworks.
 
 ### Tenant Admin / Tenant User
 
@@ -79,6 +81,16 @@ The following are out of scope for Phase 1:
 - The FRR operator and NMState operator are installed on the OCP cluster before EVPN configuration. [Clarify: R2.Q2]
 
 - A NetworkClass exists with `fabric_manager: "netris"` and `k8s_manager: "cudn_evpn"`, enabling dual-dispatch provisioning where fabric and k8s manager jobs run in parallel for each subnet.
+
+## Acceptance Criteria
+
+- [ ] A NetworkClass with `fabric_manager: "netris"` and `k8s_manager: "cudn_evpn"` can be created and transitions to READY state
+- [ ] Creating a VirtualNetwork + Subnet with this NetworkClass provisions both Netris VNet (with L2/L3 VNI) and OCP CUDN with EVPN transport
+- [ ] VMs deployed on the subnet receive IP addresses via OVN DHCP
+- [ ] VMs are reachable via ping from a bare-metal server on the same Netris VPC (both L2 same-subnet and L3 different-subnet scenarios)
+- [ ] FRR diagnostic commands (`show evpn vni`, `show bgp l2vpn evpn`) show correct VNI and route-target state on OCP workers
+- [ ] Creating a second Subnet under the same VirtualNetwork returns a validation error message referencing OVN Connectors limitation
+- [ ] Integration test in CI passes: subnet creation → CUDN + EVPN provisioning → VM placement → fabric reachability verification
 
 ## Dependencies
 

--- a/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
+++ b/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
@@ -17,7 +17,7 @@ The OVN EVPN spike (OSAC-1717) validated the technical approach: VMs can join th
 ## In Scope
 
 - **K8s manager registration** via NetworkClass ConfigMap with declared capabilities (`cudn_evpn`, `ipv4` or `dualstack`) [Clarify: R2.Q4]
-- **Automatic VNI and route-target propagation** from Netris VPC/VNet creation to CUDN configuration [Clarify: R1.Q3]
+- **Automatic VNI and route-target propagation** from Netris VPC/VNet creation to CUDN configuration — route targets are set automatically without manual configuration [Clarify: R1.Q3, R2.Q5, D7] [User]
 - **Automatic CUDN creation** with EVPN transport topology when a VirtualNetwork/Subnet is created [Clarify: R2.Q1]
 - **Automatic FRRConfiguration creation** for EVPN overlay (VNI-specific route targets, L2VPN EVPN address family) [Clarify: R2.Q1, D5]
 - **VM-to-fabric connectivity** via BGP EVPN (Type-2 MAC/IP routes, Type-3 VTEP discovery, Type-5 prefix routes)
@@ -41,7 +41,7 @@ The following are explicitly deferred to Phase 2 (OSAC-3667, release 0.4):
 
 The following are out of scope for Phase 1:
 
-- **`0:VNI_ID` route-target standardization** — deferred until Netris implements it. Phase 1 uses `(leaf ASN % 65536):VNI` formula. [Clarify: R1.Q3, D3]
+- **`0:VNI_ID` route-target standardization** — deferred until Netris implements it. Phase 1 uses `(leaf ASN % 65536):VNI` formula, but route targets are automatically provided by Netris (no manual calculation or configuration required). [Clarify: R1.Q3, D3, D7] [User]
 - **MetalLB IPAddressPool creation** — handled separately in OSAC-1436 (CaaS Networking) [Clarify: R3.Q3, D9]
 - **BGP underlay automation** — physical link configuration, Netris port setup, and BGP session creation are manual prerequisites configured by Cloud Infrastructure Admin [Clarify: R2.Q1, R2.Q3, D5, D6]
 - **Dual gateway MAC coordination** — automatic matching of OCP CUDN gateway and Netris VNet gateway MAC addresses (known limitation requiring manual coordination) [Clarify: R1.Q5]
@@ -56,7 +56,7 @@ The following are out of scope for Phase 1:
 
 - As a Cloud Infrastructure Admin, I want FRR diagnostic commands documented (show evpn vni, show bgp l2vpn evpn, show bgp vni <VNI>, show bgp l2vpn evpn summary) so that I can verify VNI creation and troubleshoot VNI/route-target mismatches. [Clarify: R3.Q2]
 
-- As a Cloud Infrastructure Admin, I want the k8s manager to automatically create FRRConfiguration for EVPN overlay (VNI-specific route targets, L2VPN EVPN address family) when a CUDN is created so that VMs can advertise routes to the fabric without manual FRR configuration. [Clarify: R2.Q1, D5]
+- As a Cloud Infrastructure Admin, I want the k8s manager to automatically create FRRConfiguration for EVPN overlay (VNI-specific route targets from Netris, L2VPN EVPN address family) when a CUDN is created so that VMs can advertise routes to the fabric without manual FRR or route-target configuration. [Clarify: R2.Q1, D5, D7] [User]
 
 - As a Cloud Infrastructure Admin, I want integration tests to run automatically in CI against a real Netris fabric so that I can verify the full path from subnet creation through VM-to-bare-metal connectivity before deployment. [Clarify: R3.Q1, D8]
 
@@ -106,10 +106,10 @@ The following are out of scope for Phase 1:
 ## Provenance
 
 Authored: commit @ prd 0.8.0 - 837cf0d, workspace prd/OSAC-4291 @ e18362f (20 behind origin/main)
-Final: revise @ prd 0.8.0 - 837cf0d, workspace prd/OSAC-4291 @ cd2cbfa (20 behind origin/main)
+Final: revise @ prd 0.8.0 - 837cf0d, workspace prd/OSAC-4291 @ e69542d (20 behind origin/main)
 
 > Context changed between commit and revise.
 
 > This document's phase history does not include an initial /draft — structure was not verified against the template from origin.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"837cf0d","source_repo":"cd2cbfa","source_repo_branch":"prd/OSAC-4291","commits_behind_main":20,"commits_ahead_main":2,"main_ref":"main","phases":["commit","revise","revise"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":true} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"837cf0d","source_repo":"e69542d","source_repo_branch":"prd/OSAC-4291","commits_behind_main":20,"commits_ahead_main":3,"main_ref":"main","phases":["commit","revise","revise","revise"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":true} -->

--- a/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
+++ b/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
@@ -16,7 +16,7 @@ The OVN EVPN spike (OSAC-1717) validated the technical approach: VMs can join th
 
 ## In Scope
 
-- **K8s manager registration** via NetworkClass ConfigMap with declared capabilities (`cudn_evpn`, `ipv4` or `dualstack`) [Clarify: R2.Q4]
+- **K8s manager registration** via ConfigMap (identifier: `cudn_evpn`, capabilities: IPv4 address family) [Clarify: R2.Q4]
 - **Automatic VNI and route-target propagation** from Netris VPC/VNet creation to CUDN configuration — route targets are set automatically without manual configuration [Clarify: R1.Q3, R2.Q5, D7] [User]
 - **Automatic CUDN creation** with EVPN transport topology when a VirtualNetwork/Subnet is created [Clarify: R2.Q1]
 - **Automatic FRRConfiguration creation** for EVPN overlay (VNI-specific route targets, L2VPN EVPN address family) [Clarify: R2.Q1, D5]
@@ -50,7 +50,7 @@ The following are out of scope for Phase 1:
 
 ### Cloud Infrastructure Admin
 
-- As a Cloud Infrastructure Admin, I want to register the OVN EVPN k8s manager via a NetworkClass ConfigMap so that OSAC can provision EVPN-bridged subnets for VMs. [Clarify: R1.Q1, R2.Q4, D1]
+- As a Cloud Infrastructure Admin, I want to register the `cudn_evpn` k8s manager via a ConfigMap (with IPv4 address family capability) so that OSAC can provision EVPN-bridged subnets for VMs. [Clarify: R1.Q1, R2.Q4, D1]
 
 - As a Cloud Infrastructure Admin, I want documented installation prerequisites (underlay link setup, VTEP configuration, BGP peering with Netris including VTEP subnets/prefixes advertisement) so that I can prepare the infrastructure before enabling EVPN for the first time. [Clarify: R2.Q2, R2.Q3, D6] [User]
 
@@ -77,6 +77,8 @@ The following are out of scope for Phase 1:
 - OCP workers have network connectivity to the Netris fabric switches via the configured underlay link. [Clarify: R2.Q3]
 
 - The FRR operator and NMState operator are installed on the OCP cluster before EVPN configuration. [Clarify: R2.Q2]
+
+- A NetworkClass exists with `fabric_manager: "netris"` and `k8s_manager: "cudn_evpn"`, enabling dual-dispatch provisioning where fabric and k8s manager jobs run in parallel for each subnet.
 
 ## Dependencies
 

--- a/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
+++ b/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
@@ -1,0 +1,111 @@
+# K8s Manager — OVN EVPN Phase 1: Single-Cluster VM-to-Fabric Bridging
+
+| Field       | Value   |
+|-------------|---------|
+| Author(s)   | Benny Kopilov |
+| Jira        | https://redhat.atlassian.net/browse/OSAC-4291 |
+| Date        | 2026-08-30 |
+
+## Problem Statement
+
+OSAC runs VMs on OpenShift using KubeVirt, which encapsulates each VM in a pod whose networking is managed by OVN-Kubernetes. By default, VM IP addresses exist only within the OVN overlay and are not visible on the physical fabric. This prevents VMs from being first-class fabric participants — they cannot share the same L2 subnet with bare-metal servers, cannot be reached directly from the fabric, and cannot leverage the fabric's multi-tenancy and routing capabilities.
+
+Without a k8s manager that bridges VMs to the fabric, tenants cannot deploy workloads that span VMs and bare-metal hosts in the same subnet. The CUDN LocalNet approach (OSAC-1511) has been frozen in favor of OVN EVPN, which provides better scalability and multi-cluster support. [Clarify: R1.Q3]
+
+The OVN EVPN spike (OSAC-1717) validated the technical approach: VMs can join the fabric via BGP EVPN route advertisements, enabling MAC/IP learning (Type-2 routes), VTEP discovery (Type-3 routes), and cross-subnet reachability (Type-5 routes). Phase 1 delivers single-cluster EVPN bridging with a constraint that OVN-Kubernetes does not currently route between separate CUDNs on the same cluster (the Connectors feature is pending). [Clarify: R1.Q4]
+
+## In Scope
+
+- **K8s manager registration** via NetworkClass ConfigMap with declared capabilities (`cudn_evpn`, `ipv4` or `dualstack`) [Clarify: R2.Q4]
+- **Automatic VNI and route-target propagation** from Netris VPC/VNet creation to CUDN configuration [Clarify: R1.Q3]
+- **Automatic CUDN creation** with EVPN transport topology when a VirtualNetwork/Subnet is created [Clarify: R2.Q1]
+- **Automatic FRRConfiguration creation** for EVPN overlay (VNI-specific route targets, L2VPN EVPN address family) [Clarify: R2.Q1, D5]
+- **VM-to-fabric connectivity** via BGP EVPN (Type-2 MAC/IP routes, Type-3 VTEP discovery, Type-5 prefix routes)
+- **Single-subnet-per-VirtualNetwork constraint** enforced at Subnet API creation time (OVN Connectors limitation) [Clarify: R1.Q4, D4]
+- **DHCP range coordination** between OCP CUDN IPAM and Netris DHCP to avoid IP collisions [Clarify: R1.Q5]
+- **Installation prerequisites documentation** for Cloud Infrastructure Admin (underlay link, VTEP setup, BGP peering) [Clarify: R2.Q2, R2.Q3, D6]
+- **Integration test** automated in CI with real Netris fabric, covering subnet creation → CUDN + EVPN → VM placement → fabric reachability (ping from worker to switch, VM to bare-metal connectivity) [Clarify: R3.Q1, D8]
+- **Diagnostic tooling documentation** for Cloud Infrastructure Admin (FRR commands: `show evpn vni`, `show bgp l2vpn evpn`, `show bgp vni <VNI>`, `show bgp l2vpn evpn summary`) [Clarify: R3.Q2]
+- **Single hosting cluster** (no multi-cluster VM placement)
+- **Release 0.3**
+
+## Out of Scope
+
+The following are explicitly deferred to Phase 2 (OSAC-3667, release 0.4):
+
+- **Multi-cluster hosting** — subnet provisioned on multiple clusters with VMs on different clusters sharing the same subnet via fabric
+- **Inter-subnet L3 routing between VMs** on the same cluster (requires OVN Connectors for inter-CUDN routing)
+- **Multi-NIC VMs with all NICs fabric-reachable** (requires EVPN support for secondary UDN interface advertisement)
+- **DPU-based bridging** — hardware offload of OVN-to-fabric bridging via SmartNICs
+
+The following are out of scope for Phase 1:
+
+- **`0:VNI_ID` route-target standardization** — deferred until Netris implements it. Phase 1 uses `(leaf ASN % 65536):VNI` formula. [Clarify: R1.Q3, D3]
+- **MetalLB IPAddressPool creation** — handled separately in OSAC-1436 (CaaS Networking) [Clarify: R3.Q3, D9]
+- **BGP underlay automation** — physical link configuration, Netris port setup, and BGP session creation are manual prerequisites configured by Cloud Infrastructure Admin [Clarify: R2.Q1, R2.Q3, D5, D6]
+- **Dual gateway MAC coordination** — automatic matching of OCP CUDN gateway and Netris VNet gateway MAC addresses (known limitation requiring manual coordination) [Clarify: R1.Q5]
+
+## User Stories
+
+### Cloud Infrastructure Admin
+
+- As a Cloud Infrastructure Admin, I want to register the OVN EVPN k8s manager via a NetworkClass ConfigMap so that OSAC can provision EVPN-bridged subnets for VMs. [Clarify: R1.Q1, R2.Q4, D1]
+
+- As a Cloud Infrastructure Admin, I want documented installation prerequisites (underlay link setup, VTEP configuration, BGP peering with Netris) so that I can prepare the infrastructure before enabling EVPN for the first time. [Clarify: R2.Q2, R2.Q3, D6]
+
+- As a Cloud Infrastructure Admin, I want FRR diagnostic commands documented (show evpn vni, show bgp l2vpn evpn, show bgp vni <VNI>, show bgp l2vpn evpn summary) so that I can verify VNI creation and troubleshoot VNI/route-target mismatches. [Clarify: R3.Q2]
+
+- As a Cloud Infrastructure Admin, I want the k8s manager to automatically create FRRConfiguration for EVPN overlay (VNI-specific route targets, L2VPN EVPN address family) when a CUDN is created so that VMs can advertise routes to the fabric without manual FRR configuration. [Clarify: R2.Q1, D5]
+
+- As a Cloud Infrastructure Admin, I want integration tests to run automatically in CI against a real Netris fabric so that I can verify the full path from subnet creation through VM-to-bare-metal connectivity before deployment. [Clarify: R3.Q1, D8]
+
+### Tenant Admin / Tenant User
+
+- As a Tenant Admin or Tenant User, I want to create VirtualNetworks and Subnets using the existing OSAC API without needing to configure EVPN details (VNIs, route targets, BGP peering) so that VMs I provision are automatically bridged to the physical fabric. [Clarify: R1.Q2, D2]
+
+- As a Tenant Admin or Tenant User, I want VMs I provision on an EVPN-bridged subnet to receive IP addresses via OVN DHCP and be reachable from bare-metal servers on the same Netris VPC subnet so that my workloads can span VMs and physical hosts in the same L2 network.
+
+- As a Tenant Admin or Tenant User, I want the system to reject my second Subnet creation attempt under the same VirtualNetwork with a clear error message referencing the OVN Connectors limitation so that I understand the constraint and can structure my networks accordingly. [Clarify: R1.Q4, D4]
+
+## Assumptions
+
+- The Cloud Infrastructure Admin has completed the documented prerequisites (underlay link configuration, VTEP setup, BGP session with Netris) before creating the first VirtualNetwork. [Clarify: R2.Q3]
+
+- The Netris fabric manager returns VNI IDs and route target values when OSAC creates a VPC/VNet, enabling automatic propagation to CUDN without client-side calculation. [Clarify: R1.Q3, R2.Q5, D7]
+
+- OCP workers have network connectivity to the Netris fabric switches via the configured underlay link. [Clarify: R2.Q3]
+
+- The FRR operator and NMState operator are installed on the OCP cluster before EVPN configuration. [Clarify: R2.Q2]
+
+## Dependencies
+
+- **OSAC-1717 (K8s Manager — OVN-Kubernetes EVPN Spike):** Validates OVN EVPN technical approach. Status: Closed.
+
+- **OSAC-1433 (Unified Networking Architecture):** Provides foundation for NetworkClass, dispatcher, k8s manager registration pattern. This design extends OSAC-1433 with the OVN EVPN k8s manager section. [Clarify: R3.Q4, D10]
+
+- **OSAC-1440 (Dispatcher Core):** Provides dispatcher infrastructure for routing networking operations to fabric and k8s managers. Specifically:
+  - OSAC-1457: Dispatcher resolution logic
+  - OSAC-1458: Dispatch table
+  - OSAC-1460: Wire dispatcher into controllers
+
+- **Netris Fabric Manager:** Must support:
+  - VPC/VNet creation with VNI ID allocation
+  - Route target calculation and return via API (`(leaf ASN % 65536):VNI` formula)
+  - Underlay port configuration (via Netris API or UI)
+  - BGP session configuration with OCP workers
+
+- **OVN-Kubernetes:** FRR routing capability with EVPN support, RouteAdvertisements for CUDN with EVPN transport topology. Constraint: does not currently route between separate CUDNs on the same cluster (Connectors feature pending). [Clarify: R1.Q4]
+
+- **OSAC-3667 (Phase 2):** Blocked by this feature. Adds multi-cluster hosting, inter-subnet routing, and multi-NIC support.
+
+- **OSAC-1435 (VMaaS Networking API Integration):** Blocked by this feature. Requires k8s manager (CUDN LocalNet or OVN EVPN) to be available before end-to-end VM networking works.
+
+---
+
+## Provenance
+
+Committed: commit @ prd 0.8.0 - 837cf0d, workspace prd/OSAC-4291 @ e18362f (20 behind origin/main)
+
+> Authoring phases not recorded this session (commit-time snapshot only).
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.8.0","ai_workflows":"837cf0d","source_repo":"e18362f","source_repo_branch":"prd/OSAC-4291","commits_behind_main":20,"commits_ahead_main":0,"main_ref":"main","phases":["commit"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
+++ b/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
@@ -16,16 +16,15 @@ The OVN EVPN spike (OSAC-1717) validated the technical approach: VMs can join th
 
 ## In Scope
 
-- **K8s manager registration** via ConfigMap (identifier: `cudn_evpn`, capabilities: `addressFamily:ipv4`) [Clarify: R2.Q4]
-- **Automatic VNI propagation** from Netris VPC/VNet creation to CUDN configuration (route targets are calculated automatically from VNI) [Clarify: R1.Q3, R2.Q5, D7] [User]
-- **Automatic overlay network provisioning** on hosting clusters (via ClusterUserDefinedNetwork with EVPN transport) when a VirtualNetwork/Subnet is created [Clarify: R2.Q1]
-- **Automatic BGP EVPN route advertisement** for VMs, using VNI mappings from Netris [Clarify: R2.Q1, D5]
-- **VM-to-fabric connectivity** — VMs are discoverable and directly reachable from bare-metal servers on the physical fabric
-- **Layer 2 and Layer 3 VPC support** — VMs can be bridged to Netris VPCs with flexible subnet configuration: same subnet uses Layer 2 bridging for direct connectivity; different subnets within the same VPC use Layer 3 routing [User]
-- **Single-subnet-per-VirtualNetwork constraint** enforced at Subnet API creation time (OVN Connectors limitation) [Clarify: R1.Q4, D4]
-- **Non-conflicting IP address assignment** — VMs receive IP addresses that do not conflict with Netris DHCP allocations [Clarify: R1.Q5]
-- **Installation prerequisites documentation** for Cloud Infrastructure Admin (underlay link, VTEP setup, BGP peering with VTEP subnets/prefixes advertisement) [Clarify: R2.Q2, R2.Q3, D6] [User]
-- **Diagnostic tooling documentation** for Cloud Infrastructure Admin (FRR commands: `show evpn vni`, `show bgp l2vpn evpn`, `show bgp vni <VNI>`, `show bgp l2vpn evpn summary`) [Clarify: R3.Q2]
+- **K8s manager registration** for EVPN fabric bridging (IPv4 address family only) [Clarify: R2.Q4]
+- **Fabric-to-k8s manager data dependency** — subnet provisioning must ensure the fabric manager completes and provides network segment identifiers before the k8s manager begins, using a manager-agnostic interface [Clarify: R1.Q3, R2.Q5, D7] [User]
+- **Automatic overlay network provisioning** on hosting clusters that bridges VMs to the physical fabric when a VirtualNetwork/Subnet is created [Clarify: R2.Q1]
+- **VM-to-fabric connectivity** — VMs are discoverable and directly reachable from bare-metal servers on the physical fabric (both L2 same-subnet and L3 cross-subnet scenarios)
+- **Single-subnet-per-VirtualNetwork constraint for this k8s manager** — when a VirtualNetwork uses a NetworkClass with this k8s manager, the system rejects additional subnet creation with a clear error [Clarify: R1.Q4, D4]
+- **Non-conflicting IP address assignment** — VMs receive IP addresses that do not conflict with fabric DHCP allocations [Clarify: R1.Q5]
+- **Installation prerequisites documentation** — Cloud Infrastructure Admin must complete documented infrastructure prerequisites to enable physical fabric connectivity before creating the first VirtualNetwork [Clarify: R2.Q2, R2.Q3, D6] [User]
+- **Diagnostic tooling documentation** — documented tools for Cloud Infrastructure Admins to verify network segment state and troubleshoot connectivity issues [Clarify: R3.Q2]
+- **Gateway MAC coordination prerequisite** — Cloud Infrastructure Admin must ensure gateway MAC addresses match between overlay and fabric before enabling EVPN to prevent L3 traffic failures [Clarify: R1.Q5]
 - **Single hosting cluster** (no multi-cluster VM placement)
 - **Release 0.3**
 
@@ -40,44 +39,45 @@ The following are explicitly deferred to Phase 2 (OSAC-3667, release 0.4):
 
 The following are out of scope for Phase 1:
 
-- **`0:VNI_ID` route-target standardization** — deferred until Netris implements it. Phase 1 uses `(leaf ASN % 65536):VNI` formula, with route targets calculated automatically from VNI (no manual configuration required). [Clarify: R1.Q3, D3, D7] [User]
+- **IPv6 and dual-stack support** — Phase 1 supports IPv4 only. IPv6 route advertisement via EVPN is untested and deferred to Phase 2. [Clarify: R2.Q4]
+- **Standardized route-target format** — deferred until fabric manager implements it [Clarify: R1.Q3, D3, D7] [User]
 - **MetalLB IPAddressPool creation** — handled separately in OSAC-1436 (CaaS Networking) [Clarify: R3.Q3, D9]
-- **BGP underlay automation** — physical link configuration, Netris port setup, and BGP session creation are manual prerequisites configured by Cloud Infrastructure Admin [Clarify: R2.Q1, R2.Q3, D5, D6]
-- **Dual gateway MAC coordination** — automatic matching of OCP CUDN gateway and Netris VNet gateway MAC addresses (known limitation requiring manual coordination) [Clarify: R1.Q5]
+- **Physical infrastructure automation** — manual prerequisites remain manual for Phase 1 [Clarify: R2.Q1, R2.Q3, D5, D6]
+- **Automatic gateway MAC coordination** — Cloud Infrastructure Admin must manually coordinate gateway MAC addresses (moved to prerequisites above) [Clarify: R1.Q5]
 
 ## User Stories
 
 ### Cloud Infrastructure Admin
 
-- As a Cloud Infrastructure Admin, I want to register the `cudn_evpn` k8s manager via a ConfigMap (with `addressFamily:ipv4` capability) so that OSAC can provision EVPN-bridged subnets for VMs. [Clarify: R1.Q1, R2.Q4, D1]
+- As a Cloud Infrastructure Admin, I want to register the EVPN k8s manager so that OSAC can provision fabric-bridged subnets for VMs. [Clarify: R1.Q1, R2.Q4, D1]
 
-- As a Cloud Infrastructure Admin, I want documented installation prerequisites (underlay link setup, VTEP configuration, BGP peering with Netris including VTEP subnets/prefixes advertisement) so that I can prepare the infrastructure before enabling EVPN for the first time. [Clarify: R2.Q2, R2.Q3, D6] [User]
+- As a Cloud Infrastructure Admin, I want documented installation prerequisites so that I can prepare the infrastructure before enabling EVPN for the first time. [Clarify: R2.Q2, R2.Q3, D6] [User]
 
-- As a Cloud Infrastructure Admin, I want FRR diagnostic commands documented (show evpn vni, show bgp l2vpn evpn, show bgp vni <VNI>, show bgp l2vpn evpn summary) so that I can verify VNI creation and troubleshoot VNI/route-target mismatches. [Clarify: R3.Q2]
-
-- As a Cloud Infrastructure Admin, I want VMs to automatically advertise their routes to the fabric via BGP EVPN when a subnet is provisioned, using VNI mappings from Netris, so that VMs are reachable from the fabric without manual BGP configuration. [Clarify: R2.Q1, D5, D7] [User]
+- As a Cloud Infrastructure Admin, I want documented diagnostic tools so that I can verify network segment state and troubleshoot connectivity issues when VMs cannot reach the fabric. [Clarify: R3.Q2]
 
 - As a Cloud Infrastructure Admin, I want to identify which VirtualNetworks have reached the single-subnet limit (via monitoring or status queries) so that I can plan for Phase 2 deployment or guide tenants to create additional VirtualNetworks.
 
 ### Tenant Admin / Tenant User
 
-- As a Tenant Admin or Tenant User, I want to create VirtualNetworks and Subnets using the existing OSAC API without needing to configure EVPN details (VNIs, BGP peering) so that VMs I provision are automatically bridged to the physical fabric. [Clarify: R1.Q2, D2]
+- As a Tenant Admin or Tenant User, I want to create VirtualNetworks and Subnets using the existing OSAC API without needing to configure fabric bridging details, so that VMs I provision are automatically reachable from the physical fabric. [Clarify: R1.Q2, D2]
 
-- As a Tenant Admin or Tenant User, I want VMs I provision on an EVPN-bridged subnet to receive IP addresses via OVN DHCP and be reachable from bare-metal servers in the same Netris VPC so that my workloads can span VMs and physical hosts — either via Layer 2 connectivity when using the same subnet, or via Layer 3 routing when using different subnets within the same VPC. [User]
+- As a Tenant Admin or Tenant User, I want VMs I provision on fabric-bridged subnets to be reachable from bare-metal servers, so that my workloads can span VMs and physical hosts. [User]
 
-- As a Tenant Admin or Tenant User, I want the system to reject my second Subnet creation attempt under the same VirtualNetwork with a clear error message referencing the OVN Connectors limitation so that I understand the constraint and can structure my networks accordingly. [Clarify: R1.Q4, D4]
+- As a Tenant Admin or Tenant User, I want the system to reject my second Subnet creation attempt under the same VirtualNetwork with a clear error message, so that I understand the constraint and can structure my networks accordingly. [Clarify: R1.Q4, D4]
 
 ## Assumptions
 
-- The Cloud Infrastructure Admin has completed the documented prerequisites (underlay link configuration, VTEP setup, BGP session with Netris including VTEP subnets/prefixes advertisement) before creating the first VirtualNetwork. [Clarify: R2.Q3] [User]
+- The Cloud Infrastructure Admin has completed the documented infrastructure prerequisites before creating the first VirtualNetwork. [Clarify: R2.Q3] [User]
 
-- The Netris fabric manager returns VNI IDs when OSAC creates a VPC/VNet, enabling automatic propagation to CUDN. Route targets are calculated automatically from VNI (no manual configuration required). [Clarify: R1.Q3, R2.Q5, D7]
+- The fabric manager provides network segment identifiers when OSAC creates a VPC/VNet, enabling automatic provisioning by the k8s manager without manual configuration. [Clarify: R1.Q3, R2.Q5, D7]
 
-- OCP workers have network connectivity to the Netris fabric switches via the configured underlay link. [Clarify: R2.Q3]
+- OCP workers have network connectivity to the fabric. [Clarify: R2.Q3]
 
-- The FRR operator and NMState operator are installed on the OCP cluster before EVPN configuration. [Clarify: R2.Q2]
+- A NetworkClass exists with both fabric and k8s managers configured, enabling dual-dispatch provisioning.
 
-- A NetworkClass exists with `fabric_manager: "netris"` and `k8s_manager: "cudn_evpn"`, enabling dual-dispatch provisioning where fabric and k8s manager jobs run in parallel for each subnet.
+- Fabric-level SecurityGroups (ACL rules) apply to fabric-bridged VM traffic.
+
+- Fabric-level NATGateways (SNAT via softgate) apply to fabric-bridged VM egress traffic.
 
 ## Acceptance Criteria
 
@@ -99,18 +99,21 @@ The following are out of scope for Phase 1:
 
 - **OSAC-1440 (Dispatcher Core):** Provides dispatcher infrastructure for routing networking operations to fabric and k8s managers based on NetworkClass configuration.
 
-- **Netris Fabric Manager:** Must support:
-  - VPC/VNet creation with VNI ID allocation and return via API
-  - Underlay port configuration (via Netris API or UI)
-  - BGP session configuration with OCP workers
-  
-  Route targets are calculated automatically using `(leaf ASN % 65536):VNI` formula — no API return or manual configuration needed.
+- **Fabric Manager (Netris):** Must support VPC/VNet provisioning with network segment identifier allocation and API return. Physical infrastructure configuration (underlay ports, BGP sessions) is manual.
 
-- **OVN-Kubernetes:** FRR routing capability with EVPN support, RouteAdvertisements for CUDN with EVPN transport topology. Constraint: does not currently route between separate CUDNs on the same cluster (Connectors feature pending). [Clarify: R1.Q4]
+- **OVN-Kubernetes:** Must support overlay network provisioning with fabric bridging. Constraint: does not currently route between separate overlay networks on the same cluster (Connectors feature pending). [Clarify: R1.Q4]
+
+- **FRR Operator (kubernetes-nmstate-operator):** Required for BGP EVPN route advertisement from OCP workers. Must be installed before EVPN configuration.
+
+- **NMState Operator (openshift-nmstate):** Required for network interface configuration on OCP workers. Must be installed before EVPN configuration.
 
 - **OSAC-3667 (Phase 2):** Blocked by this feature. Adds multi-cluster hosting, inter-subnet routing, and multi-NIC support.
 
 - **OSAC-1435 (VMaaS Networking API Integration):** Blocked by this feature. Requires k8s manager (CUDN LocalNet or OVN EVPN) to be available before end-to-end VM networking works.
+
+## Known Limitations
+
+- **Silent connectivity failure on network segment mismatch** — If network segment identifiers are misconfigured between the fabric and overlay, VMs may boot successfully and receive IP addresses but cannot reach the fabric. The system does not surface warnings when segment state is inconsistent. Cloud Infrastructure Admins must use documented diagnostic tools to verify segment state. [Clarify: R3.Q2]
 
 ---
 

--- a/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
+++ b/enhancements/OSAC-4291-ovn-evpn-phase-1/prd.md
@@ -12,7 +12,7 @@ OSAC runs VMs on OpenShift using KubeVirt, which encapsulates each VM in a pod w
 
 Without a k8s manager that bridges VMs to the fabric, tenants cannot deploy workloads that span VMs and bare-metal hosts in the same subnet. The CUDN LocalNet approach (OSAC-1511) has been frozen in favor of OVN EVPN, which provides better scalability and multi-cluster support. [Clarify: R1.Q3]
 
-The OVN EVPN spike (OSAC-1717) validated the technical approach: VMs can join the fabric via BGP EVPN route advertisements, enabling MAC/IP learning (Type-2 routes), VTEP discovery (Type-3 routes), and cross-subnet reachability (Type-5 routes). Phase 1 delivers single-cluster EVPN bridging with a constraint that OVN-Kubernetes does not currently route between separate CUDNs on the same cluster (the Connectors feature is pending). [Clarify: R1.Q4]
+The OVN EVPN spike (OSAC-1717) validated the technical approach: VMs can join the fabric via BGP EVPN route advertisements, enabling L2 same-subnet and L3 cross-subnet reachability. Phase 1 delivers single-cluster EVPN bridging with a constraint that OVN-Kubernetes does not currently route between separate CUDNs on the same cluster (the Connectors feature is pending). [Clarify: R1.Q4]
 
 ## In Scope
 
@@ -82,7 +82,7 @@ The following are out of scope for Phase 1:
 ## Acceptance Criteria
 
 - [ ] A NetworkClass with `fabric_manager: "netris"` and `k8s_manager: "cudn_evpn"` can be created and transitions to READY state
-- [ ] Creating a VirtualNetwork + Subnet with this NetworkClass provisions both Netris VNet (with L2/L3 VNI) and overlay network on OCP
+- [ ] Creating a VirtualNetwork + Subnet with this NetworkClass provisions both Netris VNet and overlay network on OCP
 - [ ] VMs deployed on the subnet receive IP addresses that do not conflict with Netris DHCP allocations
 - [ ] VMs are discoverable and directly reachable from bare-metal servers on the physical fabric (both L2 same-subnet and L3 different-subnet scenarios)
 - [ ] FRR diagnostic commands show correct VNI state on OCP workers
@@ -99,7 +99,7 @@ The following are out of scope for Phase 1:
 
 - **OSAC-1440 (Dispatcher Core):** Provides dispatcher infrastructure for routing networking operations to fabric and k8s managers based on NetworkClass configuration.
 
-- **Fabric Manager (Netris):** Must support VPC/VNet provisioning with network segment identifier allocation and API return. Physical infrastructure configuration (underlay ports, BGP sessions) is manual.
+- **Fabric Manager (Netris):** Must support VPC/VNet provisioning with network segment identifier allocation and API return. Physical infrastructure configuration is manual.
 
 - **OVN-Kubernetes:** Must support overlay network provisioning with fabric bridging. Constraint: does not currently route between separate overlay networks on the same cluster (Connectors feature pending). [Clarify: R1.Q4]
 


### PR DESCRIPTION
## PRD: K8s Manager — OVN EVPN Phase 1: Single-Cluster VM-to-Fabric Bridging

**Jira:** https://redhat.atlassian.net/browse/OSAC-4291

### Summary

Implements the OVN EVPN k8s manager for single-cluster deployments, enabling VMs to be first-class fabric participants via BGP EVPN route advertisement. VMs running on OVN-Kubernetes can share the same L2 subnet with bare-metal servers and are reachable from the physical fabric through Type-2/Type-3/Type-5 EVPN routes.

Phase 1 delivers automatic VNI/route-target propagation from Netris to CUDN, automatic FRRConfiguration creation for EVPN overlay, VM-to-fabric connectivity, and DHCP range coordination. Includes single-subnet-per-VirtualNetwork constraint enforcement (OVN Connectors limitation) and comprehensive installation prerequisites documentation.

### Requesting Review On

- Requirements completeness and accuracy across all personas (Cloud Infrastructure Admin, Tenant Admin/User)
- Scope boundaries (In Scope vs Out of Scope) — particularly Phase 1 vs Phase 2 delineation
- User stories clarity — whether capabilities are specific enough to implement and test
- Dependencies and prerequisites — whether prerequisite steps are clearly documented
- Known limitations documentation (dual gateway MAC, single-subnet constraint)

### How to Review

- Comment inline on specific sections
- Verify user stories align with personas from `osac-docs/personas.md`
- Check that prerequisites cover what Cloud Infrastructure Admins need before enabling EVPN
- Approve when the PRD accurately reflects the agreed requirements and scope
