### PR TITLE
OSAC-4542: address review follow-ups on Volume Get/List PRD

### DIFF
--- a/enhancements/OSAC-4542-volume-get-list/prd.md
+++ b/enhancements/OSAC-4542-volume-get-list/prd.md
@@ -5,6 +5,7 @@
 | Author(s)   | Zoltan Szabo |
 | Jira        | [OSAC-4542](https://redhat.atlassian.net/browse/OSAC-4542) |
 | Date        | 2026-08-27 |
+| Target Release | 0.3 |
 
 ## Problem Statement
 
@@ -16,9 +17,9 @@ The OSAC storage control plane (OSAC-2872) already provisions standalone storage
 
 - **Retrieve a volume's details.** A user can fetch a single volume and see its tenant-meaningful attributes — name, tier, size, access mode, and current state — so they can confirm its configuration and availability.
 - **List volumes.** A user can list the volumes they are entitled to see, consistent with the standard OSAC list contract, so the console and CLI can present and navigate storage inventory.
-- **Tenant-scoped visibility.** Each caller sees only the volumes in the tenants they are entitled to: a Cloud Provider Admin across their assigned tenants, and tenant members within their own tenant — the same visibility model used by every other OSAC resource.
+- **Tenant- and project-scoped visibility.** Each caller sees only the volumes they are entitled to under OSAC's standard tenant- and project-based visibility: a Cloud Provider Admin across all tenants, and tenant members within the tenants and projects visible to them — the same visibility model used by every other OSAC resource.
 - **Read-only, tenant-meaningful representation.** The public view exposes only information that is meaningful to tenants; internal placement and routing details used to serve a volume — the serving backend, its storage protocol, the hub that hosts it, and the vendor-assigned volume identifier — are never shown. Volumes are read-only through this API.
-- **Stable public identifier.** Each volume has an immutable, tenant-unique `id` that `List` returns and `Get` accepts; `name` is a display attribute and is not the request key. Console deep-links and Get requests use `id`, so they remain stable even if a volume is renamed and are unambiguous when names repeat.
+- **Stable public identifier.** Each volume has an immutable, system-generated `id` that `List` returns and `Get` accepts as the request key. `name` is a separate, immutable attribute that is unique within the volume's tenant/project scope (a valid RFC 1123 label), and `display_name` is an optional human-friendly label; neither is the request key. Console deep-links and `Get` requests use `id`.
 - **Same access channels as other resources.** Volumes are reachable over the same public gRPC and REST endpoints, console, and CLI as other OSAC resources; no storage-specific access path is introduced. CLI support (`osac get volumes`, `osac get volume <id>`) comes for free from the existing `get_cmd.go` / `list_cmd.go` patterns and requires no separate tracking.
 - **Test and documentation.** Tests cover retrieving and listing standalone volumes through the public API, including tenant-scoped isolation; API documentation and the published API spec are updated with the new read endpoints.
 
@@ -26,9 +27,10 @@ The OSAC storage control plane (OSAC-2872) already provisions standalone storage
 
 Deferred to later work (this release is read-only Get/List only):
 
-- **Volume lifecycle through the public API** — creating, updating, resizing, or deleting volumes. These remain on the internal API and are tracked under later OSAC-984 phases.
-- **Volume attach / detach** — managed via VMaaS / Compute work.
-- **Snapshots, clones, and restore.**
+- **Volume lifecycle through the public API** — creating, updating, and deleting volumes. These remain on the internal API and are tracked under [OSAC-984](https://redhat.atlassian.net/browse/OSAC-984).
+- **Volume expansion, snapshots, clones, and restore** — tracked under [OSAC-48](https://redhat.atlassian.net/browse/OSAC-48).
+- **Volume attach / detach** — tracked under [OSAC-4884](https://redhat.atlassian.net/browse/OSAC-4884).
+- **Volume identifiability / provenance** — distinguishing what each volume represents (e.g. a VM filesystem disk vs. a workload PV) and which tenant cluster it belongs to. Deferred to [OSAC-4793](https://redhat.atlassian.net/browse/OSAC-4793) under the OSAC-2871 Storage Volumes outcome.
 - **File storage** (NFS/SMB — OSAC-4515) and **object storage** (S3).
 
 ## User Stories
@@ -49,7 +51,7 @@ Deferred to later work (this release is read-only Get/List only):
 ## Assumptions
 
 - The volumes to be read already exist and are inventoried by the storage control plane (OSAC-2872); this feature adds a read surface, not a new source of data.
-- Tenant-level visibility is the correct and consistent default for this release, matching how every other OSAC resource scopes reads.
+- Tenant- and project-scoped visibility is the correct and consistent default for this release, matching how every other OSAC resource scopes reads.
 - The public representation of a volume is a subset of the internal one; fields that are not meaningful to tenants are omitted rather than reshaped.
 
 ## Dependencies
@@ -62,15 +64,15 @@ Deferred to later work (this release is read-only Get/List only):
 `List` inherits the standard OSAC list contract (CEL filtering via `this.<field>`, `offset`/`limit` pagination, SQL-like ordering with implicit secondary sort on `id asc`). The following volume-specific criteria apply:
 
 - **Identifier.** `List` items and `Get` both key on the immutable `id`; a `Get` by the `id` of a visible volume returns it, and a `Get` by an id outside the caller's tenants returns `not found` (indistinguishable from a non-existent id, so existence is not leaked across tenants).
-- **Inventory states.** `List` and `Get` return volumes in every state tracked by OSAC-2872 (`creating`, `available`, `deleting`, `deleted`) as long as the volume remains in inventory; there is no implicit state filter — callers filter by `status.state` if they want a subset.
+- **Inventory states.** `List` and `Get` return volumes in every non-archived state tracked by OSAC-2872 (`creating`, `available`, `deleting`). Once a volume is fully deprovisioned its record is archived (`deleted`) and no longer appears through `List`/`Get`. There is no other implicit state filter — callers filter by `status.state` for a subset.
 - **Isolation.** A caller never receives a volume outside their entitled tenants through either `List` or `Get`, and this is covered by an automated tenant-isolation test.
 
 ---
 
 ## Provenance
 
-Committed: commit @ prd 0.9.0 - f7f8c6d, workspace main @ b177ce9 (dirty)
+Committed: commit @ prd 0.9.0 - 562b610, workspace prd/OSAC-4542-review-followups @ 04971f4
 
 > Authoring phases not recorded this session (commit-time snapshot only).
 
-<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.9.0","ai_workflows":"f7f8c6d","source_repo":"b177ce9 (dirty)","source_repo_branch":"main","commits_behind_main":0,"commits_ahead_main":0,"main_ref":"main","phases":["commit"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->
+<!-- ai-workflow-provenance:{"schema_version":1,"provenance_kind":"commit_only","workflow":"prd","workflow_version":"0.9.0","ai_workflows":"562b610","source_repo":"04971f4","source_repo_branch":"prd/OSAC-4542-review-followups","commits_behind_main":0,"commits_ahead_main":1,"main_ref":"main","phases":["commit"],"authoring_modes":["skill"],"context_changed":false,"origin_untracked":false} -->


### PR DESCRIPTION
## [OSAC-4542](https://redhat.atlassian.net/browse/OSAC-4542) — Volume Get/List PRD: review follow-ups

Follow-up to the merged PRD (#236) addressing the review comments that were
still open at merge time. Documentation-only — no code, test, or design
changes (behavior was verified against the implementation).

### Changes
- **id vs name.** `id` is the immutable, system-generated request key for
  Get/List; `name` is immutable and unique within tenant/project scope.
  Removed the rename / repeated-name wording.
- **Visibility.** Reworded to tenant- **and project**-scoped, and corrected
  the Cloud Provider Admin to "all tenants".
- **Returned states.** Dropped `deleted` from the states returned by
  List/Get — fully deprovisioned volumes are archived out of the main
  inventory and no longer appear.
- **Feature references.** [OSAC-984](https://redhat.atlassian.net/browse/OSAC-984) (create/update/delete), [OSAC-48](https://redhat.atlassian.net/browse/OSAC-48)
  (expansion/snapshots), [OSAC-4884](https://redhat.atlassian.net/browse/OSAC-4884) (attach/detach).
- **Out of scope.** Re-added "volume identifiability / provenance"
  (deferred to [OSAC-4793](https://redhat.atlassian.net/browse/OSAC-4793)), which was missing from the merged doc.
- **Metadata.** Added Target Release = 0.3.

Assisted-by: Chai Bot <chai-bot@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Documentation/API surface:** Updated the Volume Get/List PRD with stable `id` semantics, immutable `name` rules, tenant/project visibility, non-archived states, and target release 0.3.
- **Authorization:** Defined tenant- and project-level isolation for `List` and `Get`, including cross-tenant `not found` behavior.
- **Scope:** Added related feature references. Deferred lifecycle, expansion, snapshot, clone, restore, attach, detach, and provenance work.
- **Tests:** Added tenant- and project-isolation requirements to the acceptance criteria. No test implementation changed.
- **CI:** Confirmed [OSAC-4542](https://redhat.atlassian.net/browse/OSAC-4542) is valid. Jira has no target version, while the target branch expects 5.1.0.
- **Other areas:** No controller, database, deployment, or runtime implementation changes.

## Backward compatibility

This PR changes documentation only. It does not change runtime behavior. Future implementations must follow the clarified visibility, identifier, naming, and archived-volume rules.

## Risk classification

**risk:ship** — documentation-only changes with no runtime, deployment, data, or security impact. It was not close to `risk:show` because it does not change production behavior, and it does not meet `risk:ask` criteria because it introduces no implementation, migration, or operational risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->