### PR TITLE
NO-ISSUE: Update catalog items status and links

### DIFF
--- a/enhancements/OSAC-1002-catalog-items/README.md
+++ b/enhancements/OSAC-1002-catalog-items/README.md
@@ -7,11 +7,16 @@ last-updated: 2026-07-23
 tracking-link:
   - https://redhat.atlassian.net/browse/OSAC-1002
 see-also:
+  - "/enhancements/OSAC-3538-catalog-items-v2"
 replaces:
+  - N/A
 superseded-by:
+  - "/enhancements/OSAC-3538-catalog-items-v2"
 ---
 
 # Published Templates
+
+> **Status:** This proposal is superseded by [Catalog Items v2](../OSAC-3538-catalog-items-v2/design.md). It remains useful as historical background, but its `FieldDefinition`, dot-notation path, and JSON Schema API model are legacy and should not be treated as current behavior.
 
 ## Summary
 

--- a/enhancements/OSAC-1002-catalog-items/ui-design.md
+++ b/enhancements/OSAC-1002-catalog-items/ui-design.md
@@ -11,11 +11,16 @@ prd:
 see-also:
   - "/enhancements/OSAC-1002-catalog-items"
   - "/enhancements/OSAC-1421-cluster-and-vm-provisioning-wizard"
+  - "/enhancements/OSAC-3538-catalog-items-v2"
 replaces:
+  - N/A
 superseded-by:
+  - "/enhancements/OSAC-3538-catalog-items-v2"
 ---
 
 # Catalog Items — UI Management
+
+> **Status:** This design remains related to the Catalog Items admin-management flow, but its legacy field-definition payload and editor details are superseded by [Catalog Items v2](../OSAC-3538-catalog-items-v2/design.md). Use v2 for current catalog-item field governance and API behavior.
 
 ## Summary
 

--- a/enhancements/OSAC-3538-catalog-items-v2/design.md
+++ b/enhancements/OSAC-3538-catalog-items-v2/design.md
@@ -9,9 +9,9 @@ tracking-link:
 prd:
   - "prd.md"
 see-also:
-  - "/enhancements/OSAC-1002-catalog-items"
+  - "/enhancements/OSAC-1002-catalog-items/ui-design.md"
 replaces:
-  - N/A
+  - "/enhancements/OSAC-1002-catalog-items"
 superseded-by:
   - N/A
 ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Marked the Catalog Items v1 proposal as superseded by Catalog Items v2.
- Added links between the v1 and v2 documentation.
- Documented the legacy status of the v1 proposal.
- Redirected current field-governance and API behavior references to Catalog Items v2.
- Declared the v1 design as replaced in the v2 design metadata.

## Affected areas

- Documentation and design metadata only.
- No API, controller, database, authentication, deployment, CI, or test changes.

## Backward compatibility

- No runtime behavior changes.
- No backward-compatibility impact is expected.
- The documentation changes clarify the transition from Catalog Items v1 to Catalog Items v2.

## Risk classification

- `risk:ship` applies because the changes affect documentation only and do not modify runtime code, APIs, data, authentication, deployment, or tests.
- The PR is not close to `risk:show` because it introduces no user-visible runtime behavior change.
- The PR is not close to `risk:ask` because it has no operational, security, data, or compatibility risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->