### PR TITLE
OSAC-2540: correct global-DiskImage tenant sentinel from empty to "shared"

### DIFF
--- a/enhancements/OSAC-2540-disk-image/design-ui.md
+++ b/enhancements/OSAC-2540-disk-image/design-ui.md
@@ -284,7 +284,7 @@ Columns:
 | Guest OS family | `spec.guest_os_family` |
 | Architecture | `spec.architecture[]` rendered as `LabelGroup` chips |
 | Lifecycle | `DiskImageLifecycleLabel` |
-| Scope | Global if `metadata.tenant` empty, else Tenant |
+| Scope | Global if `metadata.tenant == "shared"`, else Tenant |
 | Created | `metadata.creation_timestamp` (`Timestamp`) |
 | — | per-row `DiskImageActionsMenu` |
 
@@ -423,9 +423,9 @@ responsibilities:
   **global scope** control in the create form and global-image lifecycle
   actions are shown only to the provider-admin role.
 - **Visibility**: the console renders exactly what `List`/`Get` return for the
-  caller — global images (empty `metadata.tenant`) plus the caller's own tenant.
-  Cross-tenant images are never returned, so no client-side filtering is needed
-  for isolation.
+  caller — global images (`metadata.tenant == "shared"`) plus the caller's own
+  tenant. Cross-tenant images are never returned, so no client-side filtering
+  is needed for isolation.
 - **Jira component convention**: each persona's UI task carries the epic's
   components plus `UI` (Provider Admin, Tenant Admin, Tenant User all use `UI`).
   [Codebase: .design/context/osac-dimensions.md]

--- a/enhancements/OSAC-2540-disk-image/design-ui.md
+++ b/enhancements/OSAC-2540-disk-image/design-ui.md
@@ -288,6 +288,12 @@ Columns:
 | Created | `metadata.creation_timestamp` (`Timestamp`) |
 | — | per-row `DiskImageActionsMenu` |
 
+`DiskImageActionsMenu` currently offers no items: its original View and Edit
+entries are both removed (View duplicated the Name column's link; Edit's
+`:id/edit` route was removed with edit mode — see Resolved Questions §5). It
+gains entries again once workflow 4's lifecycle actions
+(deprecate/obsolete/reactivate/delete) ship.
+
 Toolbar: name search plus filter controls for guest OS family, architecture,
 lifecycle (including a **show obsolete** option that adds
 `this.spec.lifecycle == 3`), and scope (Global / Tenant). Filters are passed to

--- a/enhancements/OSAC-2540-disk-image/design-ui.md
+++ b/enhancements/OSAC-2540-disk-image/design-ui.md
@@ -288,11 +288,11 @@ Columns:
 | Created | `metadata.creation_timestamp` (`Timestamp`) |
 | — | per-row `DiskImageActionsMenu` |
 
-`DiskImageActionsMenu` currently offers no items: its original View and Edit
-entries are both removed (View duplicated the Name column's link; Edit's
-`:id/edit` route was removed with edit mode — see Resolved Questions §5). It
-gains entries again once workflow 4's lifecycle actions
-(deprecate/obsolete/reactivate/delete) ship.
+`DiskImageActionsMenu`'s content is workflow 4's lifecycle actions
+(deprecate/obsolete/reactivate/delete), described below. Two entries it
+originally also carried, View and Edit, are removed: View duplicated the
+Name column's link, and Edit's `:id/edit` route was removed with edit mode
+(see Resolved Questions §5).
 
 Toolbar: name search plus filter controls for guest OS family, architecture,
 lifecycle (including a **show obsolete** option that adds

--- a/enhancements/OSAC-2540-disk-image/design-ui.md
+++ b/enhancements/OSAC-2540-disk-image/design-ui.md
@@ -286,12 +286,7 @@ Columns:
 | Lifecycle | `DiskImageLifecycleLabel` |
 | Scope | Global if `metadata.tenant == "shared"`, else Tenant |
 | Created | `metadata.creation_timestamp` (`Timestamp`) |
-
-No per-row actions column for now: `DiskImageActionsMenu.tsx` originally
-offered View/Edit, but View duplicated the Name column's link and Edit's
-`:id/edit` route was removed (edit mode deferred — see Resolved Questions
-§5), leaving no live action to menu. It returns, non-empty, when workflow 4's
-lifecycle actions (deprecate/obsolete/reactivate/delete) ship.
+| — | per-row `DiskImageActionsMenu` |
 
 Toolbar: name search plus filter controls for guest OS family, architecture,
 lifecycle (including a **show obsolete** option that adds

--- a/enhancements/OSAC-2540-disk-image/design-ui.md
+++ b/enhancements/OSAC-2540-disk-image/design-ui.md
@@ -305,18 +305,23 @@ that set, not an authorization boundary.
 (deprecate/obsolete/reactivate) plus a delete button with a confirmation modal.
 [Codebase: osac-ui/libs/ui-components/src/components/InstanceType/AdminInstanceTypeDetailPage.tsx]
 
-#### Create/edit form (`DiskImageForm.tsx`)
+#### Create form (`DiskImageForm.tsx`)
 
-One form component, create and edit modes.
+**Milestone scope** [Locked: D11]: create mode only for the first UI
+milestone. Edit mode (the only ever-mutable field is `spec.architecture`,
+per Immutability below) is deferred to a follow-up story — see Resolved
+Questions §5. `DiskImageForm.tsx` is written as a single component so the
+deferred edit mode is additive later, not a rewrite.
 
 - Fields: source type (fixed `REGISTRY`, read-only), source reference (text,
   required, `min_len ≥ 1`), guest OS family (select, default `LINUX`), and
   architecture (multi-select, ≥ 1 required). The human label is `metadata.name`;
   there is no custom icon input.
-- **Immutability** [Locked: D2]: in **edit** mode, source type, source
-  reference, and guest OS family render read-only; only architecture is
-  editable. This matches the server, which rejects changes to the immutable
-  fields with `InvalidArgument`.
+- **Immutability** [Locked: D2]: source type, source reference, and guest OS
+  family can never change after creation — the server rejects changes to
+  these fields with `InvalidArgument`. Only `spec.architecture` is ever
+  mutable via `Update`. This constraint still holds even though the edit UI
+  itself is deferred (see Milestone scope above).
 - **Scope (Provider Admin only)**: a Global-vs-tenant control shown only to the
   provider-admin role. Tenant personas always create tenant-scoped images; the
   control is hidden and the tenant is set server-side from identity.
@@ -504,7 +509,8 @@ architecture badge(s) (see Resolved Questions).
 
 ## Resolved Questions
 
-All open questions were resolved in PR review (rawagner, PR #223):
+Questions 1–4 were resolved in PR review (rawagner, PR #223); question 5 was
+decided later, during [OSAC-4450](https://redhat.atlassian.net/browse/OSAC-4450)'s implementation:
 
 ### 1. Create-form input UX for architecture and icon — RESOLVED
 
@@ -530,6 +536,17 @@ The first UI milestone includes the **full lifecycle controls**
 (deprecate / obsolete / reactivate), plus delete gated to OBSOLETE. No split
 into a follow-up.
 
+### 5. Edit-mode milestone split — DEFERRED
+
+Decided during `DiskImageForm.tsx` implementation ([OSAC-4450](https://redhat.atlassian.net/browse/OSAC-4450)):
+edit mode is cut from the first UI milestone. `spec.architecture` is the only
+field the server ever allows an `Update` to change (see Immutability, above),
+so an edit surface in this milestone would be a single-field control for
+comparatively high UI cost (a whole read-only-field-rendering mode). The
+create flow ships independently; editing architecture post-creation ships as
+a follow-up story, tracked separately. `DiskImageForm.tsx` remains a single
+component so that follow-up is additive.
+
 ## Test Plan
 
 **Note:** *osac-ui uses Vitest 4 + React Testing Library (jsdom), colocated
@@ -547,8 +564,8 @@ as manual/exploratory against a live cluster.*
   (deprecate only from AVAILABLE; obsolete from AVAILABLE/DEPRECATED; reactivate
   from DEPRECATED/OBSOLETE; delete only from OBSOLETE).
 - `DiskImageForm` client validation rejects empty source_ref and empty
-  architecture, and renders source type / source ref / guest OS family
-  read-only in edit mode.
+  architecture (create mode only for this milestone — see Resolved
+  Questions §5).
 - Scope control is rendered for the provider-admin role and hidden for tenant
   roles.
 

--- a/enhancements/OSAC-2540-disk-image/design-ui.md
+++ b/enhancements/OSAC-2540-disk-image/design-ui.md
@@ -286,7 +286,12 @@ Columns:
 | Lifecycle | `DiskImageLifecycleLabel` |
 | Scope | Global if `metadata.tenant == "shared"`, else Tenant |
 | Created | `metadata.creation_timestamp` (`Timestamp`) |
-| — | per-row `DiskImageActionsMenu` |
+
+No per-row actions column for now: `DiskImageActionsMenu.tsx` originally
+offered View/Edit, but View duplicated the Name column's link and Edit's
+`:id/edit` route was removed (edit mode deferred — see Resolved Questions
+§5), leaving no live action to menu. It returns, non-empty, when workflow 4's
+lifecycle actions (deprecate/obsolete/reactivate/delete) ship.
 
 Toolbar: name search plus filter controls for guest OS family, architecture,
 lifecycle (including a **show obsolete** option that adds

--- a/enhancements/OSAC-2540-disk-image/design.md
+++ b/enhancements/OSAC-2540-disk-image/design.md
@@ -66,8 +66,8 @@ On ComputeInstance, the `image` field (ComputeInstanceImage) and `is_windows` fi
 **Actor:** Cloud Provider Admin (global images), Tenant Admin or Tenant User (tenant-scoped images)
 
 1. Caller invokes `DiskImages/Create` with the DiskImage object containing `spec.source_type`, `spec.source_ref`, `spec.guest_os_family`, and `spec.architecture`.
-2. Server validates required fields, sets `spec.lifecycle` to `DISK_IMAGE_LIFECYCLE_AVAILABLE` if unspecified, persists the object, and returns it with system-generated `id` and `metadata`.
-3. For global images, `metadata.tenant` is set to the platform's shared-tenant sentinel (`"shared"`). For tenant-scoped images, the server sets `metadata.tenant` from the caller's identity.
+2. Server validates required fields, sets `spec.lifecycle` to `DISK_IMAGE_LIFECYCLE_AVAILABLE` if unspecified, and resolves `metadata.tenant`: for global images it's set to the platform's shared-tenant sentinel (`"shared"`); for tenant-scoped images it's set from the caller's identity.
+3. Server persists the object and returns it with system-generated `id` and `metadata`.
 
 #### Creating a ComputeInstance with DiskImage
 

--- a/enhancements/OSAC-2540-disk-image/design.md
+++ b/enhancements/OSAC-2540-disk-image/design.md
@@ -67,7 +67,7 @@ On ComputeInstance, the `image` field (ComputeInstanceImage) and `is_windows` fi
 
 1. Caller invokes `DiskImages/Create` with the DiskImage object containing `spec.source_type`, `spec.source_ref`, `spec.guest_os_family`, and `spec.architecture`.
 2. Server validates required fields, sets `spec.lifecycle` to `DISK_IMAGE_LIFECYCLE_AVAILABLE` if unspecified, persists the object, and returns it with system-generated `id` and `metadata`.
-3. For global images, `metadata.tenant` is empty. For tenant-scoped images, the server sets `metadata.tenant` from the caller's identity.
+3. For global images, `metadata.tenant` is set to the platform's shared-tenant sentinel (`"shared"`). For tenant-scoped images, the server sets `metadata.tenant` from the caller's identity.
 
 #### Creating a ComputeInstance with DiskImage
 
@@ -451,7 +451,7 @@ Default list excludes OBSOLETE images. The server prepends `this.spec.lifecycle 
 CatalogItem Create and Update handlers validate DiskImage references in `field_definitions`. A new `validateFieldDefinitionsDiskImage()` function scans `field_definitions` for entries targeting `spec.disk_image`, extracts the default value, and validates:
 
 1. The referenced DiskImage exists.
-2. The DiskImage is visible to the CatalogItem's tenant — accept global DiskImages (empty tenant) or those belonging to the same tenant. Cross-tenant references are rejected with `InvalidArgument`. This prevents CatalogItems from persisting inaccessible references that would fail at ComputeInstance creation time. Note: `validateFieldDefinitionsInstanceType()` does not need this check because InstanceTypes are always global/shared.
+2. The DiskImage is visible to the CatalogItem's tenant — accept global DiskImages (`metadata.tenant == "shared"`) or those belonging to the same tenant. Cross-tenant references are rejected with `InvalidArgument`. This prevents CatalogItems from persisting inaccessible references that would fail at ComputeInstance creation time. Note: `validateFieldDefinitionsInstanceType()` does not need this check because InstanceTypes are always global/shared.
 3. The DiskImage lifecycle is not OBSOLETE — return `InvalidArgument`.
 4. If the DiskImage lifecycle is DEPRECATED, return a warning.
 
@@ -513,7 +513,7 @@ DiskImage inherits the existing OSAC security model without modification:
 - **Authentication:** JWT validation via the gRPC interceptor chain (same as all other resources).
 - **Authorization:** OPA policies control access. See RBAC / Tenancy section below.
 - **Input validation:** `buf.validate` annotations enforce required fields, enum validity, and minimum lengths on proto fields. The `source_ref` field accepts any string (URLs, digests). OSAC does not validate OCI reference reachability — invalid references surface as errors at VM provisioning time, consistent with the current behavior.
-- **Tenant isolation:** The generic server enforces tenant field validation, ensuring tenant-scoped DiskImages are only accessible within their tenant. Global DiskImages (empty tenant) are readable by all tenants.
+- **Tenant isolation:** The generic server enforces tenant field validation, ensuring tenant-scoped DiskImages are only accessible within their tenant. Global DiskImages (`metadata.tenant == "shared"`) are readable by all tenants.
 
 No new attack surface is introduced. DiskImage does not handle binary uploads, registry authentication, or credential storage.
 
@@ -552,7 +552,7 @@ All authenticated users (Tenant Users and Tenant Admins) can create, update, and
 
 **Tenant isolation metadata:**
 
-- `metadata.tenant`: Set by the server from the caller's identity for tenant-scoped images. Empty for global (provider-managed) images.
+- `metadata.tenant`: Set by the server from the caller's identity for tenant-scoped images. Set to the platform's shared-tenant sentinel (`"shared"`) for global (provider-managed) images — the same convention used by StorageTier, StorageBackend, and other platform-scoped resources. The generic server's tenant-assignment logic never leaves this field empty: an unset tenant resolves to the caller's own tenant, or to `"shared"` for a caller with universal (admin) access.
 - `osac.openshift.io/owner-reference`: Not applicable — DiskImage has no parent resource.
 - `osac.openshift.io/tenant`: Set as annotation by the generic server (standard behavior).
 
@@ -560,7 +560,7 @@ All authenticated users (Tenant Users and Tenant Admins) can create, update, and
 
 | DiskImage tenant | Who can see it |
 |-----------------|---------------|
-| Empty (global) | All authenticated users |
+| `"shared"` (global) | All authenticated users |
 | Tenant X | Users in Tenant X only |
 
 The generic server's existing tenant filtering handles this automatically. Tenant Users see global images and their own tenant's images in List results.

--- a/enhancements/OSAC-2540-disk-image/testplan.md
+++ b/enhancements/OSAC-2540-disk-image/testplan.md
@@ -190,7 +190,7 @@
 
 ##### Preconditions
 
-- Global DiskImage created by Cloud Provider Admin (metadata.tenant empty)
+- Global DiskImage created by Cloud Provider Admin (metadata.tenant == "shared")
 - Users in Tenant A and Tenant B exist
 
 ##### Steps


### PR DESCRIPTION
## Summary

`design.md` and `design-ui.md` for [OSAC-2540](https://redhat.atlassian.net/browse/OSAC-2540) (DiskImage) described global visibility as an **empty** `metadata.tenant`. That doesn't match the generic server's actual tenant-assignment/list-filtering implementation.

## Why

Verified directly against `fulfillment-service/internal/auth` and `internal/servers`:
- `tenancy_logic.go`: `SharedTenant = "shared"` is a first-class sentinel used for platform-wide visibility.
- `default_tenancy_logic.go` (`DetermineDefaultTenant`): an unresolved tenant defaults to the caller's own tenant, or to `"shared"` for a caller with universal (admin) access — **never** to an empty string.
- `generic_server.go` (`determineAssignedTenant`): an empty resolved tenant is rejected as `PermissionDenied` — a stored object can never end up with `tenant == ""`.
- `generic_dao_request.go` (`addTenancyFilter`): list filtering matches `tenant = any($visible_tenants)`; empty string is never a member of any visible-tenants set.
- DiskImage's own server (`private_disk_images_server.go`) already calls `.AddAllowedTenants(auth.SharedTenant)`, the same pattern used by StorageTier and StorageBackend for platform-scoped resources.

This surfaced while implementing [OSAC-4449](https://redhat.atlassian.net/browse/OSAC-4449) (DiskImage list page) — the Scope column and toolbar filter were built to the design doc's (incorrect) "empty tenant" spec, and needed fixing in the implementation once this was caught.

## Changes

- `design.md`: 5 references to "empty tenant" → `metadata.tenant == "shared"`.
- `design-ui.md`: 2 references (Scope column spec, visibility description).
- `testplan.md`: TC-FR4-01's precondition wording.

## Testing

Docs-only change, no code. Cross-checked against the actual backend implementation (file:line citations above); no other `enhancements/` design doc references this pattern for DiskImage.

## Also in this PR: defer DiskImage edit mode

Unrelated to the tenant-sentinel fix above, but bundled in here per request: `design-ui.md`'s Create/edit form section described `DiskImageForm.tsx` as shipping both create and edit modes in the first UI milestone. While implementing [OSAC-4450](https://redhat.atlassian.net/browse/OSAC-4450) (DiskImage create/edit form), the edit-mode UI was cut from that milestone — `spec.architecture` is the only field the server ever allows an `Update` to change, so a whole read-only-field-rendering edit mode for one mutable field wasn't worth the cost this milestone. The create flow ships on its own in [OSAC-4450](https://redhat.atlassian.net/browse/OSAC-4450); editing architecture post-creation is deferred to a follow-up story.

- `design-ui.md`: "Create/edit form" → "Create form" section rewritten to document the milestone cut (`[Locked: D11]`) and restate the still-true immutability constraint independent of the deferred edit UI; added Resolved Questions §5 documenting the deferral decision; updated the Unit Tests bullet that referenced edit-mode rendering.

## Also in this PR: DiskImageActionsMenu is now empty (View/Edit removed)

Follow-up to the edit-mode deferral above: `osac-ui`'s `DiskImageActionsMenu.tsx` offered View and Edit — with edit mode gone, Edit pointed at a route that no longer exists, and View only duplicated the Name column's link to the detail page. Both actions were removed in [osac-ui#175](https://github.com/osac-project/osac-ui/pull/175); the actions column itself stays, since workflow 4's lifecycle actions (deprecate/obsolete/reactivate/delete) will populate it in a follow-up story.

- `design-ui.md`: List page's Columns table keeps the `DiskImageActionsMenu` row, with a new note that it currently offers no items (View/Edit both removed) until lifecycle actions ship.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated DiskImage guidance to use the `"shared"` tenant marker for globally shared images.
  * Clarified visibility, security, tenant isolation, and tenant assignment behavior.
  * Updated examples and test expectations to reflect shared-tenant behavior.
  * Documented lifecycle actions for DiskImage row menus while retaining removal of View and Edit options.
  * Documented create-only support for the initial DiskImage UI milestone and deferred architecture editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


