### PR TITLE
NO-ISSUE: Add udis to the OWNERS as approver and reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -27,6 +27,7 @@ approvers:
 - oourfali
 - ronniel1
 - ybettan
+- udis
 reviewers:
 - adriengentil
 - akshaynadkarni
@@ -57,3 +58,4 @@ reviewers:
 - vladikr
 - ygalblum
 - ybettan
+- udis


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `udis` to the Managers approver list in `OWNERS`.
- Added `udis` to the reviewer list.
- Affected area: repository governance.
- No API, runtime, database, authentication, deployment, CI, test, or documentation changes.
- No backward-compatibility impact.

## Risk classification

- **risk:ship**: The change only updates ownership metadata. It does not change product behavior, interfaces, data, or deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->