### PR TITLE
OSAC-3459: PRD - BMaaS Provisioning Progress and Step Visibility

### DIFF
--- a/enhancements/OSAC-3459-bmaas-provisioning-progress/prd.md
+++ b/enhancements/OSAC-3459-bmaas-provisioning-progress/prd.md
@@ -1,0 +1,68 @@
+# BMaaS Provisioning Progress and Step Visibility
+
+| Field     | Value |
+|-----------|-------|
+| Author(s) | Matthieu Bernardin |
+| Jira      | https://redhat.atlassian.net/browse/OSAC-3459 |
+| Date      | 2026-08-31 |
+
+## Problem Statement
+
+When a bare metal server is ordered through the OSAC UI, the instance enters a "Provisioning" state with no indication of which deployment step is executing, how long it has been running, or where the process has stalled. Users cannot distinguish host allocation from OS imaging from configuration — and a terminal "Failed" badge on error leaves no information to guide self-service troubleshooting. The same gap exists during deprovisioning: teardown progress is equally opaque. Every stalled or slow deployment that cannot be self-diagnosed adds to operator support load and extends time-to-resolution.
+
+## In Scope
+
+- Both provisioning and deprovisioning workflows expose step-level progress: the bare metal instance detail view shows each phase's name, state (pending, running, succeeded, or failed), and start and end timestamps. [Clarify: R2.Q3]
+- The provisioning workflow presents five user-visible phases: Host Allocation, Hardware Preparation, OS Deployment, Configuration, and Verification. The deprovisioning workflow presents three phases: Teardown Initiated, Cleaning, and Released. [Clarify: R3.Q3]
+- The progress view auto-refreshes approximately every 5 seconds without requiring user action. [Clarify: R1.Q2]
+- The step-level timeline persists after provisioning or deprovisioning finishes, giving users access to the full phase history of completed — including failed — instances. [Clarify: R1.Q4]
+- The provisioning progress data model is designed for reuse across OSAC services: its structure must accommodate the provisioning semantics of other services (such as VMaaS and CaaS) so that they can adopt the same model without redesign when their progress visibility is implemented. [User]
+- Failure descriptions identify the phase that failed and the failure condition in human-readable terms; raw internal system errors and implementation-level details are not surfaced. [User]
+
+## Out of Scope
+
+- User-initiated actions on failure: the progress and failure display is read-only. No retry or re-provision actions are in scope. [Clarify: R1.Q3]
+- Automated remediation of failed provisioning steps.
+- Changes to the underlying bare metal operator or provisioning automation logic.
+- Progress visibility for VMaaS compute instances or CaaS clusters: while the pattern introduced here is intended to generalize across OSAC services, those services are out of scope for this feature. [Clarify: R3.Q1]
+- A new cross-tenant aggregated list of in-progress bare metal instances: Cloud Provider Admin reaches individual instances through existing navigation. [Clarify: R2.Q2]
+- Component log access per provisioning phase: this feature delivers step-level visibility only — phase name, state, and timestamps. Surfacing log output from the underlying provisioning automation is out of scope. [User]
+
+## User Stories
+
+### Tenant User, Tenant Admin, and Cloud Provider Admin
+
+- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to see a step-by-step progress timeline on a bare metal instance's detail page — with each phase's state and start/end timestamps — so that I can tell where the deployment is in the workflow and how long each step has been running.
+- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to see which provisioning phase failed and a clear description of the failure condition, so that I can understand where the deployment stopped and determine next steps. [User]
+
+  Example failure descriptions, by phase:
+
+  | Phase | Example |
+  |---|---|
+  | Host Allocation | "No available host matching the requested configuration. All hosts with the required profile are currently allocated." |
+  | Hardware Preparation | "Hardware preparation timed out — the host did not complete cleaning within the expected time." |
+  | OS Deployment | "OS deployment failed — the operating system image could not be written to the host." |
+  | Configuration | "Configuration failed — the host was not reachable for configuration application after imaging." |
+  | Verification | "Verification failed — the host did not pass readiness checks within the expected time." |
+
+  Failure descriptions identify the phase and condition without persona-specific action guidance; the appropriate next step varies by user role.
+- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want the progress view to refresh automatically while I am watching, so that I do not have to reload the page to track an active deployment.
+- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to see the full step-level provisioning history for an instance that has already finished deploying (successfully or with a failure), so that I can review what phases ran and how long each took.
+- As a Tenant User, Tenant Admin, or Cloud Provider Admin, I want to see step-by-step deprovisioning progress when a bare metal instance is being deleted, so that I can track teardown to completion.
+
+## Assumptions
+
+- The five provisioning phases (Host Allocation, Hardware Preparation, OS Deployment, Configuration, Verification) and three deprovisioning phases (Teardown Initiated, Cleaning, Released) accurately represent the stages a user can observe during bare metal deployment and teardown. The mapping from backend states to these labels is subject to validation during design; phase names may be adjusted if the backend state model does not align.
+
+## Dependencies
+
+- **OSAC-1604 (Cluster status report, CaaS):** OSAC-1604 is actively working on granular status reporting for CaaS clusters. The design for this feature should coordinate with OSAC-1604 to produce a consistent progress visibility pattern across OSAC services and to avoid divergent approaches that would complicate future cross-service generalization. [Clarify: R3.Q2]
+
+---
+
+## Provenance
+
+Authored: revise @ prd 0.9.0 - a17a43d, workspace main @ ed93971
+Phases: draft, revise, revise, revise, revise, revise
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.9.0","ai_workflows":"a17a43d","source_repo":"ed93971","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":2,"main_ref":"main","phases":["draft","revise","revise","revise","revise","revise"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->

--- a/enhancements/OSAC-3459-bmaas-provisioning-progress/prd.md
+++ b/enhancements/OSAC-3459-bmaas-provisioning-progress/prd.md
@@ -16,7 +16,7 @@ When a bare metal server is ordered through the OSAC UI, the instance enters a "
 - The provisioning workflow presents five user-visible phases: Host Allocation, Hardware Preparation, OS Deployment, Configuration, and Verification. The deprovisioning workflow presents three phases: Teardown Initiated, Cleaning, and Released. [Clarify: R3.Q3]
 - The progress view auto-refreshes approximately every 5 seconds without requiring user action. [Clarify: R1.Q2]
 - The step-level timeline persists after provisioning or deprovisioning finishes, giving users access to the full phase history of completed — including failed — instances. [Clarify: R1.Q4]
-- The provisioning progress data model is designed for reuse across OSAC services: its structure must accommodate the provisioning semantics of other services (such as VMaaS and CaaS) so that they can adopt the same model without redesign when their progress visibility is implemented. [User]
+- Progress is surfaced using the status-condition pattern OSAC already established for VMaaS compute instances (OSAC-1027) and is adopting for CaaS clusters (OSAC-1604): a lifecycle phase plus status conditions whose reason names the current sub-step. BMaaS-specific phases (host allocation, hardware preparation, and so on) are expressed as BMaaS reason values within that shared shape — they are not imposed on other services. Reusing the established pattern keeps the progress experience consistent across services without inventing a BMaaS-specific model. [User]
 - Failure descriptions identify the phase that failed and the failure condition in human-readable terms; raw internal system errors and implementation-level details are not surfaced. [User]
 
 ## Out of Scope
@@ -24,7 +24,7 @@ When a bare metal server is ordered through the OSAC UI, the instance enters a "
 - User-initiated actions on failure: the progress and failure display is read-only. No retry or re-provision actions are in scope. [Clarify: R1.Q3]
 - Automated remediation of failed provisioning steps.
 - Changes to the underlying bare metal operator or provisioning automation logic.
-- Progress visibility for VMaaS compute instances or CaaS clusters: while the pattern introduced here is intended to generalize across OSAC services, those services are out of scope for this feature. [Clarify: R3.Q1]
+- Progress visibility for VMaaS compute instances or CaaS clusters: those services are addressed by OSAC-1027 and OSAC-1604 respectively and are out of scope for this feature, which reuses the same pattern for BMaaS. [Clarify: R3.Q1]
 - A new cross-tenant aggregated list of in-progress bare metal instances: Cloud Provider Admin reaches individual instances through existing navigation. [Clarify: R2.Q2]
 - Component log access per provisioning phase: this feature delivers step-level visibility only — phase name, state, and timestamps. Surfacing log output from the underlying provisioning automation is out of scope. [User]
 
@@ -52,17 +52,20 @@ When a bare metal server is ordered through the OSAC UI, the instance enters a "
 
 ## Assumptions
 
-- The five provisioning phases (Host Allocation, Hardware Preparation, OS Deployment, Configuration, Verification) and three deprovisioning phases (Teardown Initiated, Cleaning, Released) accurately represent the stages a user can observe during bare metal deployment and teardown. The mapping from backend states to these labels is subject to validation during design; phase names may be adjusted if the backend state model does not align.
+- The five provisioning phases (Host Allocation, Hardware Preparation, OS Deployment, Configuration, Verification) and three deprovisioning phases (Teardown Initiated, Cleaning, Released) are user-facing labels, not backend states. They do not map one-to-one to the metal3 BareMetalHost state machine: OS Deployment corresponds to metal3 `provisioning`; Hardware Preparation aggregates metal3 `registering`/`inspecting`/`preparing`/`cleaning`; and Configuration and Verification are OSAC-level steps that occur after metal3 reaches `provisioned`. The design must map each user-visible phase to an authoritative backend signal and define its start/finish conditions, timestamp durability, and behavior for skipped or retried steps; phases that do not correspond to a distinct, observable backend signal (for example, Verification) may be renamed, merged, or dropped during design.
+- A bare metal instance's step-level timeline remains viewable after the instance finishes provisioning or is released. How a released instance's history stays addressable, how long it is retained, and which roles can view it are design decisions deferred to the design phase.
 
 ## Dependencies
 
-- **OSAC-1604 (Cluster status report, CaaS):** OSAC-1604 is actively working on granular status reporting for CaaS clusters. The design for this feature should coordinate with OSAC-1604 to produce a consistent progress visibility pattern across OSAC services and to avoid divergent approaches that would complicate future cross-service generalization. [Clarify: R3.Q2]
+- **OSAC-1027 (ComputeInstance phase/condition expansion, VMaaS) and OSAC-1604 (Cluster status report, CaaS):** together these establish the OSAC status-condition progress pattern — a lifecycle phase plus orthogonal conditions with a reason vocabulary. OSAC-1027 is implemented for VMaaS; OSAC-1604 adapts it for CaaS and is in progress. This feature adopts that same pattern for BMaaS rather than introducing a new one; the design should align with OSAC-1604 to keep the cross-service experience consistent. (OSAC-1604's own PRD already scopes BMaaS as a separate feature sharing this pattern.) [Clarify: R3.Q2]
 
 ---
 
 ## Provenance
 
-Authored: revise @ prd 0.9.0 - a17a43d, workspace main @ ed93971
-Phases: draft, revise, revise, revise, revise, revise
+Authored: draft @ prd 0.9.0 - a17a43d, workspace main @ ed93971
+Final: respond @ prd 0.9.0 - a17a43d, workspace main @ 63b090a
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.9.0","ai_workflows":"a17a43d","source_repo":"ed93971","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":2,"main_ref":"main","phases":["draft","revise","revise","revise","revise","revise"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+> Context changed between draft and respond.
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.9.0","ai_workflows":"a17a43d","source_repo":"63b090a","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":6,"main_ref":"main","phases":["draft","revise","revise","revise","revise","revise","respond"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-3459-bmaas-provisioning-progress/prd.md
+++ b/enhancements/OSAC-3459-bmaas-provisioning-progress/prd.md
@@ -52,20 +52,20 @@ When a bare metal server is ordered through the OSAC UI, the instance enters a "
 
 ## Assumptions
 
-- The five provisioning phases (Host Allocation, Hardware Preparation, OS Deployment, Configuration, Verification) and three deprovisioning phases (Teardown Initiated, Cleaning, Released) are user-facing labels, not backend states. They do not map one-to-one to the metal3 BareMetalHost state machine: OS Deployment corresponds to metal3 `provisioning`; Hardware Preparation aggregates metal3 `registering`/`inspecting`/`preparing`/`cleaning`; and Configuration and Verification are OSAC-level steps that occur after metal3 reaches `provisioned`. The design must map each user-visible phase to an authoritative backend signal and define its start/finish conditions, timestamp durability, and behavior for skipped or retried steps; phases that do not correspond to a distinct, observable backend signal (for example, Verification) may be renamed, merged, or dropped during design.
+- The five provisioning phases (Host Allocation, Hardware Preparation, OS Deployment, Configuration, Verification) and three deprovisioning phases (Teardown Initiated, Cleaning, Released) are user-facing labels, not backend states. They do not map one-to-one to the metal3 BareMetalHost state machine: OS Deployment corresponds to metal3 `provisioning`; Hardware Preparation aggregates metal3 `registering`/`inspecting`/`preparing`/`cleaning`; and Configuration and Verification are OSAC-level steps that occur after metal3 reaches `provisioned`. The design must map each user-visible phase to an authoritative backend signal and define its start/finish conditions, timestamp durability, and behavior for skipped, retried, or overlapping steps. The design must also classify each phase as either a point-in-time milestone or a phase with a running state — in particular the deprovisioning phases Teardown Initiated and Released. Phases that do not correspond to a distinct, observable backend signal (for example, Verification) may be renamed, merged, or dropped during design.
 - A bare metal instance's step-level timeline remains viewable after the instance finishes provisioning or is released. How a released instance's history stays addressable, how long it is retained, and which roles can view it are design decisions deferred to the design phase.
 
 ## Dependencies
 
-- **OSAC-1027 (ComputeInstance phase/condition expansion, VMaaS) and OSAC-1604 (Cluster status report, CaaS):** together these establish the OSAC status-condition progress pattern — a lifecycle phase plus orthogonal conditions with a reason vocabulary. OSAC-1027 is implemented for VMaaS; OSAC-1604 adapts it for CaaS and is in progress. This feature adopts that same pattern for BMaaS rather than introducing a new one; the design should align with OSAC-1604 to keep the cross-service experience consistent. (OSAC-1604's own PRD already scopes BMaaS as a separate feature sharing this pattern.) [Clarify: R3.Q2]
+- **OSAC-1027 (ComputeInstance phase/condition expansion, VMaaS) and OSAC-1604 (Cluster status report, CaaS) — references, not blockers:** these establish the OSAC status-condition progress pattern — a lifecycle phase plus orthogonal conditions with a reason vocabulary — that this feature reuses. This work is not gated on either: OSAC-1027 is already implemented for VMaaS, and OSAC-1604 (adapting the pattern for CaaS) can proceed in parallel. The design should align with OSAC-1604 to keep the cross-service experience consistent. (OSAC-1604's own PRD already scopes BMaaS as a separate feature sharing this pattern.) [Clarify: R3.Q2]
 
 ---
 
 ## Provenance
 
 Authored: draft @ prd 0.9.0 - a17a43d, workspace main @ ed93971
-Final: respond @ prd 0.9.0 - a17a43d, workspace main @ 63b090a
+Final: respond @ prd 0.9.0 - 562b610, workspace main @ 63b090a
 
 > Context changed between draft and respond.
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.9.0","ai_workflows":"a17a43d","source_repo":"63b090a","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":6,"main_ref":"main","phases":["draft","revise","revise","revise","revise","revise","respond"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.9.0","ai_workflows":"562b610","source_repo":"63b090a","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":6,"main_ref":"main","phases":["draft","revise","revise","revise","revise","revise","respond","respond"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->


### PR DESCRIPTION
## PRD: BMaaS Provisioning Progress and Step Visibility

**Jira:** https://redhat.atlassian.net/browse/OSAC-3459

### Summary

This PRD covers step-level provisioning and deprovisioning progress visibility for bare metal instances in the OSAC UI. Users currently see only a single "Provisioning" state badge with no indication of which phase is executing or how long it has been running. The feature introduces a phase timeline (5 provisioning phases, 3 deprovisioning phases) with per-phase state and timestamps, auto-refreshing every ~5 seconds. The progress data model is designed to generalize across OSAC services (VMaaS, CaaS) in future work.

### Requesting Review On

- Requirements completeness and accuracy
- Scope (In Scope / Out of Scope boundaries)
- Provisioning phase naming and granularity (subject to validation against the BM operator implementation)
- The generic data model requirement — does the constraint to design for cross-service reuse belong at the PRD level?
- Open questions that need resolution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

* **Documentation**
  * Added a PRD for step-level BMaaS provisioning and deprovisioning progress.
  * Defined five provisioning phases and three deprovisioning phases.
  * Documented phase states, timestamps, auto-refresh, persisted history, and human-readable failure descriptions.
  * Described shared modeling through the OSAC status-condition pattern.
  * Defined user stories, scope boundaries, assumptions, dependencies, and open questions.
* **API surface, controllers, database, auth, deployment, CI, and tests**
  * No implementation changes affect these areas.
* **Backward compatibility**
  * No backward-compatibility impact. The PRD does not change APIs, controllers, storage, authentication, deployment, CI, or tests.

## Risk classification

* **risk:show** — Documentation-only changes with no production code, API, data, authentication, deployment, or test changes.
* The change does not qualify for **risk:ship** because it introduces no implementation that can be validated as a routine low-risk code change.
* The change does not qualify for **risk:ask** because it does not alter runtime behavior or require additional approval for operational risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->