### PR TITLE
OSAC-4372: PRD - Self-Subject Access Review API

### DIFF
--- a/enhancements/OSAC-2476-self-subject-access-review/prd.md
+++ b/enhancements/OSAC-2476-self-subject-access-review/prd.md
@@ -12,21 +12,21 @@ Authenticated users (tenant admins and tenant users) currently have no way to ch
 
 ## In Scope
 
-- **SelfSubjectAccessReview-style API** that allows authenticated users to check their own permissions without performing the operation
-- **Create-only RPC** that evaluates permission requests inline and returns results immediately (no persistence to database)
-- **Request specification** describing the permission check:
-  - Resource type (e.g., Cluster, ComputeInstance, VirtualNetwork, Subnet, SecurityGroup)
+- **Permission check API** that allows authenticated users to check their own permissions on OSAC resources without performing the actual operation
+- **Request specification** describing the hypothetical operation to check:
+  - Resource type (e.g., Cluster, ComputeInstance, VirtualNetwork, Subnet, SecurityGroup, User, Tenant)
   - Verb (create, get, update, delete, list)
-  - Optional scoping by tenant name and resource name
-- **Response status** indicating the authorization result:
-  - `allowed` boolean field showing whether the user has permission
-  - Optional `denied` and `reason` fields explaining why permission was denied
-- **Identity inference** from authentication context — server extracts user identity from the request's JWT token claims (username, organization, realm roles, groups)
-- **Comprehensive resource coverage** — support permission checks for all OSAC resource types and standard verbs
+  - Optional tenant name and resource name to scope the hypothetical operation (the authenticated user's identity is always determined from the request's authentication context, never from request fields)
+- **Response** indicating whether the authenticated user would be authorized:
+  - `allowed` boolean field showing whether the permission check passed
+  - Optional `reason` field providing explanation when permission is denied
+- **Advisory results** — permission check results reflect authorization state at check time; the actual operation must independently re-evaluate authorization since permissions and resource state may change between the check and the operation
+- **Authorization consistency** — permission check results must match the authorization decision that would be made for the same user attempting the same operation (same resource type, verb, tenant, and resource name) at the time of the check
+- **User identity determination** — the API determines the authenticated user's identity, tenants, and roles automatically from authentication context (no separate identity parameters)
+- **Comprehensive resource coverage** — support permission checks for all OSAC resource types and standard verbs (note: user management and quota scenarios referenced in user stories translate to permission checks on underlying resource operations like creating/updating User or Tenant resources)
 - **Access control** — any authenticated user can call the endpoint to check their own permissions
-- **Authorization reuse** — leverage existing OPA policy evaluation logic to ensure permission check results match actual authorization decisions
-- **Testing** — unit tests covering allowed/denied scenarios across different roles (Admin, Tenant Admin, Client), integration tests verifying behavior across resource types, verbs, and scoping
-- **API documentation** describing the new endpoint, request/response schemas, and usage examples
+- **Validation** — tests must demonstrate that permission check results match actual authorization outcomes for allowed and denied scenarios across different roles (Admin, Tenant Admin, Client) and resource types
+- **API documentation** describing the endpoint, request/response schemas, usage examples, and the advisory nature of results
 
 ## Out of Scope
 
@@ -39,31 +39,28 @@ Authenticated users (tenant admins and tenant users) currently have no way to ch
 
 ### Tenant Admin
 
-- As a tenant admin, I want to check whether I have permission to create a VirtualNetwork in my tenant via the UI, CLI, or API, so that the interface can show or hide the "Create Network" action based on my actual permissions
-- As a tenant admin, I want to check whether I have permission to manage users in my tenant before navigating to the user management section, so that the UI can prevent navigation to features I cannot use
-- As a tenant admin, I want to check whether I have permission to update quota settings for my tenant, so that quota-related controls can be enabled or disabled based on my role
+- As a tenant admin, I want to check whether I have permission to perform management operations (create VirtualNetwork, manage users via User resource operations, update Tenant quota settings) before attempting them via the UI, CLI, or API, so that interfaces can show or hide actions based on my actual permissions and prevent navigation to features I cannot use
 
 ### Tenant User
 
-- As a tenant user, I want to check whether I have permission to create a ComputeInstance in a specific tenant before starting the creation workflow, so that the UI can validate my permissions upfront rather than failing at submission time
-- As a tenant user, I want to check whether I have permission to update a specific ComputeInstance (scoped by tenant and resource name) before enabling the edit form, so that I don't invest effort in changes I cannot save
-- As a tenant user, I want to check whether I have permission to delete a Subnet in my tenant, so that the CLI can warn me if I lack permission before prompting for confirmation
-- As a tenant user, I want to check whether I have permission to list SecurityGroups in a tenant, so that the API client can detect authorization failures before attempting bulk operations
+- As a tenant user, I want to check whether I have permission to create, update, or delete infrastructure resources (ComputeInstance, Subnet, SecurityGroup) in a specific tenant before starting the workflow, so that the UI and CLI can validate permissions upfront and warn me before I invest effort in changes I cannot save
+- As a tenant user, I want to check resource-scoped permissions (update or delete operations on a specific resource by name) before enabling edit or delete actions, so that I know whether I can modify a particular resource before attempting the operation
 
 ## Assumptions
 
-- The existing OPA authorization policy (`internal/auth/policies/authz.rego`) contains all necessary logic to evaluate permissions for OSAC resources and verbs, and this logic can be invoked programmatically to perform hypothetical "what if" evaluations without side effects
-- All role and permission information required to evaluate authorization decisions is available in the JWT token claims (username, organization, realm roles, groups) presented by the authenticated user
-- The Kubernetes SelfSubjectAccessReview API pattern (create-only RPC with spec describing the check and status describing the result) is well-understood by the target audience and does not require additional design justification
+- The Kubernetes SelfSubjectAccessReview API pattern (request specifying the operation to check, response with allowed/denied result) is well-understood by the target audience and does not require additional design justification
 
 ## Dependencies
 
-N/A
+This feature depends on internal fulfillment-service components (authentication, authorization policy evaluation) but has no external team or service dependencies
 
 ---
 
 ## Provenance
 
 Authored: draft @ prd 0.9.0 - a17a43d, workspace main @ ed93971 (dirty)
+Final: revise @ prd 0.9.0 - a17a43d, workspace main @ 3c61513
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.9.0","ai_workflows":"a17a43d","source_repo":"ed93971 (dirty)","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+> Context changed between draft and revise.
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.9.0","ai_workflows":"a17a43d","source_repo":"3c61513","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft","revise"],"authoring_modes":["skill"],"context_changed":true,"origin_untracked":false} -->

--- a/enhancements/OSAC-2476-self-subject-access-review/prd.md
+++ b/enhancements/OSAC-2476-self-subject-access-review/prd.md
@@ -1,0 +1,69 @@
+# Self-Subject Access Review API
+
+| Field       | Value   |
+|-------------|---------|
+| Author(s)   | CrystalChun |
+| Jira        | https://redhat.atlassian.net/browse/OSAC-2476 |
+| Date        | 2026-08-31 |
+
+## Problem Statement
+
+Authenticated users (tenant admins and tenant users) currently have no way to check their permissions on OSAC resources without attempting the actual operation. This creates friction in user workflows: users must attempt actions to discover they lack permission, leading to unexpected errors and poor user experience. For UI and CLI developers, this limitation prevents implementing permission-aware interfaces that could hide unavailable actions, validate workflows before execution, or provide clear permission-based guidance. Without a permission check API, every permission denial is a user-facing failure rather than a proactive workflow decision.
+
+## In Scope
+
+- **SelfSubjectAccessReview-style API** that allows authenticated users to check their own permissions without performing the operation
+- **Create-only RPC** that evaluates permission requests inline and returns results immediately (no persistence to database)
+- **Request specification** describing the permission check:
+  - Resource type (e.g., Cluster, ComputeInstance, VirtualNetwork, Subnet, SecurityGroup)
+  - Verb (create, get, update, delete, list)
+  - Optional scoping by tenant name and resource name
+- **Response status** indicating the authorization result:
+  - `allowed` boolean field showing whether the user has permission
+  - Optional `denied` and `reason` fields explaining why permission was denied
+- **Identity inference** from authentication context — server extracts user identity from the request's JWT token claims (username, organization, realm roles, groups)
+- **Comprehensive resource coverage** — support permission checks for all OSAC resource types and standard verbs
+- **Access control** — any authenticated user can call the endpoint to check their own permissions
+- **Authorization reuse** — leverage existing OPA policy evaluation logic to ensure permission check results match actual authorization decisions
+- **Testing** — unit tests covering allowed/denied scenarios across different roles (Admin, Tenant Admin, Client), integration tests verifying behavior across resource types, verbs, and scoping
+- **API documentation** describing the new endpoint, request/response schemas, and usage examples
+
+## Out of Scope
+
+- **Checking another user's permissions** (SubjectAccessReview equivalent) — this feature only supports self-subject access review; checking permissions for a different user or service account is explicitly excluded
+- **Bulk permission checks** — evaluating multiple permission scenarios in a single request is not supported; each check requires a separate API call
+- **Caching or memoization of results** — permission checks evaluate fresh on every request using current authorization state; no result caching mechanism is provided
+- **UI integration work** — while this API enables permission-aware UIs, the actual UI changes to consume this API are a separate feature and not included in this work
+
+## User Stories
+
+### Tenant Admin
+
+- As a tenant admin, I want to check whether I have permission to create a VirtualNetwork in my tenant via the UI, CLI, or API, so that the interface can show or hide the "Create Network" action based on my actual permissions
+- As a tenant admin, I want to check whether I have permission to manage users in my tenant before navigating to the user management section, so that the UI can prevent navigation to features I cannot use
+- As a tenant admin, I want to check whether I have permission to update quota settings for my tenant, so that quota-related controls can be enabled or disabled based on my role
+
+### Tenant User
+
+- As a tenant user, I want to check whether I have permission to create a ComputeInstance in a specific tenant before starting the creation workflow, so that the UI can validate my permissions upfront rather than failing at submission time
+- As a tenant user, I want to check whether I have permission to update a specific ComputeInstance (scoped by tenant and resource name) before enabling the edit form, so that I don't invest effort in changes I cannot save
+- As a tenant user, I want to check whether I have permission to delete a Subnet in my tenant, so that the CLI can warn me if I lack permission before prompting for confirmation
+- As a tenant user, I want to check whether I have permission to list SecurityGroups in a tenant, so that the API client can detect authorization failures before attempting bulk operations
+
+## Assumptions
+
+- The existing OPA authorization policy (`internal/auth/policies/authz.rego`) contains all necessary logic to evaluate permissions for OSAC resources and verbs, and this logic can be invoked programmatically to perform hypothetical "what if" evaluations without side effects
+- All role and permission information required to evaluate authorization decisions is available in the JWT token claims (username, organization, realm roles, groups) presented by the authenticated user
+- The Kubernetes SelfSubjectAccessReview API pattern (create-only RPC with spec describing the check and status describing the result) is well-understood by the target audience and does not require additional design justification
+
+## Dependencies
+
+N/A
+
+---
+
+## Provenance
+
+Authored: draft @ prd 0.9.0 - a17a43d, workspace main @ ed93971 (dirty)
+
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"session","workflow":"prd","workflow_version":"0.9.0","ai_workflows":"a17a43d","source_repo":"ed93971 (dirty)","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["draft"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->


### PR DESCRIPTION
## PRD: Self-Subject Access Review API

**Jira:** https://redhat.atlassian.net/browse/OSAC-2476

### Summary

This PRD defines a SelfSubjectAccessReview-style API for the OSAC fulfillment service, enabling authenticated users to check their permissions on resources before attempting operations. This API allows UI, CLI, and API clients to build permission-aware interfaces that proactively validate user capabilities, reducing unexpected permission errors and improving user experience.

### Requesting Review On

- Requirements completeness and accuracy — do the user stories capture the right scenarios for tenant admins and tenant users?
- Scope (in scope and out of scope) — is the boundary clear on what this API provides vs. what it explicitly excludes?
- Assumptions — are the assumptions about OPA policy reuse and JWT token claims correct?
- User stories — are there additional permission-check scenarios we should include for tenant admins or tenant users?

### How to Review

- Comment inline on specific sections
- Validate the user stories against actual tenant admin and tenant user workflows
- Approve when the PRD accurately reflects the agreed requirements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the product requirements for a Self-Subject Access Review “Permission check API” for authenticated users.
  * Clarified the expected response behavior (including optional reasons) and removed the former denied response framing.
  * Expanded supported resources to include User and Tenant access checks.
  * Added requirements that results must reflect authorization at check time and match actual authorization outcomes, plus revised identity, scope, and user-story details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->