### PR TITLE
OSAC-3959: Log resolved skills revisions

### DIFF
--- a/.github/scripts/test_skill_source_traceability_ep.py
+++ b/.github/scripts/test_skill_source_traceability_ep.py
@@ -16,7 +16,7 @@ WORKFLOWS = {
 
 
 class SkillSourceTraceabilityTests(unittest.TestCase):
-    def test_workflows_log_the_resolved_skills_commit(self):
+    def test_workflows_validate_then_log_the_resolved_skills_commit(self):
         for workflow_name, (workflow_path, checkout_path) in WORKFLOWS.items():
             with self.subTest(workflow=workflow_name):
                 content = (REPO_ROOT / workflow_path).read_text()
@@ -26,14 +26,19 @@ class SkillSourceTraceabilityTests(unittest.TestCase):
                     content,
                 )
                 self.assertIn(
-                    f'git -C {checkout_path} rev-parse --verify "HEAD^{{commit}}"',
+                    f'''skills_sha="$(git -C {checkout_path} rev-parse --verify "HEAD^{{commit}}")"
+          if ! [[ "$skills_sha" =~ ^[0-9a-f]{{40}}$ ]]; then
+            echo "::error::osac-ai-skills resolved to an invalid commit SHA: $skills_sha"
+            exit 1
+          fi
+          echo "Resolved osac-ai-skills commit: ${{skills_sha}}"
+          {{
+            echo "### OSAC AI skills"
+            echo
+            echo "Resolved osac-ai-skills commit: ${{skills_sha}}"
+          }} >> "$GITHUB_STEP_SUMMARY"''',
                     content,
                 )
-                self.assertIn("^[0-9a-f]{40}$", content)
-                self.assertIn(
-                    'Resolved osac-ai-skills commit: ${skills_sha}', content
-                )
-                self.assertIn("$GITHUB_STEP_SUMMARY", content)
 
     def test_ep_review_keeps_required_skill_validation(self):
         content = (REPO_ROOT / ".github/workflows/ep-review.yml").read_text()

--- a/.github/scripts/test_skill_source_traceability_ep.py
+++ b/.github/scripts/test_skill_source_traceability_ep.py
@@ -1,0 +1,46 @@
+"""Regression coverage for EP skill-source traceability."""
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS_REPOSITORY = "https://github.com/osac-project/osac-ai-skills"
+WORKFLOWS = {
+    "EP Review": (".github/workflows/ep-review.yml", "/opt/skills"),
+    "Test Plan Review": (
+        ".github/workflows/test-plan-review.yml",
+        "/opt/test-plan-skills",
+    ),
+}
+
+
+class SkillSourceTraceabilityTests(unittest.TestCase):
+    def test_workflows_log_the_resolved_skills_commit(self):
+        for workflow_name, (workflow_path, checkout_path) in WORKFLOWS.items():
+            with self.subTest(workflow=workflow_name):
+                content = (REPO_ROOT / workflow_path).read_text()
+
+                self.assertIn(
+                    f"git clone --depth 1 {SKILLS_REPOSITORY} {checkout_path}",
+                    content,
+                )
+                self.assertIn(
+                    f'git -C {checkout_path} rev-parse --verify "HEAD^{{commit}}"',
+                    content,
+                )
+                self.assertIn("^[0-9a-f]{40}$", content)
+                self.assertIn(
+                    'Resolved osac-ai-skills commit: ${skills_sha}', content
+                )
+                self.assertIn("$GITHUB_STEP_SUMMARY", content)
+
+    def test_ep_review_keeps_required_skill_validation(self):
+        content = (REPO_ROOT / ".github/workflows/ep-review.yml").read_text()
+
+        self.assertIn("for s in prd-review design-review; do", content)
+        self.assertIn('"/opt/skills/skills/$s/SKILL.md"', content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ep-review.yml
+++ b/.github/workflows/ep-review.yml
@@ -100,7 +100,19 @@ jobs:
 
       - name: Clone skills
         run: |
+          set -euo pipefail
           git clone --depth 1 https://github.com/osac-project/osac-ai-skills /opt/skills
+          skills_sha="$(git -C /opt/skills rev-parse --verify "HEAD^{commit}")"
+          if ! [[ "$skills_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::osac-ai-skills resolved to an invalid commit SHA: $skills_sha"
+            exit 1
+          fi
+          echo "Resolved osac-ai-skills commit: ${skills_sha}"
+          {
+            echo "### OSAC AI skills"
+            echo
+            echo "Resolved osac-ai-skills commit: ${skills_sha}"
+          } >> "$GITHUB_STEP_SUMMARY"
           for s in prd-review design-review; do
             if [[ ! -f "/opt/skills/skills/$s/SKILL.md" ]]; then
               echo "::error::skills/$s/SKILL.md missing from osac-ai-skills"

--- a/.github/workflows/test-plan-review.yml
+++ b/.github/workflows/test-plan-review.yml
@@ -114,7 +114,20 @@ jobs:
         run: pip install -r .github/scripts/requirements.txt
 
       - name: Clone test plan skills
-        run: git clone --depth 1 https://github.com/osac-project/osac-ai-skills /opt/test-plan-skills
+        run: |
+          set -euo pipefail
+          git clone --depth 1 https://github.com/osac-project/osac-ai-skills /opt/test-plan-skills
+          skills_sha="$(git -C /opt/test-plan-skills rev-parse --verify "HEAD^{commit}")"
+          if ! [[ "$skills_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::osac-ai-skills resolved to an invalid commit SHA: $skills_sha"
+            exit 1
+          fi
+          echo "Resolved osac-ai-skills commit: ${skills_sha}"
+          {
+            echo "### OSAC AI skills"
+            echo
+            echo "Resolved osac-ai-skills commit: ${skills_sha}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up GCP credentials
         run: |


### PR DESCRIPTION
## [OSAC-3959](https://redhat.atlassian.net/browse/OSAC-3959): Log resolved skills revisions

**Jira:** https://redhat.atlassian.net/browse/OSAC-3959
**Story type:** Task

### Summary

This change retains the existing floating `osac-ai-skills` checkout used by the enhancement-proposal review workflows. Each run now records the exact resolved commit SHA in its job log and workflow summary, providing audit traceability without the maintenance cost of consumer-side pins.

### Changes

- Add SHA resolution, validation, job-log output, and run-summary output to EP Review.
- Add the same traceability behavior to Test Plan Review.
- Add CI-discovered regression coverage for both workflow contracts.

### Testing

- **Unit tests:** `python3 -m unittest discover -s .github/scripts -p 'test_*ep*.py' -v` (208 passed; 2 existing skips).
- **Integration tests:** N/A — the change retains the existing real workflow clone and adds deterministic reporting after it.
- **Coverage:** Both active workflow consumers, SHA validation, log/summary output, and EP Review's existing required-skill guard are covered.

### Acceptance Criteria

- [x] Each automated workflow that fetches `osac-ai-skills` records the full resolved commit SHA in its job log and workflow summary.
- [ ] After merge, update [OSAC-3959](https://redhat.atlassian.net/browse/OSAC-3959) to replace the superseded ADR/pinned-copy criteria, then close the task after confirming CI.

### Notes

`actionlint` reports four existing `SC2129` style warnings in unchanged command blocks; the same warnings reproduce on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **CI:** EP Review and Test Plan Review now validate the resolved 40-character `osac-ai-skills` commit SHA and record it in logs and `GITHUB_STEP_SUMMARY`.
- **Tests:** Regression tests cover SHA validation, failure handling, commit logging, workflow summaries, and EP Review required-skill validation.
- **Other areas:** No API, controller, database, authentication, deployment, or documentation changes.
- **Validation:** 208 tests pass with 2 existing skips. Four pre-existing `actionlint` `SC2129` warnings remain.
- **Follow-up:** [OSAC-3959](https://redhat.atlassian.net/browse/OSAC-3959) requires an update after merge and CI confirmation. The issue has no target version; `5.1.0` is expected for `main`.

## Compatibility

No backward-compatibility impact is expected. Invalid skill-source resolution now fails the affected workflow.

## Risk classification

**risk:show** — The change affects observable CI behavior and workflow summaries, but does not modify production runtime code, APIs, data, authentication, or deployment behavior.

It does not qualify as **risk:ship** because it does not change production functionality. It does not qualify as **risk:ask** because the behavior has explicit validation and regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->