### PR TITLE
NO-ISSUE: Gate on human review changes requested

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -3,7 +3,6 @@ name: review-gate
 
 # Fail required check while a human reviewer still has CHANGES_REQUESTED.
 permissions:
-  contents: read
   pull-requests: read
 
 on:
@@ -11,10 +10,11 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
   pull_request_review:
-    types: [submitted]
+    types: [submitted, dismissed]
 
 jobs:
   check-human-reviews:
+    if: github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Check for human changes requested

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -1,0 +1,50 @@
+---
+name: review-gate
+
+# Fail required check while a human reviewer still has CHANGES_REQUESTED.
+permissions:
+  contents: read
+  pull-requests: read
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  check-human-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for human changes requested
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          reviews=$(gh api --paginate --slurp "repos/${REPO}/pulls/${PR}/reviews" | jq 'add // []')
+          set +e
+          jq -e '
+            [.[]
+              | select(.user != null)
+              | select(((.user.login // "") | endswith("[bot]")) | not)
+              | select((.user.type // "User") != "Bot")
+              | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+            ]
+            | group_by(.user.login)
+            | map(max_by([(.submitted_at // ""), (.id // 0)]))
+            | map(select(.state == "CHANGES_REQUESTED"))
+            | length > 0
+          ' <<<"${reviews}" >/dev/null
+          rc=$?
+          set -e
+          if [[ ${rc} -eq 0 ]]; then
+            echo "::error::Human reviewer still has CHANGES_REQUESTED"
+            exit 1
+          elif [[ ${rc} -ne 1 ]]; then
+            echo "::error::Cannot evaluate human review state (jq rc=${rc})"
+            exit 1
+          fi
+          echo "No outstanding human changes requested"


### PR DESCRIPTION
## Summary
- Adds `review-gate.yml`: required check fails while a human reviewer still has `CHANGES_REQUESTED`.

## Jira
N/A

## Test plan
- [ ] Human Request changes fails `check-human-reviews`
- [ ] Human Approves -> check passes
- [ ] Admin dismisses review -> check passes
- [ ] `actionlint` on `review-gate.yml`

## Follow-up
- Merge before osac-project/github-config PR that adds `check-human-reviews` to the EP ruleset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CI

- Adds a required `review-gate` workflow for pull requests targeting `main`.
- Fails when a human reviewer has `CHANGES_REQUESTED`.
- Passes after approval or review dismissal removes the outstanding request.
- Excludes bot reviewers.
- Fails when review-state evaluation returns an error.
- Uses only `pull-requests: read` permission.
- Runs for pull request updates, review submissions, and review dismissals.

## Tests and validation

- No separate test files changed.
- `actionlint` validation is required.
- The workflow logic covers requested-change, approval, and dismissal states.

## API surface

- No exported or public entities changed.

## Backward compatibility

- No application, API, database, authentication, or deployment compatibility impact.
- The workflow changes merge gating for pull requests targeting `main`.

## Risk classification

- **risk:show**: The change modifies CI merge-gating behavior and can block merges when a human reviewer requests changes.
- It does not qualify for **risk:ship** because it changes required repository checks.
- It does not qualify for **risk:ask** because it does not change production code, data, authentication, or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->