### PR TITLE
OSAC-4919: Design Review scores the full Design document, not just the PR diff

### DIFF
--- a/.github/scripts/ep_hooks.py
+++ b/.github/scripts/ep_hooks.py
@@ -5,6 +5,7 @@ Implements the hook interface: prompt_builder, context_writer,
 verdict_loader, label_applier, and gates.
 """
 
+import base64
 import json
 import os
 import re
@@ -206,6 +207,12 @@ class EPHooks:
         diff = self._gh(["pr", "diff", pr_number, "--repo", self.repo])
         (context_dir / "pr-diff.txt").write_text(diff)
 
+        if ticket.get("_skill_name") == "design-review":
+            design_full = self._fetch_design_full_text(
+                ticket.get("design_doc_paths") or [], ticket.get("headRefOid", "")
+            )
+            (context_dir / "design-full.txt").write_text(design_full)
+
         skill_path = ticket.get("_skill_path", "")
         skill_file = Path(self.skills_path) / skill_path
         if skill_file.exists():
@@ -214,6 +221,49 @@ class EPHooks:
         (context_dir / "pr-meta.json").write_text(
             json.dumps(ticket, indent=2, default=str)
         )
+
+    def _fetch_design_full_text(self, paths, head_sha):
+        """Full content of every Design document touched by this PR, at the
+        PR's head commit -- the source of truth for Design scoring, as
+        opposed to pr-diff.txt's diff-only view.
+
+        Tolerates individual fetch failures as long as at least one document
+        comes through; raises if none do, so the caller fails the review
+        instead of scoring placeholder content."""
+        sections = []
+        fetched = 0
+        for path in (paths if head_sha else []):
+            content = self._fetch_file_at_ref(path, head_sha)
+            if content is None:
+                sections.append(
+                    f"### File: {path}\n\n(Could not fetch this document at "
+                    "the PR head commit -- it may have been deleted or "
+                    "renamed in this PR.)\n"
+                )
+                continue
+            fetched += 1
+            sections.append(f"### File: {path}\n\n{content}\n")
+
+        if fetched == 0:
+            raise RuntimeError(
+                f"Could not fetch any Design document at {head_sha or '(no head sha)'} "
+                f"for paths {paths or '(none identified)'}"
+            )
+        return "\n".join(sections)
+
+    def _fetch_file_at_ref(self, path, ref):
+        """Read-only content fetch via the GitHub contents API. Never checks
+        out or executes the PR head -- just reads a text blob by SHA."""
+        encoded = self._gh([
+            "api", "--method", "GET", f"repos/{self.repo}/contents/{path}",
+            "-f", f"ref={ref}", "--jq", ".content",
+        ]).strip()
+        if not encoded or encoded == "null":
+            return None
+        try:
+            return base64.b64decode(encoded).decode("utf-8", errors="replace")
+        except ValueError:
+            return None
 
     # ── Prompt builder ──
 
@@ -278,8 +328,12 @@ class EPHooks:
         return (
             PROMPT_INJECTION_BOUNDARY +
             self._feature_context_block(ticket) +
-            "Review the design document in .context/pr-diff.txt using the review criteria "
-            "in .context/skill-prompt.md.\n\n"
+            "The full resulting content of each Design document in this PR, at this "
+            "PR's head commit, is in .context/design-full.txt -- this is the source of "
+            "truth for scoring Design quality. Review it using the review criteria in "
+            ".context/skill-prompt.md.\n\n"
+            ".context/pr-diff.txt is secondary context showing what this PR changed -- "
+            "use it to understand the change, not as the basis for scoring.\n\n"
             "Apply the review dimensions from skill-prompt.md, then map your assessment "
             "to these 4 scoring criteria:\n\n"
             "- feasibility (0-2): Is the design technically feasible and implementable?\n"

--- a/.github/scripts/ep_review.py
+++ b/.github/scripts/ep_review.py
@@ -66,14 +66,22 @@ def filenames_only(files):
     return [f["filename"] for f in files]
 
 
+def design_doc_filenames(files):
+    """Changed-file paths that are Design documents: design.md, or the
+    legacy enhancements/**/README.md format. Same match detect_skills() uses
+    to decide whether design-review runs at all."""
+    return [
+        f for f in files
+        if os.path.basename(f).lower() == "design.md"
+        or (os.path.basename(f).lower() == "readme.md" and "enhancements/" in f.lower())
+    ]
+
+
 def detect_skills(files):
     skills = []
     basenames = [os.path.basename(f).lower() for f in files]
     has_prd = "prd.md" in basenames
-    has_design = "design.md" in basenames or any(
-        os.path.basename(f).lower() == "readme.md" and "enhancements/" in f.lower()
-        for f in files
-    )
+    has_design = bool(design_doc_filenames(files))
 
     if has_prd:
         skills.append(("prd-review", "skills/prd-review/SKILL.md"))
@@ -133,6 +141,7 @@ def build_ticket_base(pr, head_sha, pr_number, files):
         "jira_key": feature_key_result if feature_key_result != "ambiguous" else None,
         "jira_key_ambiguous": feature_key_result == "ambiguous",
         "structure_violations": ep_paths.validate_ep_structure(files),
+        "design_doc_paths": design_doc_filenames(files),
     }
 
 

--- a/.github/scripts/ep_review.py
+++ b/.github/scripts/ep_review.py
@@ -73,7 +73,7 @@ def design_doc_filenames(files):
     return [
         f for f in files
         if os.path.basename(f).lower() == "design.md"
-        or (os.path.basename(f).lower() == "readme.md" and "enhancements/" in f.lower())
+        or (os.path.basename(f).lower() == "readme.md" and f.lower().startswith("enhancements/"))
     ]
 
 

--- a/.github/scripts/test_ep_hooks.py
+++ b/.github/scripts/test_ep_hooks.py
@@ -1,8 +1,11 @@
+import base64
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from ep_hooks import (
@@ -79,7 +82,7 @@ class PRDPromptTests(unittest.TestCase):
 
 
 class DesignPromptTests(unittest.TestCase):
-    """_design_prompt() must remain unchanged (already correct)."""
+    """_design_prompt() must still request scores using the skill's criteria."""
 
     def setUp(self):
         self.hooks = EPHooks(repo="test/repo", skills_path="/tmp")
@@ -88,6 +91,22 @@ class DesignPromptTests(unittest.TestCase):
     def test_prompt_contains_all_design_keys(self):
         for key in DESIGN_KEYS:
             self.assertIn(f"- {key} (0-2):", self.prompt)
+
+
+class DesignPromptSourceOfTruthTests(unittest.TestCase):
+    """_design_prompt() must point scoring at the full document, not the diff."""
+
+    def setUp(self):
+        self.hooks = EPHooks(repo="test/repo", skills_path="/tmp")
+        self.prompt = self.hooks._design_prompt({})
+
+    def test_full_document_is_primary_source(self):
+        self.assertIn("design-full.txt", self.prompt)
+        self.assertIn("source of truth", self.prompt)
+
+    def test_diff_is_secondary_context_only(self):
+        self.assertIn("pr-diff.txt", self.prompt)
+        self.assertIn("secondary context", self.prompt)
 
 
 class ValidateScoresTests(unittest.TestCase):
@@ -731,6 +750,194 @@ class ProgressPlaceholderTests(unittest.TestCase):
             # Must not raise.
             hooks.post_progress_placeholder("EP-1", "prd-review")
             hooks.post_failure_note("EP-1", "prd-review")
+
+
+class FetchFileAtRefTests(unittest.TestCase):
+    """_fetch_file_at_ref() reads file content read-only via the GitHub
+    contents API, by SHA -- never checks out or executes the PR head."""
+
+    def setUp(self):
+        self.hooks = EPHooks(repo="test/repo", skills_path="/tmp")
+
+    def _with_gh(self, return_value):
+        return mock.patch.object(self.hooks, "_gh", return_value=return_value)
+
+    def test_decodes_base64_content(self):
+        encoded = base64.b64encode(b"# Design\n\nfull content\n").decode()
+        with self._with_gh(encoded):
+            content = self.hooks._fetch_file_at_ref("enhancements/x/design.md", "deadbeef")
+        self.assertEqual(content, "# Design\n\nfull content\n")
+
+    def test_fetch_uses_contents_api_at_given_ref(self):
+        captured = {}
+
+        def fake_gh(args, check=False):
+            captured["args"] = args
+            return base64.b64encode(b"content").decode()
+
+        with mock.patch.object(self.hooks, "_gh", side_effect=fake_gh):
+            self.hooks._fetch_file_at_ref("enhancements/x/design.md", "deadbeef")
+        self.assertIn("repos/test/repo/contents/enhancements/x/design.md", captured["args"])
+        self.assertIn("ref=deadbeef", captured["args"])
+        self.assertNotIn("checkout", captured["args"])
+        # gh api silently switches to POST when -f is present unless the
+        # method is pinned explicitly -- this must stay a GET.
+        self.assertIn("GET", captured["args"])
+
+    def test_missing_file_returns_none(self):
+        with self._with_gh(""):
+            self.assertIsNone(
+                self.hooks._fetch_file_at_ref("enhancements/x/design.md", "deadbeef")
+            )
+
+    def test_null_content_returns_none(self):
+        with self._with_gh("null"):
+            self.assertIsNone(
+                self.hooks._fetch_file_at_ref("enhancements/x/design.md", "deadbeef")
+            )
+
+    def test_invalid_base64_returns_none(self):
+        with self._with_gh("not-valid-base64!!"):
+            self.assertIsNone(
+                self.hooks._fetch_file_at_ref("enhancements/x/design.md", "deadbeef")
+            )
+
+
+class FetchDesignFullTextTests(unittest.TestCase):
+    """_fetch_design_full_text() assembles the full-document scoring source
+    for one or more Design documents. Tolerates individual fetch failures as
+    long as at least one document comes through; raises if none do."""
+
+    def setUp(self):
+        self.hooks = EPHooks(repo="test/repo", skills_path="/tmp")
+
+    def test_no_paths_raises(self):
+        with self.assertRaises(RuntimeError):
+            self.hooks._fetch_design_full_text([], "deadbeef")
+
+    def test_no_head_sha_raises(self):
+        with self.assertRaises(RuntimeError):
+            self.hooks._fetch_design_full_text(["enhancements/x/design.md"], "")
+
+    def test_all_fetches_failing_raises(self):
+        with mock.patch.object(self.hooks, "_fetch_file_at_ref", return_value=None):
+            with self.assertRaises(RuntimeError):
+                self.hooks._fetch_design_full_text(
+                    ["enhancements/OSAC-1-x/design.md"], "deadbeef"
+                )
+
+    def test_single_document_initial_submission(self):
+        full_doc = "---\ntitle: X\n---\n\n## Summary\n\nfull design content\n"
+        with mock.patch.object(self.hooks, "_fetch_file_at_ref", return_value=full_doc):
+            text = self.hooks._fetch_design_full_text(
+                ["enhancements/OSAC-1-x/design.md"], "deadbeef"
+            )
+        self.assertIn("### File: enhancements/OSAC-1-x/design.md", text)
+        self.assertIn(full_doc, text)
+
+    def test_full_document_fetched_regardless_of_diff_size(self):
+        full_doc = "---\ntitle: X\n---\n\n" + "\n".join(
+            f"## Section {i}\n\ndetailed content\n" for i in range(20)
+        )
+        with mock.patch.object(self.hooks, "_fetch_file_at_ref", return_value=full_doc):
+            text = self.hooks._fetch_design_full_text(
+                ["enhancements/OSAC-1-x/design.md"], "deadbeef"
+            )
+        self.assertIn("Section 19", text)
+
+    def test_degraded_revision_content_passed_through_unmodified(self):
+        degraded_doc = "---\ntitle: X\n---\n\n## Summary\n\nno test plan section here\n"
+        with mock.patch.object(self.hooks, "_fetch_file_at_ref", return_value=degraded_doc):
+            text = self.hooks._fetch_design_full_text(
+                ["enhancements/OSAC-1-x/design.md"], "deadbeef"
+            )
+        self.assertIn(degraded_doc, text)
+        self.assertNotIn("Test Plan", text)
+
+    def test_multiple_documents_in_one_pr(self):
+        docs = {
+            "enhancements/OSAC-1-a/design.md": "design A content",
+            "enhancements/OSAC-2-b/design.md": "design B content",
+        }
+        with mock.patch.object(self.hooks, "_fetch_file_at_ref", side_effect=lambda p, r: docs[p]):
+            text = self.hooks._fetch_design_full_text(list(docs), "deadbeef")
+        for path, content in docs.items():
+            self.assertIn(f"### File: {path}", text)
+            self.assertIn(content, text)
+
+    def test_unfetchable_document_gets_placeholder_others_unaffected(self):
+        def fake_fetch(path, ref):
+            return None if path == "enhancements/OSAC-1-a/design.md" else "design B content"
+
+        with mock.patch.object(self.hooks, "_fetch_file_at_ref", side_effect=fake_fetch):
+            text = self.hooks._fetch_design_full_text(
+                ["enhancements/OSAC-1-a/design.md", "enhancements/OSAC-2-b/design.md"],
+                "deadbeef",
+            )
+        self.assertIn("Could not fetch", text)
+        self.assertIn("design B content", text)
+
+
+class WritePrContextDesignFullTests(unittest.TestCase):
+    """write_pr_context() writes design-full.txt for design-review only,
+    sourced from the ticket's already-known design_doc_paths."""
+
+    def setUp(self):
+        self.hooks = EPHooks(repo="test/repo", skills_path="/tmp")
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    def test_design_review_writes_design_full_txt(self):
+        def fake_gh(args, check=False):
+            if args[:2] == ["pr", "diff"]:
+                return "tiny diff"
+            if any("contents/enhancements/OSAC-1-x/design.md" in a for a in args):
+                return base64.b64encode(b"full design content").decode()
+            return ""
+
+        with mock.patch.object(self.hooks, "_gh", side_effect=fake_gh):
+            self.hooks.write_pr_context(
+                "EP-1",
+                {
+                    "_skill_name": "design-review",
+                    "_skill_path": "skills/design-review/SKILL.md",
+                    "headRefOid": "deadbeef",
+                    "design_doc_paths": ["enhancements/OSAC-1-x/design.md"],
+                },
+                mode="resolve", work_dir=self.tmp,
+            )
+        design_full = (Path(self.tmp) / ".context" / "design-full.txt").read_text()
+        self.assertIn("full design content", design_full)
+        self.assertTrue((Path(self.tmp) / ".context" / "pr-diff.txt").exists())
+
+    def test_design_review_raises_when_fetch_fails_entirely(self):
+        with mock.patch.object(self.hooks, "_gh", return_value=""):
+            with self.assertRaises(RuntimeError):
+                self.hooks.write_pr_context(
+                    "EP-1",
+                    {
+                        "_skill_name": "design-review",
+                        "_skill_path": "skills/design-review/SKILL.md",
+                        "headRefOid": "deadbeef",
+                        "design_doc_paths": ["enhancements/OSAC-1-x/design.md"],
+                    },
+                    mode="resolve", work_dir=self.tmp,
+                )
+        self.assertFalse((Path(self.tmp) / ".context" / "design-full.txt").exists())
+
+    def test_prd_review_does_not_write_design_full_txt(self):
+        with mock.patch.object(self.hooks, "_gh", return_value=""):
+            self.hooks.write_pr_context(
+                "EP-1",
+                {
+                    "_skill_name": "prd-review",
+                    "_skill_path": "skills/prd-review/SKILL.md",
+                    "headRefOid": "deadbeef",
+                    "design_doc_paths": [],
+                },
+                mode="resolve", work_dir=self.tmp,
+            )
+        self.assertFalse((Path(self.tmp) / ".context" / "design-full.txt").exists())
 
 
 class CheckPrStateTagTests(unittest.TestCase):

--- a/.github/scripts/test_ep_review.py
+++ b/.github/scripts/test_ep_review.py
@@ -121,6 +121,38 @@ class ExcludeOwnSlugFromReferenceLibraryTests(unittest.TestCase):
         self.assertTrue((self.ref_root / "unrelated").exists())
 
 
+class DesignDocFilenamesTests(unittest.TestCase):
+    """design_doc_filenames() feeds both detect_skills() (has_design) and
+    build_ticket_base()'s design_doc_paths -- single source of truth for
+    "which changed files are Design documents"."""
+
+    def test_design_md_matched(self):
+        files = ["enhancements/OSAC-1-x/design.md", "enhancements/OSAC-1-x/prd.md"]
+        self.assertEqual(er.design_doc_filenames(files), ["enhancements/OSAC-1-x/design.md"])
+
+    def test_legacy_readme_in_enhancements_matched(self):
+        files = ["enhancements/OSAC-1-x/README.md"]
+        self.assertEqual(er.design_doc_filenames(files), files)
+
+    def test_readme_outside_enhancements_not_matched(self):
+        self.assertEqual(er.design_doc_filenames(["README.md"]), [])
+
+    def test_case_insensitive_basename(self):
+        files = ["enhancements/OSAC-1-x/DESIGN.md"]
+        self.assertEqual(er.design_doc_filenames(files), files)
+
+    def test_multiple_design_docs_multi_feature_pr(self):
+        files = [
+            "enhancements/OSAC-1-a/design.md",
+            "enhancements/OSAC-2-b/design.md",
+            "enhancements/OSAC-2-b/prd.md",
+        ]
+        self.assertEqual(
+            er.design_doc_filenames(files),
+            ["enhancements/OSAC-1-a/design.md", "enhancements/OSAC-2-b/design.md"],
+        )
+
+
 class BuildTicketBaseTests(unittest.TestCase):
     """Real file-list shapes from #168/#172/#173/#174 — filenames only, no
     diff content needed for Phase A."""
@@ -144,6 +176,7 @@ class BuildTicketBaseTests(unittest.TestCase):
         self.assertEqual(ticket["jira_key"], "OSAC-2872")
         self.assertFalse(ticket["jira_key_ambiguous"])
         self.assertEqual(ticket["structure_violations"], [])
+        self.assertEqual(ticket["design_doc_paths"], files)
 
     def test_pr_173_key_derived_from_path_not_title(self):
         # Real case: PR title references OSAC-2645, but the touched EP
@@ -194,6 +227,12 @@ class BuildTicketBaseTests(unittest.TestCase):
         self.assertIsNone(ticket["jira_key"])
         self.assertTrue(ticket["jira_key_ambiguous"])
         self.assertEqual(ticket["structure_violations"], [])
+        # Multi-feature PR: every touched Design document is carried through,
+        # even though the Feature key itself is ambiguous.
+        self.assertEqual(
+            ticket["design_doc_paths"],
+            [f for f in files if er.os.path.basename(f).lower() in ("readme.md", "design.md")],
+        )
 
     def test_missing_key_prefix_surfaces_as_structure_violation(self):
         files = ["enhancements/vm-worker-nodes/prd.md"]

--- a/.github/scripts/test_ep_review.py
+++ b/.github/scripts/test_ep_review.py
@@ -137,6 +137,9 @@ class DesignDocFilenamesTests(unittest.TestCase):
     def test_readme_outside_enhancements_not_matched(self):
         self.assertEqual(er.design_doc_filenames(["README.md"]), [])
 
+    def test_readme_under_non_root_enhancements_not_matched(self):
+        self.assertEqual(er.design_doc_filenames(["docs/enhancements/README.md"]), [])
+
     def test_case_insensitive_basename(self):
         files = ["enhancements/OSAC-1-x/DESIGN.md"]
         self.assertEqual(er.design_doc_filenames(files), files)


### PR DESCRIPTION
## Summary
- Design Review was scoring only the PR diff, effectively treating a partial diff as if it were the complete Design document.
- Fetches the full resulting Design document(s) at the PR's exact head SHA via the GitHub Contents API and uses that as the scoring source of truth; the PR diff is now secondary context only for understanding the change.
- Supports multiple Design documents in one PR; tolerates individual fetch failures as long as at least one document is fetched, and fails before invoking the reviewer if zero documents can be fetched.
- PRD Review is unchanged — this only touches the design-review path.

## Jira
https://redhat.atlassian.net/browse/OSAC-4919

## Test plan
- [x] Focused tests: 109/109 passing
- [x] Full suite (`python3 -m unittest discover -s . -p "test_*ep*.py"`, matching CI): 191/191 passing
- [x] Live validation: PR #252 fetched the full [OSAC-3538](https://redhat.atlassian.net/browse/OSAC-3538) Design; comparison smoke on PR #228
- [x] Code review: 0 findings
- [x] Pre-flight review gate (performance/security/ponytail): PASS — 2 advisory-only findings, no blockers

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.2.0). Review for accuracy_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CI and review automation

- Design Review now scores the full Design document at the PR head SHA through the GitHub Contents API.
- The PR diff remains secondary context.
- Multiple Design documents are supported.
- Individual fetch failures are tolerated when at least one document is retrieved.
- Review stops before reviewer invocation when no document is retrieved.
- PRD Review is unchanged.
- Design document detection is centralized in `design_doc_filenames()`.
- Review tickets now include `design_doc_paths`.

## Tests

- Added coverage for SHA-based Contents API reads, Base64 decoding, invalid content, multiple documents, partial failures, and total failure.
- Added coverage for Design-only context generation and prompt source selection.
- Focused tests pass: 109/109.
- Full test suite passes: 191/191.

## Backward compatibility

- No public API or exported declaration changes are reported.
- PRD Review behavior is unchanged.
- Existing Design document matching behavior is preserved.
- Design Review now evaluates full documents instead of only the PR diff.

## Risk classification

- `risk:show` was applied because the change modifies CI review behavior and adds GitHub Contents API reads.
- The repository search did not find formal criteria for `risk:ship`, `risk:show`, or `risk:ask`.
- The change was not classified as `risk:ship` because it changes the Design Review source of truth.
- The change was not classified as `risk:ask` because fetch failures have defined handling and the focused and full test suites pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->