### PR TITLE
OSAC-4346: PRD - Support NetBox Inventory

### DIFF
--- a/enhancements/OSAC-4346-netbox-inventory/clarifications.md
+++ b/enhancements/OSAC-4346-netbox-inventory/clarifications.md
@@ -1,0 +1,91 @@
+# Clarification Log — OSAC-4346
+
+## Status
+
+- Rounds completed: 1
+- Open gaps: 0
+- Exit criteria met: Yes
+
+## Round 1 — Scope & Deployment
+
+### R1.Q1: Primary Goal
+
+What are the user-facing outcomes when a Cloud Infrastructure Admin configures NetBox as the inventory backend?
+
+#### Answer
+
+Tenants can allocate and deallocate bare-metal hosts from NetBox inventory transparently. Cloud Infrastructure Admin configures the backend endpoint and credentials, then OSAC handles all allocation/deallocation internally without tenant exposure to NetBox.
+
+#### Impact
+
+Defines primary personas: Cloud Infrastructure Admin (setup and prerequisites) and Tenant User (transparent provisioning). No NetBox-specific UX exposed to tenants.
+
+#### Decision (D1)
+
+NetBox backend is transparent to Tenant Users. Tenant allocates/deallocates hosts via standard BareMetalInstance API. Cloud Infrastructure Admin configures the backend and prerequisites; OSAC handles allocation internally.
+
+---
+
+### R1.Q2: Deployment and Configuration
+
+Should the NetBox backend be compiled into the operator (in-tree) or deployed as a separate service (out-of-tree)? And how should Cloud Infrastructure Admin configure it?
+
+#### Answer
+
+In-tree backend compiled into the operator. Configuration via Helm values processed by the Enclave Wizard pipeline.
+
+#### Impact
+
+NetBox backend is a standard `inventory.Client` implementation self-registered in the operator binary. No separate sidecar or gRPC service. Configuration follows the standard Helm/Enclave pattern for infrastructure admin setup.
+
+#### Decision (D2)
+
+In-tree backend compiled into the operator. Cloud Infrastructure Admin configures NetBox backend via Helm values (osac-installer), processed through Enclave Wizard pipeline. Structured for future OSAC-3806 out-of-tree extraction.
+
+---
+
+### R1.Q3: Allocation Tracking
+
+When a host is allocated to a BareMetalInstance, how does OSAC track that allocation so the same host isn't offered to another tenant request?
+
+#### Answer
+
+OSAC records an assignment identifier in NetBox when a host is allocated, and clears it when the host is deallocated. This prevents double-allocation. The mechanism (status field, custom field, metadata, etc.) is a design-time decision based on Telefónica's NetBox schema.
+
+#### Impact
+
+Tenants can safely request hosts; OSAC guarantees no two instances claim the same hardware. The tracking mechanism is transparent to users — it's an internal concern of how OSAC manages NetBox state.
+
+#### Decision (D3)
+
+OSAC tracks host allocation state in NetBox using a native NetBox field (e.g., device status, tag, or existing metadata field). If a native field is insufficient, the design phase will define a custom field tailored to the deployment's requirements.
+
+---
+
+### R1.Q4: OS Provisioning Scope
+
+Is NetBox responsible for OS provisioning, or is that orthogonal?
+
+#### Answer
+
+Orthogonal. NetBox is inventory only. OS provisioning, BMH readiness, and power management are handled by existing Metal3/BMH integration.
+
+#### Impact
+
+NetBox provides host discovery and allocation only. All other BMaaS concerns (image selection, OS setup, power control) are independent and reuse existing patterns.
+
+#### Decision (D4)
+
+NetBox is inventory-only backend. OS provisioning, BMH readiness, and power management are orthogonal to this feature and handled by existing Metal3/BMH integration.
+
+---
+
+## Summary
+
+Four locked decisions:
+- **D1:** Transparent NetBox backend; tenants use standard API.
+- **D2:** In-tree backend, Helm + Enclave Wizard config.
+- **D3:** Reuse NetBox native status field for state.
+- **D4:** NetBox inventory-only; OS provisioning orthogonal.
+
+No remaining gaps blocking design phase.

--- a/enhancements/OSAC-4346-netbox-inventory/clarifications.md
+++ b/enhancements/OSAC-4346-netbox-inventory/clarifications.md
@@ -50,7 +50,7 @@ When a host is allocated to a BareMetalInstance, how does OSAC track that alloca
 
 #### Answer
 
-OSAC records an assignment identifier in NetBox when a host is allocated, and clears it when the host is deallocated. This prevents double-allocation. The mechanism (status field, custom field, metadata, etc.) is a design-time decision based on Telefónica's NetBox schema.
+OSAC records an assignment identifier in NetBox when a host is allocated, and clears it when the host is deallocated. This prevents double-allocation. The mechanism (status field, custom field, metadata, etc.) is a design-time decision based on the deployment's NetBox schema.
 
 #### Impact
 

--- a/enhancements/OSAC-4346-netbox-inventory/prd.md
+++ b/enhancements/OSAC-4346-netbox-inventory/prd.md
@@ -12,22 +12,25 @@ A sovereign-cloud operator runs NetBox as their authoritative source of truth fo
 
 ## In Scope
 
-- BareMetalInstance provisioning and deprovisioning completes end-to-end against NetBox inventory, with clear status visibility at each stage.
-- NetBox backend is selectable via operator configuration.
+- Cloud Infrastructure Admin can configure NetBox as the inventory backend (endpoint URL, credential Secret reference, optional CA certificate) so the system discovers and provisions available hosts without requiring changes to tenant-facing workflows.
+- Configuration failures or unreachable backends result in clear error messages visible to Cloud Infrastructure Admin.
+- Invalid credentials result in clear error messages without exposing the credential value.
 - NetBox authentication uses API token stored in Vault via the OSAC Secret Resource.
 - TLS certificates are validated for secure endpoints; self-signed certificates are supported via optional CA certificate configuration.
-- Cloud Infrastructure Admin configures: NetBox endpoint URL, credential Secret reference, and optional CA certificate path.
+- BareMetalInstance provisioning and deprovisioning completes end-to-end against NetBox inventory, with accurate status messages at each stage.
+- When host preparation fails, the host is released back to NetBox's available pool.
 - Tenant Users can request bare-metal hosts by label selector and OSAC transparently allocates them from NetBox without exposing NetBox details to the user.
-- Cloud Infrastructure Admins can configure NetBox as the inventory backend so that the system discovers available hosts and provisions them without requiring changes to tenant-facing workflows.
-- Lifecycle states (provisioning, ready, deprovisioning, deleted) accurately reflect the actual state at each stage.
-- E2E tests validate the full BareMetalInstance lifecycle with NetBox as the inventory source.
+- Host assignment is safe for parallel requests — only one BareMetalInstance can claim each host.
+- Tenant Users see "No hosts available" rather than backend-specific errors.
+- No tenant-identifying data appears in NetBox; only the assignment identifier is recorded.
+- NetBox is transparent to tenants in normal operation — allocation/deallocation workflows are identical to other backends.
 - Power management and host readiness are handled independently of inventory selection.
 
 ## Out of Scope
 
 - **OS provisioning and image selection** — NetBox supplies hardware inventory only. OSAC's existing OS provisioning pipeline is orthogonal to this integration.
 - **NetBox device management** — adding, removing, or editing devices in NetBox is not an OSAC responsibility. The operator manages their NetBox inventory independently.
-- **OSAC UI backend selection** — displaying backend selection in the UI console is tracked separately. (Admin configuration via Helm values and Enclave Wizard pipeline is in-scope.)
+- **OSAC UI backend selection** — displaying backend selection in the UI console is tracked separately. (Admin configuration of the inventory backend is in-scope.)
 - **Multi-backend deployments in a single cluster** — each deployment uses one inventory backend.
 - **Status reporting back to NetBox** — OSAC does not write provisioning status or lifecycle events back to NetBox. Only the assignment identifier is recorded.
 - **Health checks on assigned nodes** — OSAC does not periodically verify that assigned nodes still exist in NetBox. If a node is removed from NetBox while assigned, OSAC does not immediately detect the failure.
@@ -61,7 +64,7 @@ A sovereign-cloud operator runs NetBox as their authoritative source of truth fo
 - Each deployment uses a single inventory backend.
 - The operator has populated NetBox hosts with labels or attributes sufficient to distinguish host pools for allocation.
 - NetBox API is reachable from the OSAC control plane.
-- The assignment identifier will be stored in a NetBox native field (e.g., device status, tag, or existing metadata field). If a native field is insufficient, a custom field will be defined during design based on available customization capabilities.
+- OSAC tracks host assignments in NetBox to prevent double-allocation. The specific storage mechanism (native field, custom field, tag, etc.) is a design-time decision.
 
 ## Dependencies
 
@@ -69,25 +72,3 @@ A sovereign-cloud operator runs NetBox as their authoritative source of truth fo
 - **Host readiness and power management** — independent of inventory selection; existing platform mechanisms are used.
 - **Label-selector contract** — consistent across all inventory backends so tenant requests work the same way regardless of the backend in use.
 - **BareMetalInstance API** — tenant-facing API remains unchanged; NetBox integration is transparent to users.
-
-## Acceptance Criteria
-
-- [ ] A Cloud Infrastructure Admin can configure NetBox as the inventory backend (URL, Vault Secret reference, optional CA certificate) and the system connects successfully.
-- [ ] The system validates TLS certificates for secure endpoints and rejects invalid certificates unless a CA certificate is provided.
-- [ ] Invalid NetBox credentials result in a clear error message without exposing the credential value.
-- [ ] A Tenant User can provision a BareMetalInstance and the system selects an available host from NetBox inventory matching the requested labels.
-- [ ] During host preparation, the BareMetalInstance status shows a clear message indicating the host is being readied.
-- [ ] When host preparation fails, the host is released back to NetBox's available pool.
-- [ ] A provisioned BareMetalInstance transitions through provisioning, ready, deprovisioning, and deleted states with accurate status messages.
-- [ ] When a BareMetalInstance is deleted, the host is released back to NetBox's available pool for reuse.
-- [ ] Host assignment is safe for parallel requests — only one BareMetalInstance can claim each host.
-- [ ] When NetBox is unreachable, the BareMetalInstance status shows a clear error message (visible to Cloud Infrastructure Admin).
-- [ ] Tenant Users see "No hosts available" rather than backend-specific errors — NetBox implementation details are not exposed to tenants.
-- [ ] No tenant-identifying data appears in NetBox — only the assignment identifier is stored.
-- [ ] NetBox is transparent to tenants in normal operation — allocation/deallocation workflows are identical to other backends.
-- [ ] E2E tests covering the full BareMetalInstance lifecycle with NetBox pass in CI.
-
-## Non-Functional Requirements
-
-- **Inventory independence:** Networking and storage are independent of the inventory backend. The existing OSAC infrastructure stack handles all platform operations.
-- **Documentation:** Documentation describes how to configure OSAC to use the NetBox backend, including any required prerequisites.

--- a/enhancements/OSAC-4346-netbox-inventory/prd.md
+++ b/enhancements/OSAC-4346-netbox-inventory/prd.md
@@ -1,0 +1,93 @@
+# NetBox Inventory Backend for Bare Metal as a Service
+
+| Field       | Value   |
+|-------------|---------|
+| Author(s)   | Menny Aboush |
+| Jira        | https://redhat.atlassian.net/browse/OSAC-4346 |
+| Date        | 2026-09-06 |
+
+## Problem Statement
+
+A sovereign-cloud operator runs NetBox as their authoritative source of truth for physical infrastructure — devices, their capabilities, power management addresses, and availability. Today, OSAC cannot allocate bare-metal hosts directly from that NetBox inventory, forcing the operator to maintain a separate inventory system as a second source of truth. This creates data inconsistency, operational burden during host lifecycle changes (adding, decommissioning, updating capability metadata), and risk of misalignment between the operator's primary system and OSAC's view.
+
+## In Scope
+
+- BareMetalInstance provisioning and deprovisioning completes end-to-end against NetBox inventory, with clear status visibility at each stage.
+- NetBox backend is selectable via operator configuration.
+- NetBox authentication uses API token stored in Vault via the OSAC Secret Resource.
+- TLS certificates are validated for secure endpoints; self-signed certificates are supported via optional CA certificate configuration.
+- Cloud Infrastructure Admin configures: NetBox endpoint URL, credential Secret reference, and optional CA certificate path.
+- Tenant Users can request bare-metal hosts by label selector and OSAC transparently allocates them from NetBox without exposing NetBox details to the user.
+- Cloud Infrastructure Admins can configure NetBox as the inventory backend so that the system discovers available hosts and provisions them without requiring changes to tenant-facing workflows.
+- Lifecycle states (provisioning, ready, deprovisioning, deleted) accurately reflect the actual state at each stage.
+- E2E tests validate the full BareMetalInstance lifecycle with NetBox as the inventory source.
+- Power management and host readiness are handled independently of inventory selection.
+
+## Out of Scope
+
+- **OS provisioning and image selection** — NetBox supplies hardware inventory only. OSAC's existing OS provisioning pipeline is orthogonal to this integration.
+- **NetBox device management** — adding, removing, or editing devices in NetBox is not an OSAC responsibility. The operator manages their NetBox inventory independently.
+- **OSAC UI backend selection** — displaying backend selection in the UI console is tracked separately. (Admin configuration via Helm values and Enclave Wizard pipeline is in-scope.)
+- **Multi-backend deployments in a single cluster** — each deployment uses one inventory backend.
+- **Status reporting back to NetBox** — OSAC does not write provisioning status or lifecycle events back to NetBox. Only the assignment identifier is recorded.
+- **Health checks on assigned nodes** — OSAC does not periodically verify that assigned nodes still exist in NetBox. If a node is removed from NetBox while assigned, OSAC does not immediately detect the failure.
+- **Admin host-listing / inventory visibility in the OSAC API** — surfacing which hosts are available/claimed across backends is addressed separately.
+
+## User Stories
+
+### Cloud Infrastructure Admin
+
+- As a Cloud Infrastructure Admin, I want to configure NetBox as the inventory backend so that OSAC discovers and provisions bare metal hosts from my NetBox infrastructure.
+
+- As a Cloud Infrastructure Admin, I want bare metal hosts to be selected according to the capability labels I have defined in my infrastructure so that tenant requests are matched to appropriate hosts.
+
+- As a Cloud Infrastructure Admin, I want clear error messages when the inventory backend is unreachable so that I can diagnose connectivity issues without inspecting internal logs.
+
+### Cloud Provider Admin
+
+- As a Cloud Provider Admin, I want BareMetalInstance requests to be fulfilled without exposing the inventory backend to other users so that the backend is an infrastructure concern, not a user concern.
+
+### Tenant Admin / Tenant User
+
+- As a Tenant User, I want to request a bare-metal host by specifying required capabilities and have OSAC allocate it transparently.
+
+- As a Tenant User, I want BareMetalInstance lifecycle states to accurately reflect provisioning progress so that I can monitor host preparation.
+
+- As a Tenant User, I want to deallocate a bare-metal host so it becomes available for future allocations.
+
+## Assumptions
+
+- Cloud Infrastructure Admins pre-register bare metal hosts in NetBox before OSAC operates against them (Day-0 prerequisite).
+- Each deployment uses a single inventory backend.
+- The operator has populated NetBox hosts with labels or attributes sufficient to distinguish host pools for allocation.
+- NetBox API is reachable from the OSAC control plane.
+- The assignment identifier will be stored in a NetBox native field (e.g., device status, tag, or existing metadata field). If a native field is insufficient, a custom field will be defined during design based on available customization capabilities.
+
+## Dependencies
+
+- **Pluggable inventory backend system (OSAC-1032)** — the platform's ability to select different inventory backends (NetBox, OpenStack, Metal3, etc.) at deployment time.
+- **Host readiness and power management** — independent of inventory selection; existing platform mechanisms are used.
+- **Label-selector contract** — consistent across all inventory backends so tenant requests work the same way regardless of the backend in use.
+- **BareMetalInstance API** — tenant-facing API remains unchanged; NetBox integration is transparent to users.
+
+## Acceptance Criteria
+
+- [ ] A Cloud Infrastructure Admin can configure NetBox as the inventory backend (URL, Vault Secret reference, optional CA certificate) and the system connects successfully.
+- [ ] The system validates TLS certificates for secure endpoints and rejects invalid certificates unless a CA certificate is provided.
+- [ ] Invalid NetBox credentials result in a clear error message without exposing the credential value.
+- [ ] A Tenant User can provision a BareMetalInstance and the system selects an available host from NetBox inventory matching the requested labels.
+- [ ] During host preparation, the BareMetalInstance status shows a clear message indicating the host is being readied.
+- [ ] When host preparation fails, the host is released back to NetBox's available pool.
+- [ ] A provisioned BareMetalInstance transitions through provisioning, ready, deprovisioning, and deleted states with accurate status messages.
+- [ ] When a BareMetalInstance is deleted, the host is released back to NetBox's available pool for reuse.
+- [ ] Host assignment is safe for parallel requests — only one BareMetalInstance can claim each host.
+- [ ] When NetBox is unreachable, the BareMetalInstance status shows a clear error message (visible to Cloud Infrastructure Admin).
+- [ ] Tenant Users see "No hosts available" rather than backend-specific errors — NetBox implementation details are not exposed to tenants.
+- [ ] No tenant-identifying data appears in NetBox — only the assignment identifier is stored.
+- [ ] NetBox is transparent to tenants in normal operation — allocation/deallocation workflows are identical to other backends.
+- [ ] E2E tests covering the full BareMetalInstance lifecycle with NetBox pass in CI.
+
+## Non-Functional Requirements
+
+- **Inventory independence:** Networking and storage are independent of the inventory backend. The existing OSAC infrastructure stack handles all platform operations.
+- **Documentation:** Documentation describes how to configure OSAC to use the NetBox backend, including any required prerequisites.

--- a/enhancements/OSAC-4346-netbox-inventory/prd.md
+++ b/enhancements/OSAC-4346-netbox-inventory/prd.md
@@ -15,7 +15,7 @@ A sovereign-cloud operator runs NetBox as their authoritative source of truth fo
 - Cloud Infrastructure Admin can configure NetBox as the inventory backend (endpoint URL, credential Secret reference, optional CA certificate) so the system discovers and provisions available hosts without requiring changes to tenant-facing workflows.
 - Configuration failures or unreachable backends result in clear error messages visible to Cloud Infrastructure Admin.
 - Invalid credentials result in clear error messages without exposing the credential value.
-- NetBox authentication uses API token stored in Vault via the OSAC Secret Resource.
+- NetBox authentication uses API token stored as a Secret resource for secure credential management.
 - TLS certificates are validated for secure endpoints; self-signed certificates are supported via optional CA certificate configuration.
 - BareMetalInstance provisioning and deprovisioning completes end-to-end against NetBox inventory, with accurate status messages at each stage.
 - When host preparation fails, the host is released back to NetBox's available pool.


### PR DESCRIPTION
## PRD: NetBox Inventory Backend for Bare Metal as a Service

**Jira:** https://redhat.atlassian.net/browse/OSAC-4346
**Feature:** https://redhat.atlassian.net/browse/OSAC-1610

### Summary
This PRD introduces NetBox as a configurable inventory backend for OSAC's bare-metal-fulfillment-operator. Cloud Infrastructure Admins can configure NetBox as a source of truth for host discovery and allocation, enabling tenants to provision bare-metal instances transparently from their existing NetBox infrastructure without maintaining a separate inventory system.

### Requesting Review On
- Requirements completeness and accuracy
- Scope boundaries (what's in vs. out)
- Acceptance criteria clarity and testability
- User story grounding and persona alignment

See `clarifications.md` for the requirements clarification Q&A (5 locked decisions, D1–D5).

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Areas affected

- **Documentation:** Adds the NetBox inventory PRD and five locked clarification decisions.
- **Deployment documentation:** Defines Helm values and Enclave Wizard configuration for a future NetBox backend.
- **Tests:** Specifies end-to-end lifecycle test coverage, but adds no tests.
- **API surface, controllers, database, authentication, and CI:** No implementation changes.
- **Backward compatibility:** No runtime impact. The proposed design preserves the tenant-facing `BareMetalInstance` API and keeps NetBox transparent to tenants.

## Risk classification

**risk:show** applies because the PR changes requirements and design documentation only. It does not change runtime behavior, APIs, data, authentication, deployment, or tests. It is not **risk:ship** because no feature is implemented. It is not **risk:ask** because the scope, acceptance criteria, and five design decisions are documented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->