### PR TITLE
OSAC-4926: PRD Review scores the full PRD document, not just the PR diff

### DIFF
--- a/.github/scripts/ep_hooks.py
+++ b/.github/scripts/ep_hooks.py
@@ -231,9 +231,7 @@ class EPHooks:
         )
 
     def _fetch_doc_full_text(self, paths, head_sha, doc_label):
-        """Full content of every `doc_label` document (e.g. "Design", "PRD")
-        touched by this PR, at the PR's head commit -- the source of truth
-        for scoring, as opposed to pr-diff.txt's diff-only view.
+        """Full content of every doc_label document at the PR's head commit.
 
         Tolerates individual fetch failures as long as at least one document
         comes through; raises if none do, so the caller fails the review

--- a/.github/scripts/ep_hooks.py
+++ b/.github/scripts/ep_hooks.py
@@ -207,11 +207,19 @@ class EPHooks:
         diff = self._gh(["pr", "diff", pr_number, "--repo", self.repo])
         (context_dir / "pr-diff.txt").write_text(diff)
 
-        if ticket.get("_skill_name") == "design-review":
-            design_full = self._fetch_design_full_text(
-                ticket.get("design_doc_paths") or [], ticket.get("headRefOid", "")
+        skill_name = ticket.get("_skill_name")
+        if skill_name == "design-review":
+            design_full = self._fetch_doc_full_text(
+                ticket.get("design_doc_paths") or [], ticket.get("headRefOid", ""),
+                "Design",
             )
             (context_dir / "design-full.txt").write_text(design_full)
+        elif skill_name == "prd-review":
+            prd_full = self._fetch_doc_full_text(
+                ticket.get("prd_doc_paths") or [], ticket.get("headRefOid", ""),
+                "PRD",
+            )
+            (context_dir / "prd-full.txt").write_text(prd_full)
 
         skill_path = ticket.get("_skill_path", "")
         skill_file = Path(self.skills_path) / skill_path
@@ -222,10 +230,10 @@ class EPHooks:
             json.dumps(ticket, indent=2, default=str)
         )
 
-    def _fetch_design_full_text(self, paths, head_sha):
-        """Full content of every Design document touched by this PR, at the
-        PR's head commit -- the source of truth for Design scoring, as
-        opposed to pr-diff.txt's diff-only view.
+    def _fetch_doc_full_text(self, paths, head_sha, doc_label):
+        """Full content of every `doc_label` document (e.g. "Design", "PRD")
+        touched by this PR, at the PR's head commit -- the source of truth
+        for scoring, as opposed to pr-diff.txt's diff-only view.
 
         Tolerates individual fetch failures as long as at least one document
         comes through; raises if none do, so the caller fails the review
@@ -246,7 +254,7 @@ class EPHooks:
 
         if fetched == 0:
             raise RuntimeError(
-                f"Could not fetch any Design document at {head_sha or '(no head sha)'} "
+                f"Could not fetch any {doc_label} document at {head_sha or '(no head sha)'} "
                 f"for paths {paths or '(none identified)'}"
             )
         return "\n".join(sections)
@@ -290,8 +298,12 @@ class EPHooks:
         return (
             PROMPT_INJECTION_BOUNDARY +
             self._feature_context_block(ticket) +
-            "Review the document in .context/pr-diff.txt using the review criteria "
-            "in .context/skill-prompt.md.\n\n"
+            "The full resulting content of each PRD document in this PR, at this "
+            "PR's head commit, is in .context/prd-full.txt -- this is the source of "
+            "truth for scoring PRD quality. Review it using the review criteria in "
+            ".context/skill-prompt.md.\n\n"
+            ".context/pr-diff.txt is secondary context showing what this PR changed -- "
+            "use it to understand the change, not as the basis for scoring.\n\n"
             "Apply the review dimensions from skill-prompt.md, then map your assessment "
             "to these 5 scoring criteria:\n\n"
             "- what (0-2): Clear user-facing need? Does the PRD describe a new product "

--- a/.github/scripts/ep_review.py
+++ b/.github/scripts/ep_review.py
@@ -78,8 +78,7 @@ def design_doc_filenames(files):
 
 
 def prd_doc_filenames(files):
-    """Changed-file paths that are PRD documents: prd.md. Same match
-    detect_skills() uses to decide whether prd-review runs at all."""
+    """Changed-file paths that are PRD documents: prd.md."""
     return [f for f in files if os.path.basename(f).lower() == "prd.md"]
 
 

--- a/.github/scripts/ep_review.py
+++ b/.github/scripts/ep_review.py
@@ -77,10 +77,15 @@ def design_doc_filenames(files):
     ]
 
 
+def prd_doc_filenames(files):
+    """Changed-file paths that are PRD documents: prd.md. Same match
+    detect_skills() uses to decide whether prd-review runs at all."""
+    return [f for f in files if os.path.basename(f).lower() == "prd.md"]
+
+
 def detect_skills(files):
     skills = []
-    basenames = [os.path.basename(f).lower() for f in files]
-    has_prd = "prd.md" in basenames
+    has_prd = bool(prd_doc_filenames(files))
     has_design = bool(design_doc_filenames(files))
 
     if has_prd:
@@ -142,6 +147,7 @@ def build_ticket_base(pr, head_sha, pr_number, files):
         "jira_key_ambiguous": feature_key_result == "ambiguous",
         "structure_violations": ep_paths.validate_ep_structure(files),
         "design_doc_paths": design_doc_filenames(files),
+        "prd_doc_paths": prd_doc_filenames(files),
     }
 
 

--- a/.github/scripts/test_ep_hooks.py
+++ b/.github/scripts/test_ep_hooks.py
@@ -820,10 +820,8 @@ class FetchFileAtRefTests(unittest.TestCase):
 
 
 class FetchDocFullTextTests(unittest.TestCase):
-    """_fetch_doc_full_text() assembles the full-document scoring source for
-    one or more documents of a given doc_label. Tolerates individual fetch
-    failures as long as at least one document comes through; raises if none
-    do."""
+    """Tolerates individual fetch failures as long as at least one document
+    comes through; raises if none do."""
 
     def setUp(self):
         self.hooks = EPHooks(repo="test/repo", skills_path="/tmp")
@@ -848,11 +846,6 @@ class FetchDocFullTextTests(unittest.TestCase):
             self.hooks._fetch_doc_full_text([], "deadbeef", "PRD")
         self.assertIn("PRD", str(ctx.exception))
 
-    def test_raise_message_uses_design_label(self):
-        with self.assertRaises(RuntimeError) as ctx:
-            self.hooks._fetch_doc_full_text([], "deadbeef", "Design")
-        self.assertIn("Design", str(ctx.exception))
-
     def test_single_document_initial_submission(self):
         full_doc = "---\ntitle: X\n---\n\n## Summary\n\nfull design content\n"
         with mock.patch.object(self.hooks, "_fetch_file_at_ref", return_value=full_doc):
@@ -860,15 +853,6 @@ class FetchDocFullTextTests(unittest.TestCase):
                 ["enhancements/OSAC-1-x/design.md"], "deadbeef", "Design"
             )
         self.assertIn("### File: enhancements/OSAC-1-x/design.md", text)
-        self.assertIn(full_doc, text)
-
-    def test_single_prd_document(self):
-        full_doc = "---\ntitle: X\n---\n\n## What\n\nfull prd content\n"
-        with mock.patch.object(self.hooks, "_fetch_file_at_ref", return_value=full_doc):
-            text = self.hooks._fetch_doc_full_text(
-                ["enhancements/OSAC-1-x/prd.md"], "deadbeef", "PRD"
-            )
-        self.assertIn("### File: enhancements/OSAC-1-x/prd.md", text)
         self.assertIn(full_doc, text)
 
     def test_full_document_fetched_regardless_of_diff_size(self):
@@ -897,17 +881,6 @@ class FetchDocFullTextTests(unittest.TestCase):
         }
         with mock.patch.object(self.hooks, "_fetch_file_at_ref", side_effect=lambda p, r: docs[p]):
             text = self.hooks._fetch_doc_full_text(list(docs), "deadbeef", "Design")
-        for path, content in docs.items():
-            self.assertIn(f"### File: {path}", text)
-            self.assertIn(content, text)
-
-    def test_multiple_prd_documents_in_one_pr(self):
-        docs = {
-            "enhancements/OSAC-1-a/prd.md": "prd A content",
-            "enhancements/OSAC-2-b/prd.md": "prd B content",
-        }
-        with mock.patch.object(self.hooks, "_fetch_file_at_ref", side_effect=lambda p, r: docs[p]):
-            text = self.hooks._fetch_doc_full_text(list(docs), "deadbeef", "PRD")
         for path, content in docs.items():
             self.assertIn(f"### File: {path}", text)
             self.assertIn(content, text)

--- a/.github/scripts/test_ep_hooks.py
+++ b/.github/scripts/test_ep_hooks.py
@@ -109,6 +109,22 @@ class DesignPromptSourceOfTruthTests(unittest.TestCase):
         self.assertIn("secondary context", self.prompt)
 
 
+class PrdPromptSourceOfTruthTests(unittest.TestCase):
+    """_prd_prompt() must point scoring at the full document, not the diff."""
+
+    def setUp(self):
+        self.hooks = EPHooks(repo="test/repo", skills_path="/tmp")
+        self.prompt = self.hooks._prd_prompt({})
+
+    def test_full_document_is_primary_source(self):
+        self.assertIn("prd-full.txt", self.prompt)
+        self.assertIn("source of truth", self.prompt)
+
+    def test_diff_is_secondary_context_only(self):
+        self.assertIn("pr-diff.txt", self.prompt)
+        self.assertIn("secondary context", self.prompt)
+
+
 class ValidateScoresTests(unittest.TestCase):
     def setUp(self):
         self.hooks = EPHooks(repo="test/repo", skills_path="/tmp")
@@ -803,36 +819,56 @@ class FetchFileAtRefTests(unittest.TestCase):
             )
 
 
-class FetchDesignFullTextTests(unittest.TestCase):
-    """_fetch_design_full_text() assembles the full-document scoring source
-    for one or more Design documents. Tolerates individual fetch failures as
-    long as at least one document comes through; raises if none do."""
+class FetchDocFullTextTests(unittest.TestCase):
+    """_fetch_doc_full_text() assembles the full-document scoring source for
+    one or more documents of a given doc_label. Tolerates individual fetch
+    failures as long as at least one document comes through; raises if none
+    do."""
 
     def setUp(self):
         self.hooks = EPHooks(repo="test/repo", skills_path="/tmp")
 
     def test_no_paths_raises(self):
         with self.assertRaises(RuntimeError):
-            self.hooks._fetch_design_full_text([], "deadbeef")
+            self.hooks._fetch_doc_full_text([], "deadbeef", "Design")
 
     def test_no_head_sha_raises(self):
         with self.assertRaises(RuntimeError):
-            self.hooks._fetch_design_full_text(["enhancements/x/design.md"], "")
+            self.hooks._fetch_doc_full_text(["enhancements/x/design.md"], "", "Design")
 
     def test_all_fetches_failing_raises(self):
         with mock.patch.object(self.hooks, "_fetch_file_at_ref", return_value=None):
             with self.assertRaises(RuntimeError):
-                self.hooks._fetch_design_full_text(
-                    ["enhancements/OSAC-1-x/design.md"], "deadbeef"
+                self.hooks._fetch_doc_full_text(
+                    ["enhancements/OSAC-1-x/design.md"], "deadbeef", "Design"
                 )
+
+    def test_raise_message_uses_supplied_doc_label(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self.hooks._fetch_doc_full_text([], "deadbeef", "PRD")
+        self.assertIn("PRD", str(ctx.exception))
+
+    def test_raise_message_uses_design_label(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self.hooks._fetch_doc_full_text([], "deadbeef", "Design")
+        self.assertIn("Design", str(ctx.exception))
 
     def test_single_document_initial_submission(self):
         full_doc = "---\ntitle: X\n---\n\n## Summary\n\nfull design content\n"
         with mock.patch.object(self.hooks, "_fetch_file_at_ref", return_value=full_doc):
-            text = self.hooks._fetch_design_full_text(
-                ["enhancements/OSAC-1-x/design.md"], "deadbeef"
+            text = self.hooks._fetch_doc_full_text(
+                ["enhancements/OSAC-1-x/design.md"], "deadbeef", "Design"
             )
         self.assertIn("### File: enhancements/OSAC-1-x/design.md", text)
+        self.assertIn(full_doc, text)
+
+    def test_single_prd_document(self):
+        full_doc = "---\ntitle: X\n---\n\n## What\n\nfull prd content\n"
+        with mock.patch.object(self.hooks, "_fetch_file_at_ref", return_value=full_doc):
+            text = self.hooks._fetch_doc_full_text(
+                ["enhancements/OSAC-1-x/prd.md"], "deadbeef", "PRD"
+            )
+        self.assertIn("### File: enhancements/OSAC-1-x/prd.md", text)
         self.assertIn(full_doc, text)
 
     def test_full_document_fetched_regardless_of_diff_size(self):
@@ -840,16 +876,16 @@ class FetchDesignFullTextTests(unittest.TestCase):
             f"## Section {i}\n\ndetailed content\n" for i in range(20)
         )
         with mock.patch.object(self.hooks, "_fetch_file_at_ref", return_value=full_doc):
-            text = self.hooks._fetch_design_full_text(
-                ["enhancements/OSAC-1-x/design.md"], "deadbeef"
+            text = self.hooks._fetch_doc_full_text(
+                ["enhancements/OSAC-1-x/design.md"], "deadbeef", "Design"
             )
         self.assertIn("Section 19", text)
 
     def test_degraded_revision_content_passed_through_unmodified(self):
         degraded_doc = "---\ntitle: X\n---\n\n## Summary\n\nno test plan section here\n"
         with mock.patch.object(self.hooks, "_fetch_file_at_ref", return_value=degraded_doc):
-            text = self.hooks._fetch_design_full_text(
-                ["enhancements/OSAC-1-x/design.md"], "deadbeef"
+            text = self.hooks._fetch_doc_full_text(
+                ["enhancements/OSAC-1-x/design.md"], "deadbeef", "Design"
             )
         self.assertIn(degraded_doc, text)
         self.assertNotIn("Test Plan", text)
@@ -860,7 +896,18 @@ class FetchDesignFullTextTests(unittest.TestCase):
             "enhancements/OSAC-2-b/design.md": "design B content",
         }
         with mock.patch.object(self.hooks, "_fetch_file_at_ref", side_effect=lambda p, r: docs[p]):
-            text = self.hooks._fetch_design_full_text(list(docs), "deadbeef")
+            text = self.hooks._fetch_doc_full_text(list(docs), "deadbeef", "Design")
+        for path, content in docs.items():
+            self.assertIn(f"### File: {path}", text)
+            self.assertIn(content, text)
+
+    def test_multiple_prd_documents_in_one_pr(self):
+        docs = {
+            "enhancements/OSAC-1-a/prd.md": "prd A content",
+            "enhancements/OSAC-2-b/prd.md": "prd B content",
+        }
+        with mock.patch.object(self.hooks, "_fetch_file_at_ref", side_effect=lambda p, r: docs[p]):
+            text = self.hooks._fetch_doc_full_text(list(docs), "deadbeef", "PRD")
         for path, content in docs.items():
             self.assertIn(f"### File: {path}", text)
             self.assertIn(content, text)
@@ -870,9 +917,9 @@ class FetchDesignFullTextTests(unittest.TestCase):
             return None if path == "enhancements/OSAC-1-a/design.md" else "design B content"
 
         with mock.patch.object(self.hooks, "_fetch_file_at_ref", side_effect=fake_fetch):
-            text = self.hooks._fetch_design_full_text(
+            text = self.hooks._fetch_doc_full_text(
                 ["enhancements/OSAC-1-a/design.md", "enhancements/OSAC-2-b/design.md"],
-                "deadbeef",
+                "deadbeef", "Design",
             )
         self.assertIn("Could not fetch", text)
         self.assertIn("design B content", text)
@@ -926,7 +973,14 @@ class WritePrContextDesignFullTests(unittest.TestCase):
         self.assertFalse((Path(self.tmp) / ".context" / "design-full.txt").exists())
 
     def test_prd_review_does_not_write_design_full_txt(self):
-        with mock.patch.object(self.hooks, "_gh", return_value=""):
+        def fake_gh(args, check=False):
+            if args[:2] == ["pr", "diff"]:
+                return "tiny diff"
+            if any("contents/enhancements/OSAC-1-x/prd.md" in a for a in args):
+                return base64.b64encode(b"full prd content").decode()
+            return ""
+
+        with mock.patch.object(self.hooks, "_gh", side_effect=fake_gh):
             self.hooks.write_pr_context(
                 "EP-1",
                 {
@@ -934,10 +988,106 @@ class WritePrContextDesignFullTests(unittest.TestCase):
                     "_skill_path": "skills/prd-review/SKILL.md",
                     "headRefOid": "deadbeef",
                     "design_doc_paths": [],
+                    "prd_doc_paths": ["enhancements/OSAC-1-x/prd.md"],
                 },
                 mode="resolve", work_dir=self.tmp,
             )
         self.assertFalse((Path(self.tmp) / ".context" / "design-full.txt").exists())
+
+
+class WritePrContextPrdFullTests(unittest.TestCase):
+    """write_pr_context() writes prd-full.txt for prd-review only, sourced
+    from the ticket's already-known prd_doc_paths."""
+
+    def setUp(self):
+        self.hooks = EPHooks(repo="test/repo", skills_path="/tmp")
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    def test_prd_review_writes_prd_full_txt(self):
+        def fake_gh(args, check=False):
+            if args[:2] == ["pr", "diff"]:
+                return "tiny diff"
+            if any("contents/enhancements/OSAC-1-x/prd.md" in a for a in args):
+                return base64.b64encode(b"full prd content").decode()
+            return ""
+
+        with mock.patch.object(self.hooks, "_gh", side_effect=fake_gh):
+            self.hooks.write_pr_context(
+                "EP-1",
+                {
+                    "_skill_name": "prd-review",
+                    "_skill_path": "skills/prd-review/SKILL.md",
+                    "headRefOid": "deadbeef",
+                    "prd_doc_paths": ["enhancements/OSAC-1-x/prd.md"],
+                },
+                mode="resolve", work_dir=self.tmp,
+            )
+        prd_full = (Path(self.tmp) / ".context" / "prd-full.txt").read_text()
+        self.assertIn("full prd content", prd_full)
+        self.assertTrue((Path(self.tmp) / ".context" / "pr-diff.txt").exists())
+
+    def test_prd_review_uses_prd_doc_paths_and_head_sha(self):
+        captured = {}
+
+        def fake_gh(args, check=False):
+            if args[:2] == ["pr", "diff"]:
+                return "tiny diff"
+            if "GET" in args:
+                captured["args"] = args
+                return base64.b64encode(b"full prd content").decode()
+            return ""
+
+        with mock.patch.object(self.hooks, "_gh", side_effect=fake_gh):
+            self.hooks.write_pr_context(
+                "EP-1",
+                {
+                    "_skill_name": "prd-review",
+                    "_skill_path": "skills/prd-review/SKILL.md",
+                    "headRefOid": "cafef00d",
+                    "prd_doc_paths": ["enhancements/OSAC-1-x/prd.md"],
+                },
+                mode="resolve", work_dir=self.tmp,
+            )
+        self.assertIn("repos/test/repo/contents/enhancements/OSAC-1-x/prd.md", captured["args"])
+        self.assertIn("ref=cafef00d", captured["args"])
+
+    def test_prd_review_raises_when_fetch_fails_entirely(self):
+        with mock.patch.object(self.hooks, "_gh", return_value=""):
+            with self.assertRaises(RuntimeError):
+                self.hooks.write_pr_context(
+                    "EP-1",
+                    {
+                        "_skill_name": "prd-review",
+                        "_skill_path": "skills/prd-review/SKILL.md",
+                        "headRefOid": "deadbeef",
+                        "prd_doc_paths": ["enhancements/OSAC-1-x/prd.md"],
+                    },
+                    mode="resolve", work_dir=self.tmp,
+                )
+        self.assertFalse((Path(self.tmp) / ".context" / "prd-full.txt").exists())
+
+    def test_design_review_does_not_write_prd_full_txt(self):
+        def fake_gh(args, check=False):
+            if args[:2] == ["pr", "diff"]:
+                return "tiny diff"
+            if any("contents/enhancements/OSAC-1-x/design.md" in a for a in args):
+                return base64.b64encode(b"full design content").decode()
+            return ""
+
+        with mock.patch.object(self.hooks, "_gh", side_effect=fake_gh):
+            self.hooks.write_pr_context(
+                "EP-1",
+                {
+                    "_skill_name": "design-review",
+                    "_skill_path": "skills/design-review/SKILL.md",
+                    "headRefOid": "deadbeef",
+                    "design_doc_paths": ["enhancements/OSAC-1-x/design.md"],
+                    "prd_doc_paths": [],
+                },
+                mode="resolve", work_dir=self.tmp,
+            )
+        self.assertFalse((Path(self.tmp) / ".context" / "prd-full.txt").exists())
 
 
 class CheckPrStateTagTests(unittest.TestCase):

--- a/.github/scripts/test_ep_review.py
+++ b/.github/scripts/test_ep_review.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import os
 import shutil
@@ -156,6 +157,59 @@ class DesignDocFilenamesTests(unittest.TestCase):
         )
 
 
+class PrdDocFilenamesTests(unittest.TestCase):
+    """prd_doc_filenames() feeds both detect_skills() (has_prd) and
+    build_ticket_base()'s prd_doc_paths -- single source of truth for
+    "which changed files are PRD documents"."""
+
+    def test_prd_md_matched(self):
+        files = ["enhancements/OSAC-1-x/design.md", "enhancements/OSAC-1-x/prd.md"]
+        self.assertEqual(er.prd_doc_filenames(files), ["enhancements/OSAC-1-x/prd.md"])
+
+    def test_case_insensitive_basename(self):
+        files = ["enhancements/OSAC-1-x/PRD.md"]
+        self.assertEqual(er.prd_doc_filenames(files), files)
+
+    def test_unrelated_filenames_not_matched(self):
+        files = ["enhancements/OSAC-1-x/design.md", "README.md", "guidelines/prd_template.md"]
+        self.assertEqual(er.prd_doc_filenames(files), [])
+
+    def test_multiple_prd_docs_multi_feature_pr(self):
+        files = [
+            "enhancements/OSAC-1-a/prd.md",
+            "enhancements/OSAC-2-b/design.md",
+            "enhancements/OSAC-2-b/prd.md",
+        ]
+        self.assertEqual(
+            er.prd_doc_filenames(files),
+            ["enhancements/OSAC-1-a/prd.md", "enhancements/OSAC-2-b/prd.md"],
+        )
+
+
+class DetectSkillsPrdDefinitionTests(unittest.TestCase):
+    """detect_skills() must use prd_doc_filenames() as its source of truth
+    for PRD detection -- not a second, independent basename check."""
+
+    def test_prd_detected_via_prd_doc_filenames(self):
+        files = ["enhancements/OSAC-1-x/prd.md"]
+        self.assertEqual(
+            er.detect_skills(files),
+            [("prd-review", "skills/prd-review/SKILL.md")],
+        )
+
+    def test_both_detected_for_prd_and_design(self):
+        files = ["enhancements/OSAC-1-x/prd.md", "enhancements/OSAC-1-x/design.md"]
+        skills = er.detect_skills(files)
+        self.assertEqual(
+            {name for name, _ in skills}, {"prd-review", "design-review"},
+        )
+
+    def test_no_prd_when_prd_doc_filenames_empty(self):
+        files = ["enhancements/OSAC-1-x/design.md"]
+        skills = er.detect_skills(files)
+        self.assertNotIn("prd-review", [name for name, _ in skills])
+
+
 class BuildTicketBaseTests(unittest.TestCase):
     """Real file-list shapes from #168/#172/#173/#174 — filenames only, no
     diff content needed for Phase A."""
@@ -169,6 +223,7 @@ class BuildTicketBaseTests(unittest.TestCase):
         self.assertEqual(ticket["jira_key"], "OSAC-1589")
         self.assertFalse(ticket["jira_key_ambiguous"])
         self.assertEqual(ticket["structure_violations"], [])
+        self.assertEqual(ticket["prd_doc_paths"], files)
 
     def test_pr_172_single_key_no_violations(self):
         files = ["enhancements/OSAC-2872-storage-control-plane/design.md"]
@@ -180,6 +235,7 @@ class BuildTicketBaseTests(unittest.TestCase):
         self.assertFalse(ticket["jira_key_ambiguous"])
         self.assertEqual(ticket["structure_violations"], [])
         self.assertEqual(ticket["design_doc_paths"], files)
+        self.assertEqual(ticket["prd_doc_paths"], [])
 
     def test_pr_173_key_derived_from_path_not_title(self):
         # Real case: PR title references OSAC-2645, but the touched EP
@@ -230,11 +286,15 @@ class BuildTicketBaseTests(unittest.TestCase):
         self.assertIsNone(ticket["jira_key"])
         self.assertTrue(ticket["jira_key_ambiguous"])
         self.assertEqual(ticket["structure_violations"], [])
-        # Multi-feature PR: every touched Design document is carried through,
-        # even though the Feature key itself is ambiguous.
+        # Multi-feature PR: every touched Design/PRD document is carried
+        # through, even though the Feature key itself is ambiguous.
         self.assertEqual(
             ticket["design_doc_paths"],
             [f for f in files if er.os.path.basename(f).lower() in ("readme.md", "design.md")],
+        )
+        self.assertEqual(
+            ticket["prd_doc_paths"],
+            [f for f in files if er.os.path.basename(f).lower() == "prd.md"],
         )
 
     def test_missing_key_prefix_surfaces_as_structure_violation(self):
@@ -365,8 +425,18 @@ class RunReviewRealSeamTests(unittest.TestCase):
         self.work_dir = Path(self.tmp) / "workdir-prd-review"
 
         self.hooks = EPHooks(repo="test/repo", skills_path="/tmp", shadow=True)
-        # write_pr_context() otherwise shells out to the real `gh` CLI.
-        mock.patch.object(self.hooks, "_gh", return_value="").start()
+
+        # write_pr_context() shells out to the real `gh` CLI: return decodable
+        # content for the PRD contents-API call so it doesn't raise, "" for
+        # everything else (e.g. `pr diff`, which is fine to be empty here).
+        prd_full_doc = base64.b64encode(b"# PRD\n\nfull prd content\n").decode()
+
+        def fake_gh(args, check=False):
+            if any("contents/enhancements/OSAC-1589-vm-worker-caas/prd.md" in a for a in args):
+                return prd_full_doc
+            return ""
+
+        mock.patch.object(self.hooks, "_gh", side_effect=fake_gh).start()
         self.addCleanup(mock.patch.stopall)
 
         self.captured = {}
@@ -414,6 +484,7 @@ class RunReviewRealSeamTests(unittest.TestCase):
             "headRefOid": "abc12345", "labels": [],
             "jira_key": "OSAC-1589", "jira_key_ambiguous": False,
             "structure_violations": [],
+            "prd_doc_paths": ["enhancements/OSAC-1589-vm-worker-caas/prd.md"],
         }
 
         er.run_review(
@@ -438,6 +509,7 @@ class RunReviewRealSeamTests(unittest.TestCase):
             "headRefOid": "abc12345", "labels": [],
             "jira_key": None, "jira_key_ambiguous": True,
             "structure_violations": ["some violation"],
+            "prd_doc_paths": ["enhancements/OSAC-1589-vm-worker-caas/prd.md"],
         }
 
         er.run_review(

--- a/.github/scripts/test_ep_review.py
+++ b/.github/scripts/test_ep_review.py
@@ -158,10 +158,6 @@ class DesignDocFilenamesTests(unittest.TestCase):
 
 
 class PrdDocFilenamesTests(unittest.TestCase):
-    """prd_doc_filenames() feeds both detect_skills() (has_prd) and
-    build_ticket_base()'s prd_doc_paths -- single source of truth for
-    "which changed files are PRD documents"."""
-
     def test_prd_md_matched(self):
         files = ["enhancements/OSAC-1-x/design.md", "enhancements/OSAC-1-x/prd.md"]
         self.assertEqual(er.prd_doc_filenames(files), ["enhancements/OSAC-1-x/prd.md"])
@@ -187,8 +183,8 @@ class PrdDocFilenamesTests(unittest.TestCase):
 
 
 class DetectSkillsPrdDefinitionTests(unittest.TestCase):
-    """detect_skills() must use prd_doc_filenames() as its source of truth
-    for PRD detection -- not a second, independent basename check."""
+    """detect_skills() must use prd_doc_filenames(), not a separate basename
+    check, as its source of truth for PRD detection."""
 
     def test_prd_detected_via_prd_doc_filenames(self):
         files = ["enhancements/OSAC-1-x/prd.md"]
@@ -426,9 +422,8 @@ class RunReviewRealSeamTests(unittest.TestCase):
 
         self.hooks = EPHooks(repo="test/repo", skills_path="/tmp", shadow=True)
 
-        # write_pr_context() shells out to the real `gh` CLI: return decodable
-        # content for the PRD contents-API call so it doesn't raise, "" for
-        # everything else (e.g. `pr diff`, which is fine to be empty here).
+        # write_pr_context() fetches the PRD's full content via gh; anything
+        # else (e.g. pr diff) can be empty without failing the run.
         prd_full_doc = base64.b64encode(b"# PRD\n\nfull prd content\n").decode()
 
         def fake_gh(args, check=False):


### PR DESCRIPTION
## Summary

- PRD Review previously scored only the PR diff, so unchanged sections of an existing PRD could be treated as missing.
- It now fetches the complete PRD document(s) at the exact PR head SHA and uses that as the scoring source of truth.
- `pr-diff.txt` remains secondary context only.
- The document fetch/assembly logic is shared with Design Review through the narrowly scoped `_fetch_doc_full_text()` helper.
- Design Review behavior remains unchanged.

## Background

- Follow-up to [OSAC-4919](https://redhat.atlassian.net/browse/OSAC-4919) and enhancement-proposals PR #259, which gave Design Review this same full-document-at-PR-head treatment.
- During review of PR #259, Eran explicitly requested applying the same approach to PRD Review, ideally through a shared helper — that request is what this PR implements.
- [OSAC-4919](https://redhat.atlassian.net/browse/OSAC-4919) itself remains scoped to Design Review only; this work is tracked separately as [OSAC-4926](https://redhat.atlassian.net/browse/OSAC-4926).

## Test plan

- [x] Full CI-equivalent EP suite: `python3 -m unittest discover -s . -p "test_*ep*.py"` — 206 tests passing
- [x] Real `agentic_ci.skill.run_skill()` seam exercised (not mocked) for the PRD full-document fetch path
- [x] Pre-commit hooks (`pre-commit run --all-files`) — clean
- [x] Independent `/code-review medium` on the implementation — 0 correctness findings

## Jira

https://redhat.atlassian.net/browse/OSAC-4926 (follow-up to https://redhat.atlassian.net/browse/OSAC-4919)

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.2.0). Review for accuracy_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

### Review behavior
- PRD Review now scores complete PRD documents fetched at the exact PR head SHA.
- `.context/prd-full.txt` is the scoring source of truth.
- `.context/pr-diff.txt` remains secondary context.
- Design Review keeps its existing full-document behavior.
- Shared document-fetch logic now uses `_fetch_doc_full_text(paths, head_sha, doc_label)`.

### PRD detection and ticket data
- Added `prd_doc_filenames(files)` for case-insensitive PRD detection.
- `detect_skills()` now uses the shared PRD detection helper.
- Review ticket payloads now include `prd_doc_paths`.

### Tests and CI
- Added coverage for PRD prompt source-of-truth rules.
- Added coverage for PRD full-document fetching, failure handling, document labels, and review-specific output files.
- Added coverage for PRD filename detection and ticket payloads.
- Updated integration fixtures to provide base64-encoded PRD content.
- Pre-commit checks and the EP test suite are covered.

### Backward compatibility
- Design Review behavior remains unchanged.
- The renamed `_fetch_design_full_text()` method is an internal API change. Callers must use `_fetch_doc_full_text()` with a document label.
- PRD scoring behavior changes from diff-based input to full-document input.

## Risk classification

**risk:ship** — The change is limited to review-context assembly, prompt source selection, PRD detection, and automated tests. It does not change production controllers, databases, authentication, deployment, or user data. The PRD scoring input changes, but the exact head SHA and failure paths are covered by tests.

It is not **risk:show** because the change does not require staged rollout or monitoring for production behavior. It is not **risk:ask** because it does not introduce high-impact runtime, security, data, or deployment changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->