### PR TITLE
NO-ISSUE: Clarify planning-workflow entry point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,19 +5,18 @@
 This repository contains design documents (enhancement proposals) for the OSAC project. It is a documentation-only repository with no build dependencies.
 
 **Do not create PRDs or design documents directly in this repo.** Use the PRD
-and design workflows from a bootstrapped OSAC source checkout instead. Start
-the agent from that checkout's `osac/` root (where `skills/prd` and
-`skills/design` are installed), not from this documentation repository.
+and design workflows from a bootstrapped checkout of `osac-project/osac`
+instead. Start the agent from that repository's root—the directory containing
+`tools/bootstrap.sh` and `skills/`—not from this documentation repository.
 
 - **PRD workflow**: `/prd:ingest` → `/prd:clarify` → `/prd:draft` → `/prd:publish`
 - **Design workflow**: `/design:ingest` → `/design:draft` → `/design:publish`
 
-Run `tools/bootstrap.sh` in the OSAC source checkout if the workflows are not
+Run `tools/bootstrap.sh` in that OSAC checkout if the workflows are not
 installed. These workflows handle template selection, feature dimensions
-context, section guidance, provenance, and publishing; `/publish` writes the
-resulting documents to this `enhancement-proposals` checkout. The workflow's
-publish command writes there. See that OSAC
-checkout's `AGENTS.md` for the full instructions.
+context, section guidance, provenance, and publishing; the relevant publish
+command writes the resulting documents to this `enhancement-proposals`
+checkout. See the OSAC repository's `AGENTS.md` for the full instructions.
 
 ## Enhancement Proposals
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,19 @@
 
 This repository contains design documents (enhancement proposals) for the OSAC project. It is a documentation-only repository with no build dependencies.
 
-**Do not create PRDs or design documents directly in this repo.** Use the osac-workspace AI workflows instead:
+**Do not create PRDs or design documents directly in this repo.** Use the PRD
+and design workflows from a bootstrapped OSAC source checkout instead. Start
+the agent from that checkout's `osac/` root (where `skills/prd` and
+`skills/design` are installed), not from this documentation repository.
 
 - **PRD workflow**: `/prd:ingest` → `/prd:clarify` → `/prd:draft` → `/prd:publish`
 - **Design workflow**: `/design:ingest` → `/design:draft` → `/design:publish`
 
-These workflows handle template selection, feature dimensions context, section guidance, and publishing. See `osac-workspace/AGENTS.md` for full instructions.
+Run `tools/bootstrap.sh` in the OSAC source checkout if the workflows are not
+installed. These workflows handle template selection, feature dimensions
+context, section guidance, provenance, and publishing; `/publish` writes the
+resulting documents to this `enhancement-proposals` checkout. See that OSAC
+checkout's `AGENTS.md` for the full instructions.
 
 ## Enhancement Proposals
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ the agent from that checkout's `osac/` root (where `skills/prd` and
 Run `tools/bootstrap.sh` in the OSAC source checkout if the workflows are not
 installed. These workflows handle template selection, feature dimensions
 context, section guidance, provenance, and publishing; `/publish` writes the
-resulting documents to this `enhancement-proposals` checkout. See that OSAC
+resulting documents to this `enhancement-proposals` checkout. The workflow's
+publish command writes there. See that OSAC
 checkout's `AGENTS.md` for the full instructions.
 
 ## Enhancement Proposals

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ A PRD (Product Requirements Document) defines **what** a feature delivers and
 For detailed guidance on writing PRDs, the PRD vs design EP boundary, personas,
 and good/bad examples, see [guidelines/prd_guide.md](guidelines/prd_guide.md).
 
-The recommended way to create a PRD is using the `/prd` skill in an AI-assisted
-development tool (Claude Code, Cursor, or similar):
+The recommended way to create a PRD is using the `/prd` skill from a
+bootstrapped checkout of [osac-project/osac](https://github.com/osac-project/osac)
+in an AI-assisted development tool (Claude Code, Cursor, or similar):
 
 1. Run `/prd:ingest` with your Jira ticket to gather requirements.
 2. Run `/prd:clarify` to resolve ambiguities through guided Q&A.
@@ -65,14 +66,19 @@ directory. See "How do I create an enhancement proposal?" below.
 
 OSAC uses a two-document flow: a **PRD** (Product Requirements Document) describes WHAT and WHY, and a **design document** describes HOW.
 
-### Recommended: AI-assisted workflow (osac-workspace)
+### Recommended: AI-assisted workflow
 
-The [osac-workspace](https://github.com/osac-project/osac-workspace) provides AI-assisted workflows that guide you through the process:
+The [osac-project/osac](https://github.com/osac-project/osac) repository
+provides AI-assisted workflows that guide you through the process. Run
+`tools/bootstrap.sh` there, then start the agent from that repository's root
+(the directory containing `tools/bootstrap.sh` and `skills/`), not from this
+documentation repository:
 
 1. **PRD**: Run `/prd:ingest` to start a PRD, then `/prd:clarify`, `/prd:draft`, and `/prd:publish` to create it in this repo as `enhancements/OSAC-NNNN-feature-slug/prd.md`.
 2. **Design**: Run `/design:ingest` to start the design, then `/design:draft` and `/design:publish` to create it as `enhancements/OSAC-NNNN-feature-slug/design.md`.
 
-See the osac-workspace [AGENTS.md](https://github.com/osac-project/osac-workspace/blob/main/AGENTS.md) for full workflow details.
+See the OSAC [AGENTS.md](https://github.com/osac-project/osac/blob/main/AGENTS.md)
+for full workflow details.
 
 ### Manual workflow
 


### PR DESCRIPTION
## Summary

- Direct planning-document authors to start PRD/design workflows from the bootstrapped OSAC source checkout.
- Clarify that publish writes to this enhancement-proposals checkout and carries provenance.

## Jira

N/A

## Test plan

- [x] pre-commit run --all-files
- [x] Performance, security, and complexity pre-flight reviews returned no findings

---

_This PR description was drafted with AI assistance (create-pr v0.2.0). Review for accuracy._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation

- Updated `AGENTS.md` with the `osac-project/osac` source repository and root markers.
- Clarified bootstrap execution for PRD and design workflows.
- Clarified that publishing writes documents to the `enhancement-proposals` checkout and includes provenance.
- Updated `README.md` to run `/prd` from a bootstrapped `osac-project/osac` checkout.
- Added the `AGENTS.md` reference to the AI-assisted workflow documentation.

## Compatibility

This change affects documentation only. It does not change APIs, controllers, databases, authentication, deployment, CI, or tests. It has no backward-compatibility impact.

## Risk classification

**risk:ship** — The change is limited to repository guidance and has no runtime or operational impact. It does not qualify for **risk:show** because it introduces no user-facing runtime or deployment change. It does not qualify for **risk:ask** because it introduces no security-sensitive behavior or high-risk system change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->