### PR TITLE
NO-ISSUE: Enforce planning document provenance

### DIFF
--- a/.github/scripts/check_planning_provenance.py
+++ b/.github/scripts/check_planning_provenance.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Require provenance metadata for planning documents changed by a pull request.
+
+The workflow runs this trusted base-branch copy against the pull request's
+document blobs. It deliberately validates the published machine-readable
+contract rather than session-local artifacts, which are not committed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Sequence
+
+
+# Match every PRD/design path recognized by ep-review.yml.  README.md is the
+# legacy design-document convention; filenames vary in case across the library.
+CHECKED_FILENAMES = {"prd.md": "prd", "design.md": "design", "readme.md": "design"}
+PROVENANCE_KINDS = {"session", "commit_only", "declined"}
+PROVENANCE_COMMENT_PREFIX = "<!-- ai-workflow-provenance:"
+PROVENANCE_COMMENT_SUFFIX = "-->"
+
+
+def run_git(args: Sequence[str]) -> bytes:
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True
+    ).stdout
+
+
+def changed_document_paths(diff_output: bytes) -> list[str]:
+    """Return changed planning-document paths from a NUL diff list."""
+    paths = []
+    for raw_path in diff_output.split(b"\0"):
+        if not raw_path:
+            continue
+        path = raw_path.decode("utf-8")
+        basename = path.rsplit("/", 1)[-1].casefold()
+        if path.startswith("enhancements/") and basename in CHECKED_FILENAMES:
+            paths.append(path)
+    return paths
+
+
+def provenance_payloads(content: str) -> list[str]:
+    """Extract unparsed provenance payloads without accepting malformed comments."""
+    payloads = []
+    start = 0
+    while True:
+        prefix_index = content.find(PROVENANCE_COMMENT_PREFIX, start)
+        if prefix_index == -1:
+            return payloads
+        payload_start = prefix_index + len(PROVENANCE_COMMENT_PREFIX)
+        payload_end = content.find(PROVENANCE_COMMENT_SUFFIX, payload_start)
+        if payload_end == -1:
+            return payloads + [""]
+        payloads.append(content[payload_start:payload_end].strip())
+        start = payload_end + len(PROVENANCE_COMMENT_SUFFIX)
+
+
+def validate_document(path: str, content: str) -> list[str]:
+    """Return contract violations for one changed planning document."""
+    expected_workflow = CHECKED_FILENAMES[path.rsplit("/", 1)[-1].casefold()]
+    payloads = provenance_payloads(content)
+    if not payloads:
+        return [f"{path}: missing ai-workflow-provenance comment"]
+    if len(payloads) != 1:
+        return [f"{path}: expected exactly one ai-workflow-provenance comment"]
+
+    try:
+        payload = json.loads(payloads[0])
+    except json.JSONDecodeError:
+        return [f"{path}: provenance comment does not contain valid JSON"]
+
+    if not isinstance(payload, dict):
+        return [f"{path}: provenance comment must contain a JSON object"]
+    if type(payload.get("schema_version")) is not int or payload["schema_version"] != 1:
+        return [f"{path}: provenance schema_version must be integer 1"]
+
+    kind = payload.get("provenance_kind")
+    if kind not in PROVENANCE_KINDS:
+        return [f"{path}: unsupported provenance_kind {kind!r}"]
+
+    if kind == "declined":
+        if "## Provenance" in content:
+            return [f"{path}: declined provenance must not retain a Provenance footer"]
+        return []
+
+    if payload.get("workflow") != expected_workflow:
+        return [
+            f"{path}: provenance workflow must be {expected_workflow!r}, "
+            f"not {payload.get('workflow')!r}"
+        ]
+    if "## Provenance" not in content:
+        return [f"{path}: provenance comment requires a Provenance footer"]
+    return []
+
+
+def validate_changed_documents(base: str, head: str) -> list[str]:
+    diff_output = run_git(
+        [
+            "diff",
+            "--name-only",
+            "-z",
+            "--diff-filter=AMR",
+            "--find-renames",
+            base,
+            head,
+            "--",
+        ]
+    )
+    violations = []
+    for path in changed_document_paths(diff_output):
+        content = run_git(["show", f"{head}:{path}"]).decode("utf-8")
+        violations.extend(validate_document(path, content))
+    return violations
+
+
+def main(argv: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="trusted base commit SHA")
+    parser.add_argument("--head", required=True, help="fetched pull request head ref")
+    args = parser.parse_args(argv)
+
+    try:
+        violations = validate_changed_documents(args.base, args.head)
+    except (subprocess.CalledProcessError, UnicodeDecodeError) as error:
+        print(f"error: unable to inspect pull request documents: {error}", file=sys.stderr)
+        return 2
+
+    for violation in violations:
+        print(violation, file=sys.stderr)
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/test_check_planning_provenance.py
+++ b/.github/scripts/test_check_planning_provenance.py
@@ -1,0 +1,117 @@
+"""Unit tests for the planning-document provenance contract."""
+
+import unittest
+from unittest import mock
+
+import check_planning_provenance as provenance
+
+
+def marker(payload: str) -> str:
+    return f"<!-- ai-workflow-provenance:{payload} -->"
+
+
+class ChangedDocumentPathsTests(unittest.TestCase):
+    def test_selects_only_changed_planning_documents(self):
+        diff = (
+            b"README.md\0"
+            b"enhancements/OSAC-1-example/design.md\0"
+            b"enhancements/OSAC-2-example/prd.md\0"
+            b"enhancements/OSAC-3-example/Design.md\0"
+            b"enhancements/OSAC-4-example/DESIGN.md\0"
+            b"enhancements/OSAC-5-example/README.md\0"
+            b"guidelines/design.md\0"
+            b"enhancements/OSAC-6-example/notes.md\0"
+        )
+        self.assertEqual(
+            provenance.changed_document_paths(diff),
+            [
+                "enhancements/OSAC-1-example/design.md",
+                "enhancements/OSAC-2-example/prd.md",
+                "enhancements/OSAC-3-example/Design.md",
+                "enhancements/OSAC-4-example/DESIGN.md",
+                "enhancements/OSAC-5-example/README.md",
+            ],
+        )
+
+
+class DocumentValidationTests(unittest.TestCase):
+    design_path = "enhancements/OSAC-1-example/design.md"
+
+    def test_accepts_session_provenance_for_matching_document_type(self):
+        content = (
+            "# Design\n\n## Provenance\n\n"
+            + marker('{"schema_version":1,"provenance_kind":"session","workflow":"design"}')
+        )
+        self.assertEqual(provenance.validate_document(self.design_path, content), [])
+
+    def test_accepts_legacy_and_case_variant_design_filenames(self):
+        content = (
+            "# Design\n\n## Provenance\n\n"
+            + marker('{"schema_version":1,"provenance_kind":"session","workflow":"design"}')
+        )
+        for filename in ("README.md", "Design.md", "DESIGN.md"):
+            path = f"enhancements/OSAC-1-example/{filename}"
+            with self.subTest(filename=filename):
+                self.assertEqual(provenance.validate_document(path, content), [])
+
+    def test_accepts_commit_only_provenance(self):
+        content = (
+            "# Design\n\n## Provenance\n\n"
+            + marker('{"schema_version":1,"provenance_kind":"commit_only","workflow":"design"}')
+        )
+        self.assertEqual(provenance.validate_document(self.design_path, content), [])
+
+    def test_accepts_explicit_decline_marker_without_footer(self):
+        content = "# Design\n\n" + marker('{"schema_version":1,"provenance_kind":"declined"}')
+        self.assertEqual(provenance.validate_document(self.design_path, content), [])
+
+    def test_rejects_missing_provenance(self):
+        self.assertEqual(
+            provenance.validate_document(self.design_path, "# Design\n"),
+            [f"{self.design_path}: missing ai-workflow-provenance comment"],
+        )
+
+    def test_rejects_wrong_workflow(self):
+        content = (
+            "# Design\n\n## Provenance\n\n"
+            + marker('{"schema_version":1,"provenance_kind":"session","workflow":"prd"}')
+        )
+        self.assertEqual(
+            provenance.validate_document(self.design_path, content),
+            [f"{self.design_path}: provenance workflow must be 'design', not 'prd'"],
+        )
+
+    def test_rejects_invalid_json_and_multiple_markers(self):
+        invalid = "# Design\n\n" + marker("not-json")
+        self.assertEqual(
+            provenance.validate_document(self.design_path, invalid),
+            [f"{self.design_path}: provenance comment does not contain valid JSON"],
+        )
+
+        multiple = (
+            "# Design\n\n## Provenance\n\n"
+            + marker('{"schema_version":1,"provenance_kind":"session","workflow":"design"}')
+            + "\n"
+            + marker('{"schema_version":1,"provenance_kind":"session","workflow":"design"}')
+        )
+        self.assertEqual(
+            provenance.validate_document(self.design_path, multiple),
+            [f"{self.design_path}: expected exactly one ai-workflow-provenance comment"],
+        )
+
+
+class ChangedDocumentsValidationTests(unittest.TestCase):
+    @mock.patch.object(provenance, "run_git")
+    def test_reads_changed_document_at_head_and_reports_its_missing_marker(self, run_git):
+        path = "enhancements/OSAC-1-example/prd.md"
+        run_git.side_effect = [f"{path}\0".encode(), b"# PRD\n"]
+
+        self.assertEqual(
+            provenance.validate_changed_documents("base", "head"),
+            [f"{path}: missing ai-workflow-provenance comment"],
+        )
+        self.assertEqual(run_git.call_args_list[1].args[0], ["show", f"head:{path}"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/planning-provenance.yaml
+++ b/.github/workflows/planning-provenance.yaml
@@ -1,0 +1,35 @@
+name: Validate planning provenance
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: planning-provenance-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # checkout trusted base and fetch pull-request objects
+    steps:
+      - name: Checkout trusted base
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Fetch pull request head
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: git fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
+
+      - name: Validate published provenance
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: refs/remotes/pull/${{ github.event.pull_request.number }}/head
+        run: python3 .github/scripts/check_planning_provenance.py --base "$BASE_SHA" --head "$HEAD_REF"


### PR DESCRIPTION
## Summary

- Add a trusted-base pull-request gate for provenance on changed PRDs and design documents.
- Validate session, commit-only, or explicit-decline markers without executing code from the pull request.
- Cover accepted and rejected marker forms, including legacy and case-variant design filenames.

## Jira

N/A

## Test plan

- [x] python3 .github/scripts/test_check_planning_provenance.py
- [x] python3 -m py_compile .github/scripts/check_planning_provenance.py .github/scripts/test_check_planning_provenance.py
- [x] actionlint .github/workflows/planning-provenance.yaml
- [x] pre-commit run --all-files
- [x] Pre-flight security and complexity reviews clean; the performance review advisory about one Git read per changed document was assessed and retained for the small expected PR scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **CI:** Adds a trusted-base GitHub Actions gate for provenance metadata on changed PRDs and design documents.
- **Validation:** Adds checks for session, commit-only, and explicit-decline markers. The checker validates filenames, JSON schema, workflow rules, duplicate markers, and footer rules without executing pull-request code.
- **Tests:** Adds coverage for accepted and rejected markers, legacy and case-variant filenames, missing or invalid markers, workflow mismatches, and commit-based document validation.
- **Security:** Uses the trusted base revision, minimal permissions, pinned checkout, disabled credential persistence, and pull-request head fetching.
- **API surface:** Adds standalone script functions and constants. No existing public API changes.
- **Documentation:** No documentation changes.
- **Backward compatibility:** The change is additive. Existing application behavior and stored data are unaffected. Pull requests that lack valid provenance metadata for changed documents may now fail CI.

## Risk classification

**risk:ship** — The change is limited to CI validation and tests. It does not alter runtime services, databases, authentication, or production deployment. The implementation is bounded and includes unit coverage.

It is close to **risk:show** because the gate can change pull-request CI results, but it does not change user-facing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->